### PR TITLE
Secured configmaps

### DIFF
--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -39,7 +39,7 @@
 
 * [**Category: Platform Tests**](#category-platform-tests)
 
-   [[K8s Conformance]](#k8s-conformance) | [[ClusterAPI enabled]](#clusterapi-enabled) | [[OCI Compliant]](#oci-compliant) | [[(POC) Worker reboot recovery]](#poc-worker-reboot-recovery) | [[Cluster admin]](#cluster-admin) | [[Control plane hardening]](#control-plane-hardening) | [[Tiller images]](#tiller-images)
+   [[K8s Conformance]](#k8s-conformance) | [[ClusterAPI enabled]](#clusterapi-enabled) | [[OCI Compliant]](#oci-compliant) | [[(POC) Worker reboot recovery]](#poc-worker-reboot-recovery) | [[Cluster admin]](#cluster-admin) | [[Control plane hardening]](#control-plane-hardening) | [[Tiller images]](#tiller-images) | [[ConfigMaps encrypted]](#configmaps-encrypted)
 
 ----------
 
@@ -1786,3 +1786,25 @@ Switch to using Helm v3+ and make sure not to pull any images with name tiller i
 #### Usage
 
 `./cnf-testsuite platform:helm_tiller`
+
+----------
+
+### ConfigMaps encrypted
+
+#### Overview
+
+Test verifies that Kubernetes ConfigMaps are encrypted at rest in etcd. This ensures that sensitive data stored in ConfigMaps is not accessible in plain text, meeting basic security and compliance requirements. Expectation: ConfigMaps should be encrypted to ensure sensitive data is not stored in plain text.
+
+#### Rationale
+
+ConfigMaps encryption is not enabled by default in kubernetes environment. Since ConfigMaps can contain sensitive information, it is recommended to enable encryption to protect these values. To encrypt ConfigMaps stored in etcd, Kubernetes supports encryption at rest, which ensures that key-value pairs are no longer stored in plain text.
+
+#### Remediation
+
+Check version of ETCDCTL in etcd pod, it should be v3 or higher, as earlier versions lack support for encryption features. To enable encryption of ConfigMaps, create an EncryptionConfiguration file for the API server and reference it in the cluster configuration. Optionally, encryption can be enabled manually by editing the kube-apiserver manifest.
+
+#### Usage
+
+To run the test to verify if ConfigMaps are encrypted:
+
+`./cnf-testsuite platform:verify_configmaps_encryption`

--- a/embedded_files/points.yml
+++ b/embedded_files/points.yml
@@ -241,6 +241,9 @@
 - name: cluster_admin
   emoji: "🔓🔑"
   tags: ["platform", "platform:security", "dynamic"]
+- name: verify_configmaps_encryption
+  emoji: "🔓🔑"
+  tags: ["platform", "platform:security", "dynamic"]
 - name: kube_state_metrics
   emoji: "📶☠"
   tags: [platform, "platform:observability", dynamic]

--- a/spec/fixtures/encryption-config.yaml
+++ b/spec/fixtures/encryption-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - secrets
+      - configmaps
+    providers:
+      - aescbc:
+          keys:
+            - name: key1
+              secret: fEnm+aDjAzMxoPLjmvulhwoLG4Lpw8kLRS8R2TRzCqk=
+      - identity: {}

--- a/spec/fixtures/kind-config-encryption.yaml
+++ b/spec/fixtures/kind-config-encryption.yaml
@@ -1,0 +1,21 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.32.0
+    extraMounts:
+      - hostPath: ./spec/fixtures/encryption-config.yaml
+        containerPath: /etc/kubernetes/encryption-config.yaml
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiVersion: kubeadm.k8s.io/v1beta3
+        apiServer:
+          extraArgs:
+            encryption-provider-config: /etc/kubernetes/encryption-config.yaml
+          extraVolumes:
+            - name: encryption-config
+              hostPath: /etc/kubernetes/encryption-config.yaml
+              mountPath: /etc/kubernetes/encryption-config.yaml
+              readOnly: true
+              pathType: File

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -2,10 +2,11 @@
 require "sam"
 require "colorize"
 require "../utils/utils.cr"
+require "yaml"
 
 namespace "platform" do
   desc "The CNF test suite checks to see if the platform is hardened."
-  task "security", ["control_plane_hardening", "cluster_admin", "helm_tiller"] do |t, args|
+  task "security", ["control_plane_hardening", "cluster_admin", "helm_tiller", "verify_configmaps_encryption"] do |t, args|
     Log.debug { "security" }
     stdout_score("platform:security")
   end
@@ -62,5 +63,122 @@ namespace "platform" do
         CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Failed, "Containers with the Helm Tiller image are running")
       end
     end
+  end
+
+  desc "Verify if ConfigMaps are encrypted"
+  task "verify_configmaps_encryption" do |t, args|
+    logger = Log.for("verify_configmaps_encryption")
+    kube_system_ns = "kube-system"
+    cm_name = generate_cm_name
+
+    CNFManager::Task.task_runner(args, task: t, check_cnf_installed: false) do |args, config|
+      test_cm_key = "key"
+      test_cm_value = "testconfigmapvalue"
+      create_test_configmap(cm_name, test_cm_key, test_cm_value)
+      
+      etcd_pod_name = KubectlClient::Get.match_pods_by_prefix("etcd", namespace: kube_system_ns).first
+
+      etcd_certs_path = get_etcd_certs_path(etcd_pod_name, kube_system_ns)
+      
+      if etcd_certs_path
+        if etcd_cm_encrypted?(etcd_certs_path, etcd_pod_name, cm_name, test_cm_value, kube_system_ns)
+          CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Passed, "ConfigMaps are encrypted in etcd.")
+        else
+          CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Failed, "ConfigMaps are not encrypted in etcd.")
+        end
+      else
+        CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Failed, "Error: etcd certs path not found.")
+      end
+    end
+
+    begin
+      KubectlClient::Delete.resource("cm", cm_name)
+    rescue ex : KubectlClient::ShellCMD::K8sClientCMDException 
+      logger.error { "Failed to delete ConfigMap #{cm_name}: #{ex.message}" }
+    end
+  end
+end
+
+private def generate_cm_name(prefix : String = "test-cm-") : String
+  "#{prefix}-#{Random::Secure.rand(9999).to_s}"
+end
+
+private def create_test_configmap(cm_name : String, key : String, value : String) : Bool
+  logger = Log.for("create_test_configmap")
+
+  cm_manifest = <<-YAML
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: #{cm_name}
+    data:
+      #{key}: "#{value}"
+  YAML
+
+    file = File.tempfile("configmap", ".yaml")
+    file.puts cm_manifest
+    file.flush
+
+    KubectlClient::Apply.file(file.path)
+
+    file.delete
+    return true
+end
+
+
+private def get_etcd_certs_path(etcd_pod_name : String, namespace : String) : String?
+  logger = Log.for("get_etcd_certs_path")
+
+  begin
+    pod_info = KubectlClient::Get.resource("pod", etcd_pod_name, namespace: namespace)
+    volumes_json = pod_info.dig?("spec", "volumes")
+  
+    volumes = volumes_json.try(&.as_a) rescue nil
+  
+    if volumes
+      etcd_certs_volume = volumes.find { |volume| volume["name"]?.try(&.to_s) == "etcd-certs" }
+  
+      if etcd_certs_volume
+        return etcd_certs_volume["hostPath"]?.try(&.["path"]?.to_s)
+      else
+        logger.warn { "No volume named 'etcd-certs' found in pod #{etcd_pod_name}" }
+        return nil
+      end
+    else
+      logger.warn { "No volumes array found in pod spec for #{etcd_pod_name}" }
+      return nil
+    end
+  rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
+    logger.error { "Failed to get pod definition for #{etcd_pod_name}: #{ex.message}" }
+    raise ex
+  end
+end
+ 
+private def etcd_cm_encrypted?(
+  etcd_certs_path : String, 
+  etcd_pod_name : String, 
+  cm_name : String, 
+  test_cm_value : String, 
+  namespace : String,
+  ) : Bool
+  etcd_output =  execute_etcd_command(etcd_certs_path, etcd_pod_name, cm_name, namespace)
+  etcd_output.includes?("k8s:enc:") && !etcd_output.includes?(test_cm_value)
+end
+ 
+private def execute_etcd_command(etcd_certs_path : String, etcd_pod_name : String, cm_name : String, namespace : String) : String
+  logger = Log.for("execute_etcd_command")
+
+  command = "ETCDCTL_API=3 etcdctl " \
+            "--cacert #{etcd_certs_path}/ca.crt " \
+            "--cert #{etcd_certs_path}/server.crt " \
+            "--key #{etcd_certs_path}/server.key " \
+            "get /registry/configmaps/default/#{cm_name}"
+
+  begin
+    result = KubectlClient::Utils.exec(etcd_pod_name, "sh -c \"#{command}\"", namespace: namespace)
+    result["output"]
+  rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
+    logger.error {"Failed to execute etcdctl command in pod #{etcd_pod_name}: #{ex.message}"}
+    raise ex 
   end
 end

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -361,11 +361,15 @@ def read_version_file(filepath)
 end
 
 def with_kubeconfig(kube_config : String, &)
