### PR TITLE
Allow IP Addresses with Subnet Masks in `hardcoded_ip_addresses_in_k8s_runtime_configuration` 

### DIFF
--- a/spec/modules/cluster_tools_spec.cr
+++ b/spec/modules/cluster_tools_spec.cr
@@ -2,12 +2,7 @@ require "../spec_helper.cr"
 
 describe "ClusterTools" do
   before_all do
-    begin
-      KubectlClient::Apply.namespace(ClusterTools.namespace)
-      Log.info { "#{ClusterTools.namespace} namespace created" }
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-      Log.info { "#{ClusterTools.namespace} namespace already exists on the Kubernetes cluster" }
-    end
+    KubectlClient::Apply.namespace(ClusterTools.namespace)
   end
 
   after_all do

--- a/spec/modules/cluster_tools_spec.cr
+++ b/spec/modules/cluster_tools_spec.cr
@@ -2,7 +2,12 @@ require "../spec_helper.cr"
 
 describe "ClusterTools" do
   before_all do
-    KubectlClient::AssureApplied.namespace(ClusterTools.namespace)
+    begin
+      KubectlClient::Apply.namespace(ClusterTools.namespace)
+      Log.info { "#{ClusterTools.namespace} namespace created" }
+    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
+      Log.info { "#{ClusterTools.namespace} namespace already exists on the Kubernetes cluster" }
+    end
   end
 
   after_all do

--- a/spec/modules/cluster_tools_spec.cr
+++ b/spec/modules/cluster_tools_spec.cr
@@ -2,12 +2,7 @@ require "../spec_helper.cr"
 
 describe "ClusterTools" do
   before_all do
-    begin
-      KubectlClient::Apply.namespace(ClusterTools.namespace)
-      Log.info { "#{ClusterTools.namespace} namespace created" }
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-      Log.info { "#{ClusterTools.namespace} namespace already exists on the Kubernetes cluster" }
-    end
+    KubectlClient::AssureApplied.namespace(ClusterTools.namespace)
   end
 
   after_all do

--- a/spec/modules/k8s_kernel_introspection_spec.cr
+++ b/spec/modules/k8s_kernel_introspection_spec.cr
@@ -2,10 +2,7 @@ require "../spec_helper.cr"
 
 describe "KernelIntrospection" do
   before_all do
-    begin
-      KubectlClient::Apply.namespace("cnf-testsuite")
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-    end
+    KubectlClient::AssureApplied.namespace("cnf-testsuite")
     ClusterTools.install
   end
 

--- a/spec/modules/k8s_kernel_introspection_spec.cr
+++ b/spec/modules/k8s_kernel_introspection_spec.cr
@@ -2,10 +2,7 @@ require "../spec_helper.cr"
 
 describe "KernelIntrospection" do
   before_all do
-    begin
-      KubectlClient::Apply.namespace("cnf-testsuite")
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-    end
+    KubectlClient::Apply.namespace("cnf-testsuite")
     ClusterTools.install
   end
 

--- a/spec/modules/k8s_kernel_introspection_spec.cr
+++ b/spec/modules/k8s_kernel_introspection_spec.cr
@@ -2,7 +2,10 @@ require "../spec_helper.cr"
 
 describe "KernelIntrospection" do
   before_all do
-    KubectlClient::AssureApplied.namespace("cnf-testsuite")
+    begin
+      KubectlClient::Apply.namespace("cnf-testsuite")
+    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
+    end
     ClusterTools.install
   end
 

--- a/spec/modules/k8s_netstat_spec.cr
+++ b/spec/modules/k8s_netstat_spec.cr
@@ -21,10 +21,7 @@ end
 
 describe "netstat" do
   before_all do
-    begin
-      KubectlClient::Apply.namespace("cnf-testsuite")
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-    end
+    KubectlClient::Apply.namespace("cnf-testsuite")
     ClusterTools.install
   end
 

--- a/spec/modules/k8s_netstat_spec.cr
+++ b/spec/modules/k8s_netstat_spec.cr
@@ -21,10 +21,7 @@ end
 
 describe "netstat" do
   before_all do
-    begin
-      KubectlClient::Apply.namespace("cnf-testsuite")
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-    end
+    KubectlClient::AssureApplied.namespace("cnf-testsuite")
     ClusterTools.install
   end
 

--- a/spec/modules/k8s_netstat_spec.cr
+++ b/spec/modules/k8s_netstat_spec.cr
@@ -21,7 +21,10 @@ end
 
 describe "netstat" do
   before_all do
-    KubectlClient::AssureApplied.namespace("cnf-testsuite")
+    begin
+      KubectlClient::Apply.namespace("cnf-testsuite")
+    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
+    end
     ClusterTools.install
   end
 

