### PR TITLE
Improve Failure Output for single_process_type Test

### DIFF
--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -353,7 +353,7 @@ end
 desc "Do the containers in a pod have only one process type?"
 task "single_process_type" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config|
-    fail_msgs = [] of String
+    fail_msgs = Set(String).new
     resources_checked = false
     test_passed = true
 
@@ -376,6 +376,7 @@ task "single_process_type" do |t, args|
       # Iterate over every container and verify there is only one process type
       ClusterTools.all_containers_by_resource?(resource_named_tuple, namespace, only_container_pids:true) do |container_id, container_pid_on_node, node, container_proctree_statuses, container_status|
         previous_process_type = "initial_name"
+        container_name = container_status["name"]?
 
         container_proctree_statuses.each do |status|
           status_name = status["Name"].strip
@@ -388,15 +389,25 @@ task "single_process_type" do |t, args|
             verified = KernelIntrospection::K8s::Node.verify_single_proc_tree(ppid, status_name, container_proctree_statuses, SPECIALIZED_INIT_SYSTEMS)
             unless verified
               Log.for(t.name).info { "multiple proc types detected verified: #{verified}" }
-              fail_msg = "resource: #{resource} has more than one process type (#{container_proctree_statuses.map { |x| x["cmdline"]? }.compact.uniq.join(", ")})"
-              unless fail_msgs.find { |x| x == fail_msg }
-                puts fail_msg.colorize(:red)
-                fail_msgs << fail_msg
-              end
+
+              proc_list = container_proctree_statuses.map do |proc|
+                proc_name = proc["Name"]?
+                proc_pid  = proc["Pid"]?
+                proc_ppid = proc["PPid"]?
+                proc_cmd = proc["cmdline"]?.try do |cmd|
+                  cmd.split("\0").join(" ").gsub("\n", "\\n").strip
+                end || "N/A"
+                "NAME=#{proc_name}, PID=#{proc_pid}, PPID=#{proc_ppid}, CMD=#{proc_cmd}"
+              end.join("\n")
+              
+              fail_msg = "Container `#{container_name}` in `#{kind}`: `#{name}` (namespace: `#{namespace}`) has multiple process types.\n"
+              fail_msg += "Running processes detected:\n"
+              fail_msg += "#{proc_list}"
+
+              stdout_failure(fail_msg) if fail_msgs.add?(fail_msg)
               test_passed = false
             end
           end
-
           previous_process_type = status_name
         end
       end


### PR DESCRIPTION
## Description
This PR improves readability of the failure message in the `single_process_type` task.

## Issues:
Refs: #2274

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