-  last_kube_config = ENV["KUBECONFIG"]
+  last_kube_config = ENV["KUBECONFIG"]?
   ENV["KUBECONFIG"] = kube_config
-  result = yield
-  ENV["KUBECONFIG"] = last_kube_config
-  result
+  yield
+  unless last_kube_config.nil?
+    ENV["KUBECONFIG"] = last_kube_config
+  else
+    # We don't want to set kube_config variable permanently.
+    ENV.delete("KUBECONFIG")
+  end
 end
 
 def self.find(directory : String, wildcard : String)
@@ -380,3 +384,4 @@ def self.find(directory : String, wildcard : String)
 
   found_files
 end
+


### PR DESCRIPTION
## Description
By default in kubernetes system, encrypting of data inside object like configmaps is not enabled, so data in etcd are available for potential attacker.
Encrypting of configmaps is possible in newer versions of kubernetes. When this configuration is done, all newly created configmaps has encrypted data in etcd key-value store.
This testcase creates new sonfigmap with random suffix (to avoid confilct). Then we will use similar command in etcd pod to verify if encryption is working:
ETCDCTL_API=3 etcdctl \ --cacert=/etc/kubernetes/pki/etcd/ca.crt   \ --cert=/etc/kubernetes/pki/etcd/server.crt \ --key=/etc/kubernetes/pki/etcd/server.key  \ get /registry/configmaps/default/my-configmap | hexdump -C

## Issues:
Refs: #1994

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