--- a/spec/modules/k8s_netstat_spec.cr
+++ b/spec/modules/k8s_netstat_spec.cr
@@ -27,8 +27,8 @@ describe "netstat" do
 
   after_all do
     # Cleanup logic after all tests have run
-    KubectlClient::AssureDeleted.resource("pvc", "data-wordpress-mariadb-0")
-    KubectlClient::AssureDeleted.resource("pvc", "wordpress")
+    KubectlClient::Delete.resource("pvc", "data-wordpress-mariadb-0")
+    KubectlClient::Delete.resource("pvc", "wordpress")
     Log.info { "Cleanup complete" }
   end
 

--- a/spec/modules/k8s_netstat_spec.cr
+++ b/spec/modules/k8s_netstat_spec.cr
@@ -30,11 +30,8 @@ describe "netstat" do
 
   after_all do
     # Cleanup logic after all tests have run
-    begin
-      KubectlClient::Delete.resource("pvc", "data-wordpress-mariadb-0")
-      KubectlClient::Delete.resource("pvc", "wordpress")
-    rescue ex : KubectlClient::ShellCMD::NotFoundError
-    end
+    KubectlClient::AssureDeleted.resource("pvc", "data-wordpress-mariadb-0")
+    KubectlClient::AssureDeleted.resource("pvc", "wordpress")
     Log.info { "Cleanup complete" }
   end
 

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -58,10 +58,7 @@ describe "Microservice" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      begin
-        KubectlClient::Delete.resource("pvc", "data-test-mariadb-0", "wordpress")
-      rescue KubectlClient::ShellCMD::NotFoundError
-      end
+      KubectlClient::AssureDeleted.resource("pvc", "data-test-mariadb-0", "wordpress")
     end
   end
 
@@ -83,10 +80,7 @@ describe "Microservice" do
       (/(PASSED).*(No shared database found)/ =~ result[:output]).should_not be_nil
     ensure
       Helm.uninstall("multi-db", DEFAULT_CNF_NAMESPACE)
-      begin
-        KubectlClient::Delete.resource("pvc", "data-multi-db-mariadb-0")
-      rescue KubectlClient::ShellCMD::NotFoundError
-      end
+      KubectlClient::AssureDeleted.resource("pvc", "data-multi-db-mariadb-0")
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
     end

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -58,7 +58,7 @@ describe "Microservice" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      KubectlClient::AssureDeleted.resource("pvc", "data-test-mariadb-0", "wordpress")
+      KubectlClient::Delete.resource("pvc", "data-test-mariadb-0", "wordpress")
     end
   end
 
@@ -80,7 +80,7 @@ describe "Microservice" do
       (/(PASSED).*(No shared database found)/ =~ result[:output]).should_not be_nil
     ensure
       Helm.uninstall("multi-db", DEFAULT_CNF_NAMESPACE)
-      KubectlClient::AssureDeleted.resource("pvc", "data-multi-db-mariadb-0")
+      KubectlClient::Delete.resource("pvc", "data-multi-db-mariadb-0")
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
     end

--- a/spec/workload/operator_spec.cr
+++ b/spec/workload/operator_spec.cr
@@ -32,10 +32,7 @@ describe "Operator" do
         KubectlClient::Get.pods_by_resource_labels(KubectlClient::Get.resource("deployment", "packageserver", "operator-lifecycle-manager"), "operator-lifecycle-manager")
 
       Helm.uninstall("operator")
-      begin
-        KubectlClient::Delete.resource("csv", "prometheusoperator.0.47.0")
-      rescue KubectlClient::ShellCMD::NotFoundError
-      end
+      KubectlClient::AssureDeleted.resource("csv", "prometheusoperator.0.47.0")
 
       pods.map do |pod| 
         pod_name = pod.dig("metadata", "name")

--- a/spec/workload/operator_spec.cr
+++ b/spec/workload/operator_spec.cr
@@ -32,7 +32,7 @@ describe "Operator" do
         KubectlClient::Get.pods_by_resource_labels(KubectlClient::Get.resource("deployment", "packageserver", "operator-lifecycle-manager"), "operator-lifecycle-manager")
 
       Helm.uninstall("operator")
-      KubectlClient::AssureDeleted.resource("csv", "prometheusoperator.0.47.0")
+      KubectlClient::Delete.resource("csv", "prometheusoperator.0.47.0")
 
       pods.map do |pod| 
         pod_name = pod.dig("metadata", "name")

--- a/src/modules/cluster_tools/cluster_tools.cr
+++ b/src/modules/cluster_tools/cluster_tools.cr
@@ -51,7 +51,7 @@ module ClusterTools
     Log.info { "ClusterTools uninstall" }
     File.write("cluster_tools.yml", ManifestTemplate.new().to_s)
 
