### PR TITLE
Fix an incorrect Process call

### DIFF
--- a/src/tasks/setup/helmenv_setup.cr
+++ b/src/tasks/setup/helmenv_setup.cr
@@ -45,7 +45,7 @@ task "helm_local_install", ["setup:cnf_directory_setup"] do |_, args|
 
         helm = Helm::BinarySingleton.helm
         stdout = IO::Memory.new
-        status = Process.run("#{helm} version", output: stdout, error: stdout)
+        status = Process.run("#{helm} version", shell: true, output: stdout, error: stdout)
         Log.trace { stdout }
 
         #TODO what is this for?


### PR DESCRIPTION
shell must be set to true because binary and argument are in the string command.

```
[2025-06-19 07:51:02]  INFO -- CNTI: TarClient.untar stderr: [2025-06-19 07:51:02] DEBUG -- CNTI: helm_v3?:
/usr/lib/crystal/lib/crystal/system/unix/process.cr:263:7 in 'raise_exception_from_errno' /usr/lib/crystal/lib/crystal/system/unix/process.cr:200:9 in 'spawn' /usr/lib/crystal/lib/process.cr:246:5 in 'initialize' /usr/lib/crystal/lib/process.cr:238:3 in 'new'
/usr/lib/crystal/lib/process.cr:144:14 in 'run:output:error' src/tasks/setup/helmenv_setup.cr:48:9 in '->'
lib/sam/src/sam/task.cr:54:39 in 'call'
lib/sam/src/sam/execution.cr:20:7 in 'invoke'
lib/sam/src/sam/task.cr:44:29 in 'call'
lib/sam/src/sam/execution.cr:20:7 in 'invoke'
lib/sam/src/sam.cr:35:5 in 'invoke'
lib/sam/src/sam.cr:53:7 in 'process_tasks'
src/cnf-testsuite.cr:122:3 in '__crystal_main'
/usr/lib/crystal/lib/crystal/main.cr:129:5 in 'main_user_code' /usr/lib/crystal/lib/crystal/main.cr:115:7 in 'main' /usr/lib/crystal/lib/crystal/main.cr:141:3 in 'main' /lib/x86_64-linux-gnu/libc.so.6 in '??'
/lib/x86_64-linux-gnu/libc.so.6 in '__libc_start_main' ./cnf-testsuite in '_start'
???
Error executing process: '/home/collivier/.cnf-testsuite/tools/helm/linux-amd64/helm version': No such file or directory
```
