### PR TITLE
Feat: Add deletion timeout to cnf_uninstall

### DIFF
--- a/sample-cnfs/sample_stuck_finalizer/cnf-testsuite.yml
+++ b/sample-cnfs/sample_stuck_finalizer/cnf-testsuite.yml
@@ -1,0 +1,9 @@
+# WARNING: expect manual cleanup after deploying.
+# kubectl patch pod stuck-pod -n cnfspace -p '{"metadata":{"finalizers":[]}}' --type=merge
+# kubectl delete pod stuck-pod -n cnfspace
+---
+config_version: v2
+deployments:
+  manifests:
+    - name: stuck_finalizer
+      manifest_directory: manifest

--- a/sample-cnfs/sample_stuck_finalizer/manifest/stuck-pod.yaml
+++ b/sample-cnfs/sample_stuck_finalizer/manifest/stuck-pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: stuck-pod
+  namespace: cnfspace
+  finalizers:
+    - example.com/stuck
+  labels:
+    app: stuck-app
+spec:
+  containers:
+  - name: stuck-container
+    image: busybox
+    command: ["sh", "-c", "while true; do sleep 3600; done"]

--- a/sample-cnfs/sample_stuck_helm_deployment/cnf-testsuite.yml
+++ b/sample-cnfs/sample_stuck_helm_deployment/cnf-testsuite.yml
@@ -1,0 +1,9 @@
+# The deployment is not stuck immediately, but instead needs to be patched (done in spec test)
+---
+config_version: v2
+deployments:
+  helm_charts:
+  - name: stuck-nginx
+    helm_chart_name: nginx
+    helm_repo_name: bitnami
+    helm_repo_url: https://charts.bitnami.com/bitnami

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -42,9 +42,8 @@ module ShellCmd
     result
   end
 
