### PR TITLE
Allow Configured IP Adresses in `hardcoded_ip_addresses_in_k8s_runtime_configuration`

### DIFF
--- a/CNF_TESTSUITE_YML_USAGE.md
+++ b/CNF_TESTSUITE_YML_USAGE.md
@@ -89,6 +89,22 @@ Example setting:
 
 `white_list_container_names: [coredns]`
 
+##### hardcoded_ip_exceptions 
+
+The values of this optional key are the IP addresses that are allowed to appear as hardcoded values in the configuration of the CNF.
+This value is used to allow particular hardcoded IPs to be exempted from the `hardcoded_ip_adresses_in_k8s_runtime_configuration` test when the CNF is being validated.
+The reason this is needed is because the CNF Testsuite checks all configuration files and manifests used by the CNF for the presence of hardcoded IP addresses.
+While hardcoding IPs is generally discouraged in cloud-native environments, there may be cases where certain addresses are justified and cannot be avoided.
+This exception list can be used to explicitly allow such IPs and prevent them from being reported as violations.
+
+````yaml
+config_version: v2
+common:
+  hardcoded_ip_exceptions:
+    - ip: 8.8.8.8
+    - ip: 4.4.4.4
+````
+
 ##### `docker_insecure_registries`
 
 The docker client expects the image registries to be using an HTTPS API endpoint. This option is used to configure insecure registries that the docker client should be allowed to access.

--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -1481,8 +1481,8 @@ Review all Helm Charts & Kubernetes Manifest files for the CNF and remove all oc
 
 #### Overview
 
-The hardcoded ip address test will scan all of the CNF's workload resources and check for any static, hardcoded ip addresses being used in the configuration. CIDR notation is allowed and will not cause the test to fail.
-Expectation: That no hardcoded IP addresses (without CIDR masks) are found in the Kubernetes workload resources for the CNF.
+The hardcoded ip address test will scan all of the CNF's workload resources and check for any static, hardcoded ip addresses being used in the configuration. CIDR notation is allowed and will not cause the test to fail. IP addresses that are justified by application logic are possible to be included in `hardcoded_ip_exceptions` in the [CNF configuration](https://github.com/lfn-cnti/testsuite/blob/main/CNF_TESTSUITE_YML_USAGE.md) and will be excluded from violation reports.
+Expectation: That no hardcoded IP addresses are found in the Kubernetes workload resources for the CNF unless they are in CIDR format or explicitly listed in `hardcoded_ip_exceptions`.
 
 #### Rationale
 

--- a/sample-cnfs/sample_coredns/chart/values.yaml
+++ b/sample-cnfs/sample_coredns/chart/values.yaml
@@ -32,6 +32,7 @@ service:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9153"
+    hardcodedIpTest: "8.8.8.8 4.4.4.4"
 
 serviceAccount:
   create: false

--- a/sample-cnfs/sample_coredns/cnf-testsuite.yml
+++ b/sample-cnfs/sample_coredns/cnf-testsuite.yml
@@ -5,3 +5,7 @@ deployments:
   - name: coredns
     helm_directory: chart
     namespace: cnfspace
+common:
+  hardcoded_ip_exceptions:
+    - ip: 8.8.8.8
+    - ip: 4.4.4.4

--- a/src/tasks/utils/cnf_installation/config_versions/config_v2.cr
+++ b/src/tasks/utils/cnf_installation/config_versions/config_v2.cr
@@ -17,7 +17,8 @@ module CNFInstall
              white_list_container_names = [] of String,
              docker_insecure_registries = [] of String,
              image_registry_fqdns = {} of String => String,
-             five_g_parameters = FiveGParameters.new()
+             five_g_parameters = FiveGParameters.new(),
+             hardcoded_ip_exceptions = [] of HardcodedIPsAllowed
       def initialize()
       end
     end
@@ -124,6 +125,10 @@ module CNFInstall
           raise ArgumentError.new("Incorrect tag name for container configuration: #{tag_name}")
         end
       end
+    end
+
+    class HardcodedIPsAllowed < CNFInstall::Config::ConfigBase
+      getter ip : String
     end
   end
 end


### PR DESCRIPTION
## Description
This PR extends the `hardcoded_ip_addresses_in_k8s_runtime_configuration` task to allow and Configured IP Addresses.

## Issues:
Refs: #2282

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