-    KubectlClient::AssureDeleted.file("cluster_tools.yml", namespace: self.namespace!)
+    KubectlClient::Delete.file("cluster_tools.yml", namespace: self.namespace!)
     #todo make this work with cluster-tools-host-namespace
     KubectlClient::Wait.resource_wait_for_uninstall("Daemonset", "cluster-tools", namespace: self.namespace!)
   end

--- a/src/modules/cluster_tools/cluster_tools.cr
+++ b/src/modules/cluster_tools/cluster_tools.cr
@@ -51,13 +51,9 @@ module ClusterTools
     Log.info { "ClusterTools uninstall" }
     File.write("cluster_tools.yml", ManifestTemplate.new().to_s)
 
-    begin
-      KubectlClient::Delete.file("cluster_tools.yml", namespace: self.namespace!)
-      #todo make this work with cluster-tools-host-namespace
-      KubectlClient::Wait.resource_wait_for_uninstall("Daemonset", "cluster-tools", namespace: self.namespace!)
-    rescue ex : KubectlClient::ShellCMD::NotFoundError
-      Log.info { "ClusterTools not present on the cluster" }
-    end
+    KubectlClient::AssureDeleted.file("cluster_tools.yml", namespace: self.namespace!)
+    #todo make this work with cluster-tools-host-namespace
+    KubectlClient::Wait.resource_wait_for_uninstall("Daemonset", "cluster-tools", namespace: self.namespace!)
   end
 
   def self.exec(cli : String) : KubectlClient::CMDResult

--- a/src/modules/kubectl_client/modules/get.cr
+++ b/src/modules/kubectl_client/modules/get.cr
@@ -546,21 +546,5 @@ module KubectlClient
 
       runtimes.uniq
     end
-
-    def self.resource_names_from_file(file_name : String, namespace : String? = nil) : Array(String)
-      logger = @@logger.for("resource_names_from_file")
-      logger.debug { "Getting resource names from file: #{file_name}" }
-
-      cmd = "kubectl get -f #{file_name} -o name"
-      cmd = "#{cmd} -n #{namespace}" if namespace
-      result = ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
-
-      if result[:status].success?
-        result[:output].strip.split('\n')
-      else
-        logger.warn { "kubectl get failed for file: #{file_name}" }
-        [] of String
-      end
-    end
   end
 end

--- a/src/modules/kubectl_client/modules/get.cr
+++ b/src/modules/kubectl_client/modules/get.cr
@@ -547,4 +547,20 @@ module KubectlClient
       runtimes.uniq
     end
   end
+
+  def self.resource_names_from_file(file_name : String, namespace : String? = nil) : Array(String)
+    logger = @@logger.for("resource_names_from_file")
+    logger.debug { "Getting resource names from file: #{file_name}" }
+
+    cmd = "kubectl get -f #{file_name} -o name"
+    cmd = "#{cmd} -n #{namespace}" if namespace
+    result = ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
+
+    if result[:status].success?
+      result[:output].strip.split('\n')
+    else
+      logger.warn { "kubectl get failed for file: #{file_name}" }
+      [] of String
+    end
+  end
 end

--- a/src/modules/kubectl_client/modules/get.cr
+++ b/src/modules/kubectl_client/modules/get.cr
@@ -546,21 +546,21 @@ module KubectlClient
 
       runtimes.uniq
     end
-  end
 
-  def self.resource_names_from_file(file_name : String, namespace : String? = nil) : Array(String)
-    logger = @@logger.for("resource_names_from_file")
-    logger.debug { "Getting resource names from file: #{file_name}" }
+    def self.resource_names_from_file(file_name : String, namespace : String? = nil) : Array(String)
+      logger = @@logger.for("resource_names_from_file")
+      logger.debug { "Getting resource names from file: #{file_name}" }
 
-    cmd = "kubectl get -f #{file_name} -o name"
-    cmd = "#{cmd} -n #{namespace}" if namespace
-    result = ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
+      cmd = "kubectl get -f #{file_name} -o name"
+      cmd = "#{cmd} -n #{namespace}" if namespace
+      result = ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
 
-    if result[:status].success?
-      result[:output].strip.split('\n')
-    else
-      logger.warn { "kubectl get failed for file: #{file_name}" }
-      [] of String
+      if result[:status].success?
+        result[:output].strip.split('\n')
+      else
+        logger.warn { "kubectl get failed for file: #{file_name}" }
+        [] of String
+      end
     end
   end
 end

--- a/src/modules/kubectl_client/modules/modules.cr
+++ b/src/modules/kubectl_client/modules/modules.cr
@@ -82,13 +82,13 @@ module KubectlClient
       begin
         file_info = KubectlClient::Get.resource_names_from_file(file_name, namespace)
         if file_info.empty?
-          logger.info( "Resources from #{file_name} do not exist. Applying .." )
+          logger.info{ "Resources from #{file_name} do not exist. Applying .." }
         else
           logger.warn { "Resources from #{file_name} already exist." }
         end
         KubectlClient::Apply.file(file_name, namespace)
       rescue ex : KubectlClient::ShellCMD::AlreadyExistsError