-  def self.cnf_uninstall(uninstall_params="", cmd_prefix="", expect_failure=false)
-    timeout_parameter = uninstall_params.includes?("timeout") ? "" : "timeout=300"
-    result = run_testsuite("cnf_uninstall #{uninstall_params} #{timeout_parameter}", cmd_prefix)
+  def self.cnf_uninstall(timeout=300, cmd_prefix="", expect_failure=false)
+    result = run_testsuite("cnf_uninstall timeout=#{timeout}", cmd_prefix)
     if !expect_failure
       result[:status].success?.should be_true
     else

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -218,7 +218,7 @@ describe CnfTestSuite do
       result[:status].success?.should be_true
       (/(PASSED).*(Secrets defined and used)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.cnf_uninstall("")
+      result = ShellCmd.cnf_uninstall()
     end
   end
 
@@ -229,7 +229,7 @@ describe CnfTestSuite do
       result[:status].success?.should be_true
       (/(SKIPPED).*(Secrets not used)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.cnf_uninstall("")
+      result = ShellCmd.cnf_uninstall()
     end
   end
 
@@ -240,7 +240,7 @@ describe CnfTestSuite do
       result[:status].success?.should be_true
       (/(PASSED).*(Secrets defined and used)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.cnf_uninstall("")
+      result = ShellCmd.cnf_uninstall()
     end
   end
 
@@ -251,7 +251,7 @@ describe CnfTestSuite do
       result[:status].success?.should be_true
       (/(SKIPPED).*(Secrets not used)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.cnf_uninstall("")
+      result = ShellCmd.cnf_uninstall()
     end
   end
 
@@ -262,7 +262,7 @@ describe CnfTestSuite do
       result[:status].success?.should be_true
       (/(SKIPPED).*(Secrets not used)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.cnf_uninstall("")
+      result = ShellCmd.cnf_uninstall()
     end
   end
 

--- a/spec/workload/operator_spec.cr
+++ b/spec/workload/operator_spec.cr
@@ -41,7 +41,7 @@ describe "Operator" do
         pod_name = pod.dig("metadata", "name")
         pod_namespace = pod.dig("metadata", "namespace")
         Log.info { "Wait for Uninstall on Pod Name: #{pod_name}, Namespace: #{pod_namespace}" }
-        KubectlClient::Wait.resource_wait_for_uninstall("Pod", "#{pod_name}", 180, "operator-lifecycle-manager")
+        KubectlClient::Wait.resource_wait_for_uninstall("Pod", "#{pod_name}", namespace: "operator-lifecycle-manager", wait_count: 180)
       end
 
       repeat_with_timeout(timeout: GENERIC_OPERATION_TIMEOUT, errormsg: "Namespace uninstallation has timed-out") do

--- a/spec/workload/registry_spec.cr
+++ b/spec/workload/registry_spec.cr
@@ -98,7 +98,7 @@ describe "Private Registry: Rolling" do
       result[:status].success?.should be_true
       (/Passed/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.cnf_uninstall("timeout=0")
+      result = ShellCmd.cnf_uninstall()
     end
   end
 
@@ -111,7 +111,7 @@ describe "Private Registry: Rolling" do
       result[:status].success?.should be_true
       (/Passed/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.cnf_uninstall("timeout=0")
+      result = ShellCmd.cnf_uninstall()
   	end
   end
 
@@ -124,7 +124,7 @@ describe "Private Registry: Rolling" do
       result[:status].success?.should be_true
       (/Passed/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.cnf_uninstall("timeout=0")
+      result = ShellCmd.cnf_uninstall()
     end
   end  
 

--- a/spec/workload/resilience/disk_fill_spec.cr
+++ b/spec/workload/resilience/disk_fill_spec.cr
@@ -18,7 +18,7 @@ describe "Resilience Disk Fill Chaos" do
       result[:status].success?.should be_true
       (/(PASSED).*(disk_fill chaos test passed)/ =~ result[:output]).should_not be_nil
     ensure
-      result = ShellCmd.cnf_uninstall("timeout=0")
+      result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
       result = ShellCmd.run_testsuite("uninstall_litmus")
       result[:status].success?.should be_true

--- a/src/modules/helm/helm.cr
+++ b/src/modules/helm/helm.cr
@@ -278,13 +278,15 @@ module Helm
     ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
   end
 
-  def self.uninstall(release_name, namespace = nil) : CMDResult
+  def self.uninstall(release_name : String, namespace : String? = nil, wait : Bool = false) : CMDResult
     logger = Log.for("uninstall")
     logger.info { "Uninstalling helm chart: #{release_name}" }
 
     helm = BinarySingleton.helm
     cmd = "#{helm} uninstall #{release_name}"
     cmd = "#{cmd} -n #{namespace}" if namespace
+    cmd = "#{cmd} --wait" if wait
+  
     ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
   end
 

--- a/src/tasks/setup/cnf_setup.cr
+++ b/src/tasks/setup/cnf_setup.cr
@@ -27,8 +27,15 @@ end
 task "cnf_uninstall" do |_, args|
   logger = SLOG.for("cnf_uninstall")
   logger.info { "Uninstalling CNF from cluster" }
-  CNFInstall.uninstall_cnf
-  logger.info { "CNF uninstallation ended" }
+
+  result = CNFInstall.uninstall_cnf(args)
+
+  if result
+    stdout_success "CNF uninstallation succeeded."
+  else
+    stdout_failure "CNF uninstallation failed."
+    exit(1)
+  end
 end
 
 task "validate_config" do |_, args|

--- a/src/tasks/utils/cnf_installation/deployment_management/helm_deployment_manager.cr
+++ b/src/tasks/utils/cnf_installation/deployment_management/helm_deployment_manager.cr
@@ -42,18 +42,17 @@ module CNFInstall
 
     def uninstall()
       begin
-        result = Helm.uninstall(get_deployment_name(), get_deployment_namespace())
+        result = Helm.uninstall(get_deployment_name(), get_deployment_namespace(), wait: false)
       rescue ex : Helm::ShellCMD::ReleaseNotFound
-        stdout_success "Helm deployment not installed \"#{deployment_name}\"."
+        stdout_warning "Helm deployment \"#{deployment_name}\" was not installed."
         true
       rescue ex : Helm::ShellCMD::HelmCMDException
-        stdout_failure "Error while uninstalling helm deployment \"#{deployment_name}\"."
+        stdout_failure "Error while uninstalling helm deployment \"#{deployment_name}\":"
         stdout_failure "\t#{ex.message}"
         false
-      else
-        stdout_success "Successfully uninstalled helm deployment \"#{deployment_name}\"."
-        true
       end
+
+      true
     end
 
     def generate_manifest()

--- a/src/tasks/utils/cnf_installation/deployment_management/manifest_deployment_manager.cr
+++ b/src/tasks/utils/cnf_installation/deployment_management/manifest_deployment_manager.cr
@@ -39,15 +39,16 @@ module CNFInstall
 
     def uninstall()
       begin
-        result = KubectlClient::Delete.file(@manifest_directory_path, wait: true)
+        result = KubectlClient::Delete.file(@manifest_directory_path, wait: false)
       rescue KubectlClient::ShellCMD::NotFoundError
-        # We don't need to do anything here.
+        stdout_warning "Manifest deployment \"#{deployment_name}\" was not found."
+        true
       rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
-        stdout_failure "Error while uninstalling manifest deployment \"#{@manifest_config.name}\": #{ex.message}"
-        return false
+        stdout_failure "Error while uninstalling manifest deployment \"#{@manifest_config.name}\":"
+        stdout_failure "\t#{ex.message}"
+        false
       end
 
-      stdout_success "Successfully uninstalled manifest deployment \"#{@manifest_config.name}\""
       true
     end
 

--- a/src/tasks/utils/cnf_installation/manifest.cr
+++ b/src/tasks/utils/cnf_installation/manifest.cr
@@ -70,5 +70,30 @@ module CNFInstall
           "appended into #{destination_file} file" }
       end
     end
+
+    def self.find_resource(ymls : Array(YAML::Any), kind : String, name : String) : YAML::Any?
+      ymls.find do |r|
+        r["kind"].as_s == kind && r["metadata"]["name"].as_s == name
+      end
+    end
+
+    def self.extract_from_ymls(
+      ymls : Array(YAML::Any),
+      kind : String,
+      name : String,
+      path : Array(String)
+    )
+      resource = find_resource(ymls, kind, name)
+      return nil unless resource
+
+      node = resource
+      path.each do |key|
+        node = node[key]?
+        return nil if node.nil?
+      end
+
+      Log.debug { "Found node at #{path.join(".")}: #{node.as_s}"}
+      yield node
+    end
   end
 end

--- a/src/tasks/utils/kyverno.cr
+++ b/src/tasks/utils/kyverno.cr
@@ -24,7 +24,7 @@ module Kyverno
   def self.uninstall
     FileUtils.rm_rf(binary_path)
     delete_policies_repo
-    KubectlClient::Wait.resource_wait_for_uninstall("deployment", "kyverno", 180, "kyverno")
+    KubectlClient::Wait.resource_wait_for_uninstall("deployment", "kyverno",  namespace: "kyverno", wait_count: 180)
   end
 
   def self.download_url


### PR DESCRIPTION
## Description
This change adds failure checking and timeouts into the `cnf_uninstall` task, so that it mirrors the behavior of task `cnf_install` (adding uninstall timeout, making sure bad uninstall does not cause an exception, nicer user output in the terminal).

The meat of the change is in functions `wait_for_deployment_uninstallation` (which has been split from the original `wait_for_deployment_resources`) and `KubectlClient::Wait.resource_wait_for_uninstall`. The core issue was the method of detecting that something went wrong during uninstallation (imagine a stuck finalizer). The `kubectl delete` and `helm uninstall` commands do provide a `--wait` and `--timeout` flag that were attempted to be used, but this approach would not give us the fidelity of manual verification. The manual verification checks what resources have not been deleted and explicitly prints their failure to user. Since we implement manual verification with a set timeout value the `--wait` flag of `kubectl delete` and `helm uninstall` has been set to `false` by default.

As for the manual implementation in `KubectlClient::Wait.resource_wait_for_uninstall`, it checks for the existence of resource, but this is not sufficient by itself - in various cases the core deployment may have been deleted but its pods may remain (i.e. stuck finalizer) which is why we also need to pass labels, to look for pods in a secondary check.

Other big changes are relevant to the spec tests, to correctly verify that both manifest and helm uninstallation failures are detected two new spec tests were introduced, along with sample-cnfs (verification through stuck finalizers). To delete these stuck finalizers a new implementation of `kubectl patch` has been added to `KubectlClient::Utils.patch`. Another thing that I noticed while making this change was how badly the utility functions in `spec_helper.cr` were implemented (timeout was not functioning), which is why I did a minor change to the `ShellCmd.cnf_uninstall` function (full correction should be done when resolving #2280).

Other changes across the code simply correct function signatures.

## Issues:
Refs: #2194 

## How has this been tested:
 - [x] Covered by existing integration testing
 - [x] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
