### PR TITLE
Fix: Task missing a namespace

### DIFF
--- a/src/tasks/platform/observability.cr
+++ b/src/tasks/platform/observability.cr
@@ -15,7 +15,7 @@ namespace "platform" do
   end
 
   desc "Does the Platform have Kube State Metrics installed"
-  task "kube_state_metrics", ["install_cluster_tools"] do |t, args|
+  task "kube_state_metrics", ["setup:install_cluster_tools"] do |t, args|
     CNFManager::Task.task_runner(args, task: t, check_cnf_installed: false) do |args, config|
       unless check_poc(args)
         next CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Skipped, "Kube State Metrics not in poc mode")
@@ -33,7 +33,7 @@ namespace "platform" do
   end
 
   desc "Does the Platform have a Node Exporter installed"
-  task "node_exporter", ["install_cluster_tools"] do |t, args|
+  task "node_exporter", ["setup:install_cluster_tools"] do |t, args|
     CNFManager::Task.task_runner(args, task: t, check_cnf_installed: false) do |args, config|
       unless check_poc(args)
         next CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Skipped, "node exporter not in poc mode")
@@ -51,7 +51,7 @@ namespace "platform" do
 
 
   desc "Does the Platform have the prometheus adapter installed"
-  task "prometheus_adapter", ["install_cluster_tools"] do |t, args|
+  task "prometheus_adapter", ["setup:install_cluster_tools"] do |t, args|
     CNFManager::Task.task_runner(args, task: t, check_cnf_installed: false) do |args, config|
       unless check_poc(args)
         next CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Skipped, "prometheus adapter not in poc mode")
@@ -69,7 +69,7 @@ namespace "platform" do
   end
 
   desc "Does the Platform have the K8s Metrics Server installed"
-  task "metrics_server", ["install_cluster_tools"] do |t, args|
+  task "metrics_server", ["setup:install_cluster_tools"] do |t, args|
     CNFManager::Task.task_runner(args, task: t, check_cnf_installed: false) do |args, config|
       unless check_poc(args)
         next CNFManager::TestCaseResult.new(CNFManager::ResultStatus::Skipped, "Metrics server not in poc mode")


### PR DESCRIPTION
## Description
Caught by one of our users, I am not sure how this passed the tests.

@martin-mat please confirm that the reported failure was from one of these tasks.