-        logger.warn { "Resources from #{resource_name} already exist: #{ex.message}." }
+        logger.warn { "Resources from #{file_name} already exist: #{ex.message}." }
       end
     end
 
@@ -145,7 +145,7 @@ module KubectlClient
 
       begin
         resource_info = KubectlClient::Get.resource(kind, resource_name, namespace)
-        if resource_info.empty?
+        if resource_info.as_h?.try(&.empty?) || false
           logger.warn { "Resource #{resource_name} does not exist." }
         else
           logger.info { "Resource #{resource_name} exists. Deleting ..." }

--- a/src/modules/kubectl_client/modules/modules.cr
+++ b/src/modules/kubectl_client/modules/modules.cr
@@ -74,6 +74,7 @@ module KubectlClient
       rescue ex : KubectlClient::ShellCMD::AlreadyExistsError
         logger.warn { "Resource #{resource_name} already exists: #{ex.message}." }
       end
+      logger.info { "Resource #{resource_name} applied." }
     end
 
     def self.file(file_name : String?, namespace : String? = nil)
@@ -90,6 +91,7 @@ module KubectlClient
       rescue ex : KubectlClient::ShellCMD::AlreadyExistsError
         logger.warn { "Resources from #{file_name} already exist: #{ex.message}." }
       end
+      logger.info { "Resources from #{file_name} applied." }
     end
 
     def self.namespace(name : String)
@@ -99,6 +101,7 @@ module KubectlClient
       rescue ex : KubectlClient::ShellCMD::AlreadyExistsError
         logger.warn { "Namespace #{name} already exist: #{ex.message}." }
       end
+      logger.info { "Namespace #{name} created." }
     end
   end
 
@@ -153,9 +156,8 @@ module KubectlClient
         KubectlClient::Delete.resource(kind, resource_name, namespace, labels, extra_opts)
       rescue ex : KubectlClient::ShellCMD::NotFoundError
         logger.warn { "Failed to delete resource #{resource_name}: #{ex.message}." }
-        return
       end
-      
+      logger.info { "Resource #{resource_name} deleted. " }
     end
 
     def self.file(file_name : String, namespace : String? = nil, wait : Bool = false)
@@ -171,8 +173,8 @@ module KubectlClient
         KubectlClient::Delete.file(file_name, namespace, wait)
       rescue ex : KubectlClient::ShellCMD::NotFoundError
         logger.warn { "Failed to delete resources from file #{file_name}: #{ex.message}." }
-        return
       end
+      logger.info { "Resources from #{file_name} deleted. " }
     end
   end
 

--- a/src/modules/kubectl_client/modules/modules.cr
+++ b/src/modules/kubectl_client/modules/modules.cr
@@ -57,6 +57,26 @@ module KubectlClient
     end
   end
 
+  module AssureApplied
+    @@logger : ::Log = Log.for("AssureApplied")
+
+    def self.resource(kind : String, resource_name : String, namespace : String? = nil, values : String? = nil)
+      logger = @@logger.for("resource")
+
+      begin
+        resource_info = KubectlClient::Get.resource(kind, resource_name, namespace)
+        if resource_info.empty?
+          logger.warn { "Resource #{kind}/#{resource_name} does not exist." }
+        else
+          logger.warn { "Resource #{kind}/#{resource_name} does exist." }
+        end
+        KubectlClient::Apply.file(manifest_file, namespace)
+      rescue ex : KubectlClient::ShellCMD::NotFoundError
+        logger.warn { "Resource not found (#{kind}/#{resource_name}): #{ex.message}." }
+      end
+    end
+  end
+
   module Delete
     @@logger : ::Log = Log.for("Delete")
 

--- a/src/modules/kubectl_client/modules/modules.cr
+++ b/src/modules/kubectl_client/modules/modules.cr
@@ -110,12 +110,10 @@ module KubectlClient
     end
 
     def self.file(file_name : String, namespace : String? = nil, wait : Bool = false)
-      cmd = "kubectl get -f #{file_name} -o name"
-      cmd = "#{cmd} -n #{namespace}" if namespace
-
+      
       begin
-        result = ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
-        if result[:output].strip.empty?
+        file_resource_info = KubectlClient::Get.resource_names_from_file(file_name, namespace)
+        if file_resource_info.empty?
           logger.warn { "File #{file_name} does not exist, skipping deletion." }
           return
         end

--- a/src/modules/kubectl_client/modules/modules.cr
+++ b/src/modules/kubectl_client/modules/modules.cr
@@ -63,11 +63,13 @@ module KubectlClient
       manifest_file.flush
       cmd = "kubectl apply -f #{manifest_file.path}"
   
