### PR TITLE
Feat: Rework liveness and readiness tasks functionality

### DIFF
--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -16,7 +16,7 @@
 
 * [**Category: Reliability, Resilience and Availability Tests**](#category-reliability-resilience-and-availability-tests)
 
-   [[CNF under network latency]](#cnf-under-network-latency) | [[CNF with host disk fill]](#cnf-with-host-disk-fill) | [[Pod delete]](#pod-delete) | [[Memory hog]](#memory-hog) | [[IO Stress]](#io-stress) | [[Network corruption]](#network-corruption) | [[Network duplication]](#network-duplication) | [[Pod DNS errors]](#pod-dns-errors) | [[Helm chart liveness entry]](#helm-chart-liveness-entry) | [[Helm chart readiness entry]](#helm-chart-readiness-entry)
+   [[CNF under network latency]](#cnf-under-network-latency) | [[CNF with host disk fill]](#cnf-with-host-disk-fill) | [[Pod delete]](#pod-delete) | [[Memory hog]](#memory-hog) | [[IO Stress]](#io-stress) | [[Network corruption]](#network-corruption) | [[Network duplication]](#network-duplication) | [[Pod DNS errors]](#pod-dns-errors) | [[Liveness probe]](#liveness-probe) | [[Readiness probe]](#readiness-probe)
 
 * [**Category: Observability and Diagnostic Tests**](#category-observability-and-diagnostic-tests)
 
@@ -749,12 +749,12 @@ Ensure that your CNF is resilient to DNS resolution failures can maintain a leve
 
 ----------
 
-### Helm chart liveness entry
+### Liveness probe
 
 #### Overview
 
-This test scans all of the CNFs workload resources and check if a Liveness Probe has been configuered for each container.
-Expectation: The Helm chart should have a liveness probe configured.
+This test verifies that each workload resource includes at least one container with a liveness probe configured.
+Expectation: Each workload resource should have at least one container with a liveness probe defined.
 
 #### Rationale
 
@@ -774,12 +774,12 @@ Ensure that your CNF has a [Liveness Probe](https://kubernetes.io/docs/tasks/con
 
 ----------
 
-### Helm chart readiness entry
+### Readiness probe
 
 #### Overview
 
-This test scans all of the CNFs workload resources and check if a Readiness Probe has been configuered for each container.
-Expectation: The Helm chart should have a readiness probe configured.
+This test verifies that each workload resource includes at least one container with a readiness probe configured.
+Expectation: Each workload resource should have at least one container with a readiness probe defined.
 
 #### Rationale
 

--- a/sample-cnfs/k8s-multiple-deployments/chart/templates/manifest.yml
+++ b/sample-cnfs/k8s-multiple-deployments/chart/templates/manifest.yml
@@ -23,45 +23,19 @@ spec:
         args: ["-c", "while true; do echo echo $(date -u) 'Hi I am from Sidecar container 1' >> /var/log/index.html; sleep 5;done"]
         name: sidecar-container1
         resources: {}
-        livenessProbe:
-          exec:
-            command:
-            - touch
-            - /tmp/healthy
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        readinessProbe:
-          exec:
-            command:
-            - touch
-            - /tmp/healthy
-          initialDelaySeconds: 5
-          periodSeconds: 5
         volumeMounts:
           - name: var-logs
             mountPath: /var/log
+
       - image: busybox
         command: ["/bin/sh"]
         args: ["-c", "while true; do echo echo $(date -u) 'Hi I am from Sidecar container 2' >> /var/log/index.html; sleep 5;done"]
         name: sidecar-container2
         resources: {}
-        livenessProbe:
-          exec:
-            command:
-            - touch
-            - /tmp/healthy
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        readinessProbe:
-          exec:
-            command:
-            - touch
-            - /tmp/healthy
-          initialDelaySeconds: 5
-          periodSeconds: 5
         volumeMounts:
           - name: var-logs
             mountPath: /var/log
+
       - image: nginx
         name: main-container
         resources: {}
@@ -116,23 +90,10 @@ spec:
         args: ["-c", "while true; do echo echo $(date -u) 'Hi I am from Sidecar container 1' >> /var/log/index.html; sleep 5;done"]
         name: sidecar-container3
         resources: {}
-        livenessProbe:
-          exec:
-            command:
-            - touch
-            - /tmp/healthy
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        readinessProbe:
-          exec:
-            command:
-            - touch
-            - /tmp/healthy
-          initialDelaySeconds: 5
-          periodSeconds: 5
         volumeMounts:
           - name: var-logs
             mountPath: /var/log
+
       - image: busybox
         command: ["/bin/sh"]
         args: ["-c", "while true; do echo echo $(date -u) 'Hi I am from Sidecar container 2' >> /var/log/index.html; sleep 5;done"]
@@ -141,20 +102,7 @@ spec:
         volumeMounts:
           - name: var-logs
             mountPath: /var/log
-        livenessProbe:
-          exec:
-            command:
-            - touch
-            - /tmp/healthy
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        readinessProbe:
-          exec:
-            command:
-            - touch
-            - /tmp/healthy
-          initialDelaySeconds: 5
-          periodSeconds: 5
+
       - image: nginx
         name: main-container2
         resources: {}

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -18,7 +18,7 @@ describe CnfTestSuite do
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("liveness", cmd_prefix:"LOG_LEVEL=debug")
       result[:status].success?.should be_true
-      (/(PASSED).*(Helm liveness probe)/ =~ result[:output]).should_not be_nil
+      (/(PASSED).*(All workload resources have at least one container with a liveness probe)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
     end
@@ -29,7 +29,7 @@ describe CnfTestSuite do
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-testsuite.yml skip_wait_for_install")
       result = ShellCmd.run_testsuite("liveness")
       result[:status].success?.should be_true
-      (/(FAILED).*(No livenessProbe found)/ =~ result[:output]).should_not be_nil
+      (/(FAILED).*(One or more workload resources have no containers with a liveness probe)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
     end
@@ -40,7 +40,7 @@ describe CnfTestSuite do
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("readiness", cmd_prefix: "LOG_LEVEL=debug")
       result[:status].success?.should be_true
-      (/(PASSED).*(Helm readiness probe)/ =~ result[:output]).should_not be_nil
+      (/(PASSED).*(All workload resources have at least one container with a readiness probe)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
     end
@@ -51,7 +51,7 @@ describe CnfTestSuite do
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-testsuite.yml skip_wait_for_install")
       result = ShellCmd.run_testsuite("readiness")
       result[:status].success?.should be_true
-      (/(FAILED).*(No readinessProbe found)/ =~ result[:output]).should_not be_nil
+      (/(FAILED).*(One or more workload resources have no containers with a readiness probe)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
     end


### PR DESCRIPTION
## Description
- Tests reworked according to suggestions in the referenced issue. Originally all containers for a given resource had to specify a probe to pass the test. This was reworked so that at least one container with a probe would cause the test to pass.
- Changes were done to the sample-cnf for the purposes of testing (liveness and readiness probes were removed from the side-cart containers to better simulate new expectations).
- Some overdue docummentation changes were done for the tasks as well, for unknown reasons helm was mentioned as part of this task although probe definitions can be made in other forms of deployment. This helm specificity was removed and the description made more generic.

## Issues:
Refs: #2283

## How has this been tested:
 - [x] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [x] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [x] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
