### PR TITLE
Fix: `workload_resource_test` PART 1/2

### DIFF
--- a/src/modules/kubectl_client/kubectl_client.cr
+++ b/src/modules/kubectl_client/kubectl_client.cr
@@ -13,12 +13,10 @@ module KubectlClient
   alias BackgroundCMDResult = NamedTuple(process: Process, output: String, error: String)
 
   WORKLOAD_RESOURCES = {deployment:      "Deployment",
-                        service:         "Service",
                         pod:             "Pod",
                         replicaset:      "ReplicaSet",
                         statefulset:     "StatefulSet",
-                        daemonset:       "DaemonSet",
-                        service_account: "ServiceAccount"}
+                        daemonset:       "DaemonSet"}
 
   module ShellCMD
     # logger should have method name (any other scopes, if necessary) that is calling attached using .for() method.

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -679,17 +679,9 @@ end
 desc "Are any of the containers exposed as a service?"
 task "service_discovery" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args,config|
-    # Get all resources for the CNF
-    resource_ymls = CNFManager.cnf_workload_resources(args, config) { |resource| resource }
-    resources = Helm.workload_resource_kind_names(resource_ymls)
-
     # Collect service names from the CNF resource list
-    cnf_service_names = [] of String
-    resources.each do |resource|
-      case resource[:kind].downcase
-      when "service"
-        cnf_service_names.push(resource[:name])
-      end
+    cnf_service_names = CNFManager.resource_refs(args, config, ["service"]) do |service|
+      service[:name]
     end
 
     # Get all the pods in the cluster


### PR DESCRIPTION
## Description
- It was discovered that after #2294 services were somehow clawing their way into the probe tasks and causing them to fail. This prompted a long-overdue rework of `workload_resource_test` function. 
- The `workload_resource_test` function was yielding `services` and `serviceAccounts` as well, this was likely some long forgotten hack, which made the function unreadable and logically wrong.
- `Services` and `serviceAccounts` were removed from the `workload_resource_test` (thus fixing the issue with probe tasks failing). New function `resource_refs` was added to allow rudimentary iteration over any array of resource kinds (necessary for nodeport_not_used task). Other affected tasks fixed appropriatelly.
- Another issue was discovered, explained in #2300.

Changes to `hostport_not_used, external_ips, service_account_mapping, service_discovery` and `nodeport_not_used` are self-explanatory. The first four tasks should iterate over specific resources (`service/serviceAccount`), while nodeport should only iterate over workload resources.

**This does not resolve the issue of some tests reporting false results, that will be done in PART 2 (a different PR)**.

## Issues:
Refs: #2300

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