-      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
-      manifest_file.delete
+      begin
+        ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
+      ensure
+        manifest_file.delete
+      end
     end
   end
-
 
   module Delete
     @@logger : ::Log = Log.for("Delete")

--- a/src/modules/kubectl_client/modules/modules.cr
+++ b/src/modules/kubectl_client/modules/modules.cr
@@ -91,6 +91,25 @@ module KubectlClient
     end
   end
 
+  module AssureDeleted
+    @@logger : ::Log = Log.for("AssureDelete")
+
+    def self.resource(kind : String, resource_name : String? = nil, namespace : String? = nil,
+                  labels : Hash(String, String) = {} of String => String, extra_opts : String? = nil)
+      begin
+        resource_info = KubectlClient::Get.resource(kind, resource_name, namespace)
+        if resource_info.empty?
+          logger.warn { "Resource #{kind}/#{resource_name} does not exist, skipping deletion." }
+          return
+        end
+      rescue ex : KubectlClient::ShellCMD::NotFoundError
+        logger.warn { "Failed to get resource #{kind}/#{resource_name}: #{ex.message}, skipping deletion." }
+        return
+      end
+      KubectlClient::Delete.resource(kind, resource_name, namespace, labels, extra_opts)
+    end
+  end
+
   module Utils
     @@logger : ::Log = Log.for("Utils")
 

--- a/src/modules/kubectl_client/modules/modules.cr
+++ b/src/modules/kubectl_client/modules/modules.cr
@@ -58,15 +58,12 @@ module KubectlClient
           name: #{namespace}
         YAML
 
-      manifest_file = File.tempfile("#{namespace}", ".yaml")
-      manifest_file.puts namespace_manifest
-      manifest_file.flush
-      cmd = "kubectl apply -f #{manifest_file.path}"
-  
-      begin
+      File.tempfile("#{namespace}", ".yaml") do |manifest_file|
+        manifest_file.puts(namespace_manifest)
+        manifest_file.flush
+
+        cmd = "kubectl apply -f #{manifest_file.path}"
         ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
-      ensure
-        manifest_file.delete
       end
     end
   end

--- a/src/modules/kubectl_client/modules/modules.cr
+++ b/src/modules/kubectl_client/modules/modules.cr
@@ -98,7 +98,7 @@ module KubectlClient
       logger = @@logger.for("file")
       logger.info { "Delete resources from file #{file_name}" }
 
-      cmd = "kubectl delete -f #{file_name}"
+      cmd = "kubectl delete -f #{file_name} --ignore-not-found=true"
       cmd = "#{cmd} -n #{namespace}" if namespace
       cmd = "#{cmd} --wait=#{wait}"
 

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -91,7 +91,7 @@ namespace "platform" do
       end
     end
 
-    KubectlClient::AssureDeleted.resource("cm", cm_name)
+    KubectlClient::Delete.resource("cm", cm_name)
   end
 end
 

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -91,7 +91,7 @@ namespace "platform" do
       end
     end
 
-    KubectlClient::Delete.resource("cm", cm_name)
+      KubectlClient::Delete.resource("cm", cm_name)
   end
 end
 
@@ -116,6 +116,7 @@ end
       file.flush
 
       KubectlClient::Apply.file(file.path)
+
       file.delete
       return true
   end

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -91,7 +91,7 @@ namespace "platform" do
       end
     end
 
-      KubectlClient::Delete.resource("cm", cm_name)
+    KubectlClient::Delete.resource("cm", cm_name)
   end
 end
 

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -116,7 +116,6 @@ end
       file.flush
 
       KubectlClient::Apply.file(file.path)
-      
       file.delete
       return true
   end

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -91,11 +91,7 @@ namespace "platform" do
       end
     end
 
-    begin
-      KubectlClient::Delete.resource("cm", cm_name)
-    rescue ex : KubectlClient::ShellCMD::K8sClientCMDException 
-      logger.error { "Failed to delete ConfigMap #{cm_name}: #{ex.message}" }
-    end
+    KubectlClient::AssureDeleted.resource("cm", cm_name)
   end
 end
 
@@ -120,7 +116,7 @@ end
       file.flush
 
       KubectlClient::Apply.file(file.path)
-
+      KubectlClient::AssureApplied.file(file.path)
       file.delete
       return true
   end

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -116,7 +116,7 @@ end
       file.flush
 
       KubectlClient::Apply.file(file.path)
-      KubectlClient::AssureApplied.file(file.path)
+      
       file.delete
       return true
   end

--- a/src/tasks/setup/cluster_api_setup.cr
+++ b/src/tasks/setup/cluster_api_setup.cr
@@ -77,7 +77,7 @@ namespace "setup" do
   task "cluster_api_uninstall" do |_, args|
     current_dir = FileUtils.pwd
     delete_cluster_file = "#{current_dir}/capi.yaml"
