### PR TITLE
Fix build warnings coming from deprecated methods

### DIFF
--- a/spec/workload/compatibility_spec.cr
+++ b/spec/workload/compatibility_spec.cr
@@ -20,7 +20,7 @@ describe "Compatibility" do
       result = ShellCmd.run_testsuite("cni_compatible verbose")
       until (/PASSED/ =~ result[:output]) || retries > retry_limit
         Log.info { "cni_compatible spec retry: #{retries}" }
-        sleep 1.0
+        sleep 1.seconds
         result = ShellCmd.run_testsuite("cni_compatible verbose")
         retries = retries + 1
       end

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -88,7 +88,7 @@ describe CnfTestSuite do
       result = ShellCmd.run_testsuite("rolling_downgrade verbose")
       until (/Passed/ =~ result[:output]) || retries > retry_limit
         Log.info { "rolling_downgrade retry: #{retries}" }
-        sleep 1.0
+        sleep 1.seconds
         result = ShellCmd.run_testsuite("rolling_downgrade verbose")
         retries = retries + 1
       end

--- a/src/tasks/litmus_setup.cr
+++ b/src/tasks/litmus_setup.cr
@@ -64,15 +64,15 @@ module LitmusManager
   def self.get_target_node_to_cordon(deployment_label, deployment_value, namespace)
     app_nodeName_cmd = "kubectl get pods -l #{deployment_label}=#{deployment_value} -n #{namespace} -o=jsonpath='{.items[0].spec.nodeName}'"
     Log.info { "Getting the operator node name: #{app_nodeName_cmd}" }
-    status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
+    status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).system_exit_status
     Log.for("verbose").info { "status_code: #{status_code}" } 
     appNodeName_response.to_s
   end
 
-  private def self.get_status_info(chaos_resource, test_name, output_format, namespace) : {Int32, String}
+  private def self.get_status_info(chaos_resource, test_name, output_format, namespace) : {UInt32, String}
     status_cmd = "kubectl get #{chaos_resource}.#{LITMUS_K8S_DOMAIN} #{test_name} -n #{namespace} -o '#{output_format}'"
     Log.info { "Getting litmus status info: #{status_cmd}" }
-    status_code = Process.run("#{status_cmd}", shell: true, output: status_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
+    status_code = Process.run("#{status_cmd}", shell: true, output: status_response = IO::Memory.new, error: stderr = IO::Memory.new).system_exit_status
     status_response = status_response.to_s
     Log.info { "status_code: #{status_code}, response: #{status_response}" }
     {status_code, status_response}

--- a/src/tasks/utils/k8s_tshark.cr
+++ b/src/tasks/utils/k8s_tshark.cr
@@ -116,7 +116,7 @@ module K8sTshark
 
         # Some tshark captures were left in zombie states if only kill/kill -9 was invoked.
         ClusterTools.exec_by_node_bg("kill -15 #{@pid}", @node_match.not_nil!)
-        sleep 1
+        sleep 1.seconds
         ClusterTools.exec_by_node_bg("kill -9 #{@pid}", @node_match.not_nil!)
 
         @pid = nil

--- a/src/tasks/utils/timeouts.cr
+++ b/src/tasks/utils/timeouts.cr
@@ -20,7 +20,7 @@ def repeat_with_timeout(timeout, errormsg, reset_on_nil=false, delay=2, &block)
     elsif result
       return true
     end
-    sleep delay
+    sleep delay.seconds
     Log.for("verbose").info { "Time left: #{timeout - (Time.utc - start_time).to_i} seconds" }
   end
   Log.error { errormsg }

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -59,7 +59,7 @@ def ensure_kubeconfig!
   
   # Check if cluster is up and running with assigned KUBECONFIG variable 
   cmd = "kubectl get nodes --kubeconfig=#{ENV["KUBECONFIG"]}"
-  exit_code = KubectlClient::ShellCmd.run(cmd, "", false)[:status].exit_status
+  exit_code = KubectlClient::ShellCmd.run(cmd, "", false)[:status].system_exit_status
   if exit_code != 0
     stdout_failure "Cluster liveness check failed: '#{cmd}' returned exit code #{exit_code}. Check the cluster and/or KUBECONFIG environment variable."
     exit 1

--- a/src/tasks/workload/5g_validator.cr
+++ b/src/tasks/workload/5g_validator.cr
@@ -115,7 +115,7 @@ end
 
 def smf_up_heartbeat_capture_matches_count(smf_key : String, smf_value : String, command : String)
   K8sTshark::TsharkPacketCapture.begin_capture_by_label(smf_key, smf_value, command) do |capture|
-    sleep 60
+    sleep 60.seconds
     capture.regex_search(/"pfcp\.msg_type": "(1|2)"/).size
   end
 end
@@ -135,7 +135,7 @@ task "suci_enabled" do |t, args|
       K8sTshark::TsharkPacketCapture.begin_capture_by_label(core_key, core_value, command) do |capture|
         #todo put in prereq
         UERANSIM.install(config)
-        sleep 30.0
+        sleep 30.seconds
         # TODO 5g RAN (only) mobile traffic check ????
         # use suci encyption but don't use a null encryption key
         suci_found = capture.regex_match?(/"nas_5gs.mm.type_id": "1"/) && \

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -424,7 +424,7 @@ task "zombie_handled" do |t, args|
       end
     end
 
-    sleep 10.0
+    sleep 10.seconds
 
     task_response = CNFManager.workload_resource_test(args, config, check_containers:false ) do |resource, container, initialized|
       ClusterTools.all_containers_by_resource?(resource, resource[:namespace], only_container_pids:false) do | container_id, container_pid_on_node, node, container_proctree_statuses, container_status| 
@@ -618,7 +618,7 @@ task "sig_term_handled" do |t, args|
               Log.for(t.name).info { "pid_log_names: #{pid_log_names}" }
               #todo 2.3 parse the logs 
               #todo get the log
-              sleep 5
+              sleep 5.seconds
               sig_term_found = pid_log_names.map do |pid_name|
                 Log.info { "pid_name: #{pid_name}" }
                 resp = File.read("#{pid_name}")

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -263,13 +263,13 @@ task "node_drain", ["install_litmus"] do |t, args|
           deployment_label_value="#{spec_labels.as_h.first_value}"
           app_nodeName_cmd = "kubectl get pods -l #{deployment_label}=#{deployment_label_value} -n #{resource["namespace"]} -o=jsonpath='{.items[0].spec.nodeName}'"
           Log.for("node_drain").info { "Getting the app node name #{app_nodeName_cmd}" } if check_verbose(args)
-          status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
+          status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).system_exit_status
           Log.for("node_drain").info { "status_code: #{status_code}" } if check_verbose(args)
           app_nodeName = appNodeName_response.to_s
 
           litmus_nodeName_cmd = "kubectl get pods -n litmus -l app.kubernetes.io/name=litmus -o=jsonpath='{.items[0].spec.nodeName}'"
           Log.for("node_drain").info { "Getting the app node name #{litmus_nodeName_cmd}" } if check_verbose(args)
-          status_code = Process.run("#{litmus_nodeName_cmd}", shell: true, output: litmusNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
+          status_code = Process.run("#{litmus_nodeName_cmd}", shell: true, output: litmusNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).system_exit_status
           Log.for("node_drain").info { "status_code: #{status_code}" } if check_verbose(args)
           litmus_nodeName = litmusNodeName_response.to_s
           Log.info { "Workload Node Name: #{app_nodeName}" }


### PR DESCRIPTION
## Description
Small PR with fixes of annoying build errors.

## Issues:
Refs: none

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [x] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
