### PR TITLE
Fix: `workload_resource_test` PART 2/2

### DIFF
--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -29,7 +29,7 @@ end
 
 def run_probe_task(t, args, probe_type : String)
   CNFManager::Task.task_runner(args, task: t) do |args, config|
-    task_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, containers|
+    task_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, containers, _|
       resource_ref = "#{resource[:kind]}/#{resource[:name]}"
       probe_key = "#{probe_type}Probe"
       resource_has_probe = false
@@ -84,7 +84,7 @@ task "pod_network_latency", ["install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
     #todo if args has list of labels to perform test on, go into pod specific mode
     #TODO tests should fail if cnf not installed
-    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       Log.info { "Current Resource Name: #{resource["name"]} Type: #{resource["kind"]}" }
       app_namespace = resource[:namespace]
 
@@ -164,6 +164,8 @@ task "pod_network_latency", ["install_litmus"] do |t, args|
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
         test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
       end
+
+      test_passed
     end
     unless args.named["pod_labels"]?
         #todo if in pod specific mode, dont do upserts and resp = ""
@@ -181,7 +183,7 @@ desc "Does the CNF crash when network corruption occurs"
 task "pod_network_corruption", ["install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
     #TODO tests should fail if cnf not installed
-    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       Log.info {"Current Resource Name: #{resource["name"]} Type: #{resource["kind"]}"}
       app_namespace = resource[:namespace]
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
@@ -222,6 +224,8 @@ task "pod_network_corruption", ["install_litmus"] do |t, args|
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
         test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name, args, namespace: app_namespace)
       end
+
+      test_passed
     end
     if task_response
       CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Passed, "pod_network_corruption chaos test passed")
@@ -235,7 +239,7 @@ desc "Does the CNF crash when network duplication occurs"
 task "pod_network_duplication", ["install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
     #TODO tests should fail if cnf not installed
-    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       app_namespace = resource[:namespace]
       Log.info{ "Current Resource Name: #{resource["name"]} Type: #{resource["kind"]} Namespace: #{resource["namespace"]}"}
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
@@ -278,6 +282,8 @@ task "pod_network_duplication", ["install_litmus"] do |t, args|
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
         test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
       end
+
+      test_passed
     end
     if task_response
       CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Passed, "pod_network_duplication chaos test passed")
@@ -290,7 +296,7 @@ end
 desc "Does the CNF crash when disk fill occurs"
 task "disk_fill", ["install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
-    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       app_namespace = resource[:namespace]
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0
@@ -334,6 +340,7 @@ task "disk_fill", ["install_litmus"] do |t, args|
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
         test_passed = LitmusManager.check_chaos_verdict(chaos_result_name, chaos_experiment_name, args, namespace: app_namespace)
       end
+
       test_passed
     end
     if task_response
@@ -348,7 +355,7 @@ desc "Does the CNF crash when pod-delete occurs"
 task "pod_delete", ["install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
     #todo clear all annotations
-    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       app_namespace = resource[:namespace]
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0
@@ -434,6 +441,7 @@ task "pod_delete", ["install_litmus"] do |t, args|
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
       end
       test_passed=LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
+      test_passed
     end
     unless args.named["pod_labels"]?
         if task_response
@@ -448,7 +456,7 @@ end
 desc "Does the CNF crash when pod-memory-hog occurs"
 task "pod_memory_hog", ["install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
-    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       app_namespace = resource[:namespace]
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0
@@ -506,7 +514,7 @@ end
 desc "Does the CNF crash when pod-io-stress occurs"
 task "pod_io_stress", ["install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
-    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       app_namespace = resource[:namespace]
       spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
       if spec_labels.as_h? && spec_labels.as_h.size > 0
@@ -551,6 +559,8 @@ task "pod_io_stress", ["install_litmus"] do |t, args|
         LitmusManager.wait_for_test(chaos_test_name, chaos_experiment_name, args, namespace: app_namespace)
         test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
       end
+
+      test_passed
     end
     if task_response
       CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Passed, "pod_io_stress chaos test passed")
@@ -575,7 +585,7 @@ task "pod_dns_error", ["install_litmus"] do |t, args|
     runtimes = KubectlClient::Get.container_runtimes
     Log.info { "pod_dns_error runtimes: #{runtimes}" }
     if runtimes.find{|r| r.downcase.includes?("docker")}
-      task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+      task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
         app_namespace = resource[:namespace]
         spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"])
         if spec_labels.as_h? && spec_labels.as_h.size > 0
@@ -618,6 +628,8 @@ task "pod_dns_error", ["install_litmus"] do |t, args|
           LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
           test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
         end
+
+        test_passed
       end
       if task_response
         CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Passed, "pod_dns_error chaos test passed")

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -144,7 +144,7 @@ task "privileged_containers" do |t, args|
     white_list_container_names = config.common.white_list_container_names
     Log.debug { "white_list_container_names #{white_list_container_names.inspect}" }
     violation_list = [] of NamedTuple(kind: String, name: String, container: String, namespace: String)
-    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
+    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, _|
       privileged_list = KubectlClient::Get.privileged_containers(all_namespaces: true).map { |container| container.dig("name") }.uniq
       resource_containers = KubectlClient::Get.resource_containers(resource["kind"],resource["name"],resource["namespace"])
       resource_containers_list = resource_containers.as_a.map { |element| element["name"] }


### PR DESCRIPTION
## Description
- Enforces proper usage of `workload_resource_test` (block iteration now requires Bool instead of Bool?)
- Prior implementation allowed for some tasks (mostly in reliability) to be completely disfunctional (always reporting the task result as passed). More info in the referenced issue.
- All the other tasks that utilized `workload_resource_test` and weren't using it in the intended way were subtly refactored.

**Some tests now utilize early exists, that is why git diff displays indentation changes as full on code changes**

Throughout the refactoring I noticed that certain tasks could do with a further touch-up, also some tasks that utilize `workload_resource_test` don't necessarily have a binary result that could be covered with a Bool, some have skips/special cases. In the future we could consider implementing some auxiliary result-reporting logic, i.e. having `workload_resource_test` return some enum like this instead of bool:

```crystal
enum TestOutcome
  Pass
  Fail(message : String)
  Skip(reason  : String)
end

task "some_task"
  task_result = workload_resource_test(...) do |...|
    if (some_prerequisite_condition_unfulfilled)
      next TestOutcome::Skip.new("No pods for #{kind}/#{name}") # currently covered through some external variable
    
    if (some_check_true)
      next TestOutcome::Pass # currently true

    TestOutcome::Fail.new("Container does not use specialized init system...") # currently false
  end
end

final = aggregate_outcomes(task_result)
CNFManager::TestCaseResult.new(final.status, final.msg)
```

Although that would introduce a split in tests (some basing task result on bool, others on a more granular structure). Well, this is just something to consider in the future.

## Issues:
Refs: #2300

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