-    begin KubectlClient::Delete.file("#{delete_cluster_file}") rescue KubectlClient::ShellCMD::NotFoundError end
+    KubectlClient::AssureDeleted.file("#{delete_cluster_file}")
 
     cmd = "clusterctl delete --all --include-crd --include-namespace"
     Process.run(cmd, shell: true, output: stdout = IO::Memory.new, error: stderr = IO::Memory.new)

--- a/src/tasks/setup/cluster_api_setup.cr
+++ b/src/tasks/setup/cluster_api_setup.cr
@@ -77,7 +77,7 @@ namespace "setup" do
   task "cluster_api_uninstall" do |_, args|
     current_dir = FileUtils.pwd
     delete_cluster_file = "#{current_dir}/capi.yaml"
-    KubectlClient::AssureDeleted.file("#{delete_cluster_file}")
+    KubectlClient::Delete.file("#{delete_cluster_file}")
 
     cmd = "clusterctl delete --all --include-crd --include-namespace"
     Process.run(cmd, shell: true, output: stdout = IO::Memory.new, error: stderr = IO::Memory.new)

--- a/src/tasks/setup/litmus_setup.cr
+++ b/src/tasks/setup/litmus_setup.cr
@@ -32,7 +32,7 @@ task "uninstall_litmus" do |_, args|
       output: stdout = IO::Memory.new,
       error: stderr = IO::Memory.new
   )
-  KubectlClient::AssureDeleted.file("https://litmuschaos.github.io/litmus/litmus-operator-v#{LitmusManager::Version}.yaml", namespace: LitmusManager::LITMUS_NAMESPACE)
+  KubectlClient::Delete.file("https://litmuschaos.github.io/litmus/litmus-operator-v#{LitmusManager::Version}.yaml", namespace: LitmusManager::LITMUS_NAMESPACE)
   Log.info { stdout }
   Log.info { stderr }
 end

--- a/src/tasks/setup/litmus_setup.cr
+++ b/src/tasks/setup/litmus_setup.cr
@@ -32,10 +32,7 @@ task "uninstall_litmus" do |_, args|
       output: stdout = IO::Memory.new,
       error: stderr = IO::Memory.new
   )
-  begin
-    KubectlClient::Delete.file("https://litmuschaos.github.io/litmus/litmus-operator-v#{LitmusManager::Version}.yaml", namespace: LitmusManager::LITMUS_NAMESPACE)
-  rescue KubectlClient::ShellCMD::NotFoundError
-  end
+  KubectlClient::AssureDeleted.file("https://litmuschaos.github.io/litmus/litmus-operator-v#{LitmusManager::Version}.yaml", namespace: LitmusManager::LITMUS_NAMESPACE)
   Log.info { stdout }
   Log.info { stderr }
 end

--- a/src/tasks/setup/opa_setup.cr
+++ b/src/tasks/setup/opa_setup.cr
@@ -39,5 +39,4 @@ task "uninstall_opa" do |_, args|
   begin Helm.uninstall("opa-gatekeeper", TESTSUITE_NAMESPACE) rescue Helm::ShellCMD::ReleaseNotFound end
   KubectlClient::AssureDeleted.file("enforce-image-tag.yml")
   KubectlClient::AssureDeleted.file("constraint_template.yml")
-  
 end

--- a/src/tasks/setup/opa_setup.cr
+++ b/src/tasks/setup/opa_setup.cr
@@ -37,6 +37,7 @@ desc "Uninstall OPA"
 task "uninstall_opa" do |_, args|
   Log.debug { "uninstall_opa" }
   begin Helm.uninstall("opa-gatekeeper", TESTSUITE_NAMESPACE) rescue Helm::ShellCMD::ReleaseNotFound end
-  begin KubectlClient::Delete.file("enforce-image-tag.yml") rescue KubectlClient::ShellCMD::NotFoundError end
-  begin KubectlClient::Delete.file("constraint_template.yml") rescue KubectlClient::ShellCMD::NotFoundError end
+  KubectlClient::AssureDeleted.file("enforce-image-tag.yml")
+  KubectlClient::AssureDeleted.file("constraint_template.yml")
+  
 end

--- a/src/tasks/setup/opa_setup.cr
+++ b/src/tasks/setup/opa_setup.cr
@@ -37,6 +37,6 @@ desc "Uninstall OPA"
 task "uninstall_opa" do |_, args|
   Log.debug { "uninstall_opa" }
   begin Helm.uninstall("opa-gatekeeper", TESTSUITE_NAMESPACE) rescue Helm::ShellCMD::ReleaseNotFound end
-  KubectlClient::AssureDeleted.file("enforce-image-tag.yml")
-  KubectlClient::AssureDeleted.file("constraint_template.yml")
+  KubectlClient::Delete.file("enforce-image-tag.yml")
+  KubectlClient::Delete.file("constraint_template.yml")
 end

