### PR TITLE
Test: Verify if secrets are encrypted

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -381,3 +381,6 @@ closing watches for ConfigMaps marked as immutable.*"
 
 #### *Check if Tiller is being used on the plaform*: [Tiller images](docs/LIST_OF_TESTS.md#tiller-images)
 > *Tiller, found in Helm v2, has known security challenges. It requires administrative privileges and acts as a shared resource accessible to any authenticated user. Tiller can lead to privilege escalation as restricted users can impact other users. It is recommend to use Helm v3+ which does not contain Tiller for these reasons
+
+#### *Check if secrets are encrypted on the plaform*: [Kubescape secret/etcd](docs/LIST_OF_TESTS.md#kubescape-secret-etcd)
+> *Secret encryption is not enabled by default in kubernetes environment. As secrets contains sensitive information, it is recommended to encrypt these values. For encrypting secret in etcd, we are using encryption in rest, this will cause, that there will not be secret key value in plain text format anymore in etcd.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1395,3 +1395,15 @@ Switch to using Helm v3+ and make sure not to pull any images with name tiller i
 </b>
 
 
+## [Kubescape secret/etcd](docs/LIST_OF_TESTS.md#kubescape-secret-etcd)
+
+##### To run the Kubescape secret/etcd test, you can use the following command:
+```
+./cnf-testsuite platform:kubescape_secret_etc
+```
+
+<b>Remediation for failing this test: </b>
+
+Check version of ETCDCTL in etcd pod, it should be v3.+
+
+</b>

--- a/embedded_files/points.yml
+++ b/embedded_files/points.yml
@@ -360,6 +360,10 @@
   emoji: "🔓🔑"
   tags: ["platform", "platform:security", "dynamic"]
 
+- name: kubescape_secret_etcd
+  emoji: "🔓🔑"
+  tags: ["platform", "platform:security", "dynamic"]
+
 - name: external_ips
   emoji: "🔓🔑"
   tags: [security, dynamic, workload, cert, normal]

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -83,4 +83,23 @@ namespace "platform" do
       end
     end
   end
+
+  desc "Kubescape secret/etcd"
+  task "kubescape_secret_etcd", ["kubescape_scan"] do |t, args|
+    next if args.named["offline"]?
+
+    CNFManager::Task.task_runner(args, task: t, check_cnf_installed: false) do |args, config|
+      results_json = Kubescape.parse
+      test_json = Kubescape.test_by_test_name(results_json, "Secret/ETCD encryption enabled")
+      test_report = Kubescape.parse_test_report(test_json)
+
+      if test_report.failed_resources.size == 0
+        CNFManager::TestcaseResult.new(CNFManager::ResultStatus::Passed, "Secret/etcd encryption enabled")
+      else
+        test_report.failed_resources.map {|r| stdout_failure(r.alert_message) }
+        stdout_failure("Remediation: #{test_report.remediation}")
+        CNFManager::TestcaseResult.new(CNFManager::ResultStatus::Failed, "Secret/etcd encryption disabled")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
By default in kubernetes system, encrypting of data inside object like secret is not enabled, so data in etcd are available for potential attacker.
Encrypting of secret is possible in newer versions of kubernetes. When this configuration is done, all newly created secrets has encrypted data in etcd key-value store.
We can use kubescape test to cover this area.

## Issues:
Refs: #1970

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [X] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
