### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-/tools/ @denverwilliams @wavell @hashnuke @agentpoyo
-/src/ @denverwilliams @wavell @agentpoyo
-/specs/ @denverwilliams @wavell @agentpoyo
+/tools/ @martin-mat @collivier @rich-l @smitholi67
+/src/ @martin-mat @collivier @rich-l @smitholi67
+/specs/ @martin-mat @collivier @rich-l @smitholi67

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/ @martin-mat @collivier @rich-l @smitholi67
+* @martin-mat @collivier @rich-l @smitholi67

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-/tools/ @martin-mat @collivier @rich-l @smitholi67
-/src/ @martin-mat @collivier @rich-l @smitholi67
-/specs/ @martin-mat @collivier @rich-l @smitholi67
+/ @martin-mat @collivier @rich-l @smitholi67


### PR DESCRIPTION
Adding TSC members as the code owners and removed outdated owners no longer participating in CNTi. 