--- a/src/tasks/setup/setup.cr
+++ b/src/tasks/setup/setup.cr
@@ -14,7 +14,7 @@ namespace "setup" do
 
     ensure_kubeconfig!
     begin
-      KubectlClient::AssureApplied.namespace(TESTSUITE_NAMESPACE)
+      KubectlClient::Apply.namespace(TESTSUITE_NAMESPACE)
     rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
       stdout_failure "Could not create #{TESTSUITE_NAMESPACE} namespace on the Kubernetes cluster"
       logger.error { "Failed to create #{TESTSUITE_NAMESPACE} namespace: #{ex.message}" }

--- a/src/tasks/setup/setup.cr
+++ b/src/tasks/setup/setup.cr
@@ -14,12 +14,7 @@ namespace "setup" do
 
     ensure_kubeconfig!
     begin
-      KubectlClient::Apply.namespace(TESTSUITE_NAMESPACE)
-      stdout_success "Created #{TESTSUITE_NAMESPACE} namespace on the Kubernetes cluster"
-      logger.info { "#{TESTSUITE_NAMESPACE} namespace created" }
-    rescue ex : KubectlClient::ShellCMD::AlreadyExistsError
-      stdout_success "#{TESTSUITE_NAMESPACE} namespace already exists on the Kubernetes cluster"
-      logger.info { "#{TESTSUITE_NAMESPACE} namespace already exists, not creating" }
+      KubectlClient::AssureApplied.namespace(TESTSUITE_NAMESPACE)
     rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
       stdout_failure "Could not create #{TESTSUITE_NAMESPACE} namespace on the Kubernetes cluster"
       logger.error { "Failed to create #{TESTSUITE_NAMESPACE} namespace: #{ex.message}" }

--- a/src/tasks/utils/cnf_installation/deployment_management/manifest_deployment_manager.cr
+++ b/src/tasks/utils/cnf_installation/deployment_management/manifest_deployment_manager.cr
@@ -39,10 +39,7 @@ module CNFInstall
 
     def uninstall()
       begin
-        result = KubectlClient::Delete.file(@manifest_directory_path, wait: false)
-      rescue KubectlClient::ShellCMD::NotFoundError
-        stdout_warning "Manifest deployment \"#{deployment_name}\" was not found."
-        true
+        result = KubectlClient::Delete.file(@manifest_directory_path, wait: true)
       rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
         stdout_failure "Error while uninstalling manifest deployment \"#{@manifest_config.name}\":"
         stdout_failure "\t#{ex.message}"

--- a/src/tasks/utils/cnf_manager/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager/cnf_manager.cr
@@ -146,11 +146,7 @@ module CNFManager
     logger = Log.for("ensure_namespace_exists!")
     logger.info { "Ensure that namespace: #{namespace} exists on the cluster for the CNF install" }
 
-    begin
-      KubectlClient::Apply.namespace(namespace)
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-      logger.info { "Namespace: #{namespace} already exists" }
-    end
+    KubectlClient::Apply.namespace(namespace)
 
     KubectlClient::Utils.label("namespace", namespace, ["pod-security.kubernetes.io/enforce=privileged"])
     true

--- a/src/tasks/utils/cnf_manager/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager/cnf_manager.cr
@@ -146,11 +146,7 @@ module CNFManager
     logger = Log.for("ensure_namespace_exists!")
     logger.info { "Ensure that namespace: #{namespace} exists on the cluster for the CNF install" }
 
-    begin
-      KubectlClient::Apply.namespace(namespace)
-    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
-      logger.info { "Namespace: #{namespace} already exists" }
-    end
+    KubectlClient::AssureApplied.namespace(namespace)
 
     KubectlClient::Utils.label("namespace", namespace, ["pod-security.kubernetes.io/enforce=privileged"])
     true

--- a/src/tasks/utils/cnf_manager/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager/cnf_manager.cr
@@ -146,7 +146,11 @@ module CNFManager
     logger = Log.for("ensure_namespace_exists!")
     logger.info { "Ensure that namespace: #{namespace} exists on the cluster for the CNF install" }
 
-    KubectlClient::AssureApplied.namespace(namespace)
+    begin
+      KubectlClient::Apply.namespace(namespace)
+    rescue e : KubectlClient::ShellCMD::AlreadyExistsError
+      logger.info { "Namespace: #{namespace} already exists" }
+    end
 
     KubectlClient::Utils.label("namespace", namespace, ["pod-security.kubernetes.io/enforce=privileged"])
     true

--- a/src/tasks/utils/dockerd.cr
+++ b/src/tasks/utils/dockerd.cr
@@ -28,16 +28,10 @@ module Dockerd
 
   def self.uninstall
     Log.info { "Uninstall dockerd from manifest" }
