### PR TITLE
Feat: Create AssureDeleted and AssureApplied module for KubectlClient

### DIFF
--- a/spec/modules/cluster_tools_spec.cr
+++ b/spec/modules/cluster_tools_spec.cr
@@ -2,12 +2,7 @@ require "../spec_helper.cr"
 
 describe "ClusterTools" do
   before_all do
-    begin
-      KubectlClient::Apply.namespace(ClusterTools.namespace)
-      Log.info { "#{ClusterTools.namespace} namespace created" }
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-      Log.info { "#{ClusterTools.namespace} namespace already exists on the Kubernetes cluster" }
-    end
+    KubectlClient::Apply.namespace(ClusterTools.namespace)
   end
 
   after_all do

--- a/spec/modules/k8s_kernel_introspection_spec.cr
+++ b/spec/modules/k8s_kernel_introspection_spec.cr
@@ -2,10 +2,7 @@ require "../spec_helper.cr"
 
 describe "KernelIntrospection" do
   before_all do
-    begin
-      KubectlClient::Apply.namespace("cnf-testsuite")
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-    end
+    KubectlClient::Apply.namespace("cnf-testsuite")
     ClusterTools.install
   end
 

--- a/spec/modules/k8s_netstat_spec.cr
+++ b/spec/modules/k8s_netstat_spec.cr
@@ -21,20 +21,14 @@ end
 
 describe "netstat" do
   before_all do
-    begin
-      KubectlClient::Apply.namespace("cnf-testsuite")
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-    end
+    KubectlClient::Apply.namespace("cnf-testsuite")
     ClusterTools.install
   end
 
   after_all do
     # Cleanup logic after all tests have run
-    begin
-      KubectlClient::Delete.resource("pvc", "data-wordpress-mariadb-0")
-      KubectlClient::Delete.resource("pvc", "wordpress")
-    rescue ex : KubectlClient::ShellCMD::NotFoundError
-    end
+    KubectlClient::Delete.resource("pvc", "data-wordpress-mariadb-0")
+    KubectlClient::Delete.resource("pvc", "wordpress")
     Log.info { "Cleanup complete" }
   end
 

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -58,10 +58,7 @@ describe "Microservice" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      begin
-        KubectlClient::Delete.resource("pvc", "data-test-mariadb-0", "wordpress")
-      rescue KubectlClient::ShellCMD::NotFoundError
-      end
+      KubectlClient::Delete.resource("pvc", "data-test-mariadb-0", "wordpress")
     end
   end
 
@@ -83,10 +80,7 @@ describe "Microservice" do
       (/(PASSED).*(No shared database found)/ =~ result[:output]).should_not be_nil
     ensure
       Helm.uninstall("multi-db", DEFAULT_CNF_NAMESPACE)
-      begin
-        KubectlClient::Delete.resource("pvc", "data-multi-db-mariadb-0")
-      rescue KubectlClient::ShellCMD::NotFoundError
-      end
+      KubectlClient::Delete.resource("pvc", "data-multi-db-mariadb-0")
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
     end

--- a/spec/workload/operator_spec.cr
+++ b/spec/workload/operator_spec.cr
@@ -32,10 +32,7 @@ describe "Operator" do
         KubectlClient::Get.pods_by_resource_labels(KubectlClient::Get.resource("deployment", "packageserver", "operator-lifecycle-manager"), "operator-lifecycle-manager")
 
       Helm.uninstall("operator")
-      begin
-        KubectlClient::Delete.resource("csv", "prometheusoperator.0.47.0")
-      rescue KubectlClient::ShellCMD::NotFoundError
-      end
+      KubectlClient::Delete.resource("csv", "prometheusoperator.0.47.0")
 
       pods.map do |pod| 
         pod_name = pod.dig("metadata", "name")

--- a/src/modules/cluster_tools/cluster_tools.cr
+++ b/src/modules/cluster_tools/cluster_tools.cr
@@ -51,13 +51,9 @@ module ClusterTools
     Log.info { "ClusterTools uninstall" }
     File.write("cluster_tools.yml", ManifestTemplate.new().to_s)
 
-    begin
-      KubectlClient::Delete.file("cluster_tools.yml", namespace: self.namespace!)
-      #todo make this work with cluster-tools-host-namespace
-      KubectlClient::Wait.resource_wait_for_uninstall("Daemonset", "cluster-tools", namespace: self.namespace!)
-    rescue ex : KubectlClient::ShellCMD::NotFoundError
-      Log.info { "ClusterTools not present on the cluster" }
-    end
+    KubectlClient::Delete.file("cluster_tools.yml", namespace: self.namespace!)
+    #todo make this work with cluster-tools-host-namespace
+    KubectlClient::Wait.resource_wait_for_uninstall("Daemonset", "cluster-tools", namespace: self.namespace!)
   end
 
   def self.exec(cli : String) : KubectlClient::CMDResult

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -91,11 +91,7 @@ namespace "platform" do
       end
     end
 
-    begin
-      KubectlClient::Delete.resource("cm", cm_name)
-    rescue ex : KubectlClient::ShellCMD::K8sClientCMDException 
-      logger.error { "Failed to delete ConfigMap #{cm_name}: #{ex.message}" }
-    end
+    KubectlClient::Delete.resource("cm", cm_name)
   end
 end
 

--- a/src/tasks/setup/cluster_api_setup.cr
+++ b/src/tasks/setup/cluster_api_setup.cr
@@ -77,6 +77,7 @@ namespace "setup" do
   task "cluster_api_uninstall" do |_, args|
     current_dir = FileUtils.pwd
     delete_cluster_file = "#{current_dir}/capi.yaml"
