### PR TITLE
Allow IP Addresses with Subnet Masks in `hardcoded_ip_addresses_in_k8s_runtime_configuration`

### DIFF
--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -1481,8 +1481,8 @@ Review all Helm Charts & Kubernetes Manifest files for the CNF and remove all oc
 
 #### Overview
 
-The hardcoded ip address test will scan all of the CNF's workload resources and check for any static, hardcoded ip addresses being used in the configuration.
-Expectation: That no hardcoded IP addresses or subnet masks are found in the Kubernetes workload resources for the CNF.
+The hardcoded ip address test will scan all of the CNF's workload resources and check for any static, hardcoded ip addresses being used in the configuration. CIDR notation is allowed and will not cause the test to fail.
+Expectation: That no hardcoded IP addresses (without CIDR masks) are found in the Kubernetes workload resources for the CNF.
 
 #### Rationale
 

--- a/sample-cnfs/sample_coredns/chart/values.yaml
+++ b/sample-cnfs/sample_coredns/chart/values.yaml
@@ -196,3 +196,5 @@ autoscaler:
     ## Annotations for the coredns-autoscaler configmap
     # i.e. strategy.spinnaker.io/versioned: "false" to ensure configmap isn't renamed
     annotations: {}
+
+testNetworkCIDR: "1.1.1.0/24"


### PR DESCRIPTION
## Description
The hardcoded_ip_addresses_in_k8s_runtime_configuration test is designed to prevent CNFs from hardcoding IP addresses into configuration for connecting to other services. However, there are valid reasons to include IP addresses in configuration for example, when specifying IP ranges for GeoIP databases or network policies.

This PR updates the test logic to allow IP addresses that include a subnet mask.

## Issues:
Refs: #2282

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