-    begin
-      KubectlClient::Delete.file(dockerd_manifest_file, namespace: TESTSUITE_NAMESPACE)
-    rescue KubectlClient::ShellCMD::NotFoundError
-    end
+    KubectlClient::AssureDeleted.file(dockerd_manifest_file, namespace: TESTSUITE_NAMESPACE)
 
     Log.info { "Uninstall docker-config from manifest" }
-    begin
-      KubectlClient::Delete.resource("configmaps", "docker-config", TESTSUITE_NAMESPACE)
-    rescue KubectlClient::ShellCMD::NotFoundError
-    end
+    KubectlClient::AssureDeleted.resource("configmaps", "docker-config", TESTSUITE_NAMESPACE)
   end
 
   def self.exec(cli)

--- a/src/tasks/utils/dockerd.cr
+++ b/src/tasks/utils/dockerd.cr
@@ -28,10 +28,10 @@ module Dockerd
 
   def self.uninstall
     Log.info { "Uninstall dockerd from manifest" }
-    KubectlClient::AssureDeleted.file(dockerd_manifest_file, namespace: TESTSUITE_NAMESPACE)
+    KubectlClient::Delete.file(dockerd_manifest_file, namespace: TESTSUITE_NAMESPACE)
 
     Log.info { "Uninstall docker-config from manifest" }
-    KubectlClient::AssureDeleted.resource("configmaps", "docker-config", TESTSUITE_NAMESPACE)
+    KubectlClient::Delete.resource("configmaps", "docker-config", TESTSUITE_NAMESPACE)
   end
 
   def self.exec(cli)

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -246,7 +246,7 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |t, args|
   rescue
     CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Skipped, "unknown exception")
   ensure
-    KubectlClient::AssureDeleted.resource("namespace", "hardcoded-ip-test", extra_opts: "--force --grace-period 0")
+    KubectlClient::Delete.resource("namespace", "hardcoded-ip-test", extra_opts: "--force --grace-period 0")
   end
 end
 

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -246,10 +246,7 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |t, args|
   rescue
     CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Skipped, "unknown exception")
   ensure
-    begin
-      KubectlClient::Delete.resource("namespace", "hardcoded-ip-test", extra_opts: "--force --grace-period 0")
-    rescue KubectlClient::ShellCMD::NotFoundError
-    end
+    KubectlClient::AssureDeleted.resource("namespace", "hardcoded-ip-test", extra_opts: "--force --grace-period 0")
   end
 end
 

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -223,9 +223,16 @@ task "hardcoded_ip_addresses_in_k8s_runtime_configuration" do |t, args|
       file.each_line do |line|
         if line.matches?(/NOTES:/)
           break
-        elsif matches = line.scan(/([0-9]{1,3}[\.]){3}[0-9]{1,3}/)
+        elsif matches = line.scan(/((?:[0-9]{1,3}\.){3}[0-9]{1,3})(\/[0-9]{1,2})?/)
           matches.each do |match|
-            unless match[0] == "0.0.0.0" || match[0] == "127.0.0.1"
+            ip_adress = match[0]
+            if ip_adress == "127.0.0.1" || ip_adress == "0.0.0.0"
+              next
+            end
+            
+            ip_adress_with_mask = ip_adress.includes?("/")
+            
+            unless ip_adress_with_mask
               found_violations << {line_number: line_number, line: line.strip}
             end
           end

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -128,7 +128,7 @@ task "prometheus_traffic" do |t, args|
                 Log.debug { "metrics_config_map : #{metrics_config_map}" }
                 configmap_path = "#{CNF_TEMP_FILES_DIR}/metrics_configmap.yml"
                 File.write(configmap_path, "#{metrics_config_map}")
-                KubectlClient::AssureDeleted.file(configmap_path)
+                KubectlClient::Delete.file(configmap_path)
                 KubectlClient::Apply.file(configmap_path)
                 ip_match = true
               end

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -128,7 +128,7 @@ task "prometheus_traffic" do |t, args|
                 Log.debug { "metrics_config_map : #{metrics_config_map}" }
                 configmap_path = "#{CNF_TEMP_FILES_DIR}/metrics_configmap.yml"
                 File.write(configmap_path, "#{metrics_config_map}")
-                begin KubectlClient::Delete.file(configmap_path) rescue KubectlClient::ShellCMD::NotFoundError end
+                KubectlClient::AssureDeleted.file(configmap_path)
                 KubectlClient::Apply.file(configmap_path)
                 ip_match = true
               end


### PR DESCRIPTION
## Description
The `hardcoded_ip_addresses_in_k8s_runtime_configuration` test is designed to prevent CNFs from hardcoding IP addresses into configuration for connecting to other services. However, there are valid reasons to include IP addresses in configuration for example, when specifying IP ranges for GeoIP databases or network policies.

This PR updates the test logic to allow IP addresses that include a subnet mask.

## Issues:
#2282

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