+    # TODO: Ensure all dependent resources are deleted before deleting capi.yaml
     begin KubectlClient::Delete.file("#{delete_cluster_file}") rescue KubectlClient::ShellCMD::NotFoundError end
 
     cmd = "clusterctl delete --all --include-crd --include-namespace"

--- a/src/tasks/setup/litmus_setup.cr
+++ b/src/tasks/setup/litmus_setup.cr
@@ -32,10 +32,7 @@ task "uninstall_litmus" do |_, args|
       output: stdout = IO::Memory.new,
       error: stderr = IO::Memory.new
   )
-  begin
-    KubectlClient::Delete.file("https://litmuschaos.github.io/litmus/litmus-operator-v#{LitmusManager::Version}.yaml", namespace: LitmusManager::LITMUS_NAMESPACE)
-  rescue KubectlClient::ShellCMD::NotFoundError
-  end
+  KubectlClient::Delete.file("https://litmuschaos.github.io/litmus/litmus-operator-v#{LitmusManager::Version}.yaml", namespace: LitmusManager::LITMUS_NAMESPACE)
   Log.info { stdout }
   Log.info { stderr }
 end

--- a/src/tasks/setup/setup.cr
+++ b/src/tasks/setup/setup.cr
@@ -15,11 +15,6 @@ namespace "setup" do
     ensure_kubeconfig!
     begin
       KubectlClient::Apply.namespace(TESTSUITE_NAMESPACE)
-      stdout_success "Created #{TESTSUITE_NAMESPACE} namespace on the Kubernetes cluster"
-      logger.info { "#{TESTSUITE_NAMESPACE} namespace created" }
-    rescue ex : KubectlClient::ShellCMD::AlreadyExistsError
-      stdout_success "#{TESTSUITE_NAMESPACE} namespace already exists on the Kubernetes cluster"
-      logger.info { "#{TESTSUITE_NAMESPACE} namespace already exists, not creating" }
     rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
       stdout_failure "Could not create #{TESTSUITE_NAMESPACE} namespace on the Kubernetes cluster"
       logger.error { "Failed to create #{TESTSUITE_NAMESPACE} namespace: #{ex.message}" }

--- a/src/tasks/utils/cnf_installation/deployment_management/manifest_deployment_manager.cr
+++ b/src/tasks/utils/cnf_installation/deployment_management/manifest_deployment_manager.cr
@@ -40,9 +40,6 @@ module CNFInstall
     def uninstall()
       begin
         result = KubectlClient::Delete.file(@manifest_directory_path, wait: false)
-      rescue KubectlClient::ShellCMD::NotFoundError
-        stdout_warning "Manifest deployment \"#{deployment_name}\" was not found."
-        true
       rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
         stdout_failure "Error while uninstalling manifest deployment \"#{@manifest_config.name}\":"
         stdout_failure "\t#{ex.message}"

--- a/src/tasks/utils/cnf_manager/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager/cnf_manager.cr
@@ -146,11 +146,7 @@ module CNFManager
     logger = Log.for("ensure_namespace_exists!")
     logger.info { "Ensure that namespace: #{namespace} exists on the cluster for the CNF install" }
 
-    begin
-      KubectlClient::Apply.namespace(namespace)
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-      logger.info { "Namespace: #{namespace} already exists" }
-    end
+    KubectlClient::Apply.namespace(namespace)
 
     KubectlClient::Utils.label("namespace", namespace, ["pod-security.kubernetes.io/enforce=privileged"])
     true

--- a/src/tasks/utils/dockerd.cr
+++ b/src/tasks/utils/dockerd.cr
@@ -28,16 +28,10 @@ module Dockerd
 
   def self.uninstall
     Log.info { "Uninstall dockerd from manifest" }
-    begin
-      KubectlClient::Delete.file(dockerd_manifest_file, namespace: TESTSUITE_NAMESPACE)
-    rescue KubectlClient::ShellCMD::NotFoundError
-    end
+    KubectlClient::Delete.file(dockerd_manifest_file, namespace: TESTSUITE_NAMESPACE)
 
     Log.info { "Uninstall docker-config from manifest" }
-    begin
-      KubectlClient::Delete.resource("configmaps", "docker-config", TESTSUITE_NAMESPACE)
-    rescue KubectlClient::ShellCMD::NotFoundError
-    end
+    KubectlClient::Delete.resource("configmaps", "docker-config", TESTSUITE_NAMESPACE)
   end
 
   def self.exec(cli)

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -246,10 +246,7 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |t, args|
   rescue
     CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Skipped, "unknown exception")
   ensure
-    begin
-      KubectlClient::Delete.resource("namespace", "hardcoded-ip-test", extra_opts: "--force --grace-period 0")
-    rescue KubectlClient::ShellCMD::NotFoundError
-    end
+    KubectlClient::Delete.resource("namespace", "hardcoded-ip-test", extra_opts: "--force --grace-period 0")
   end
 end
 

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -128,7 +128,7 @@ task "prometheus_traffic" do |t, args|
                 Log.debug { "metrics_config_map : #{metrics_config_map}" }
                 configmap_path = "#{CNF_TEMP_FILES_DIR}/metrics_configmap.yml"
                 File.write(configmap_path, "#{metrics_config_map}")
-                begin KubectlClient::Delete.file(configmap_path) rescue KubectlClient::ShellCMD::NotFoundError end
+                KubectlClient::Delete.file(configmap_path)
                 KubectlClient::Apply.file(configmap_path)
                 ip_match = true
               end


### PR DESCRIPTION
## Description
Currently, in the KubectlClient module, calls such as KubectlClient::Delete.file(...) or other operations assume the resource exists, which can raise errors like ShellCMD::NotFoundError. In many cleanup or setup workflows (e.g., ensure blocks), we need more robust utility methods that handle these cases gracefully.

## Issues:
Refs: #2273

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
