### PR TITLE
Fix: CNF uninstallation resource discovery

### DIFF
--- a/src/modules/kubectl_client/kubectl_client.cr
+++ b/src/modules/kubectl_client/kubectl_client.cr
@@ -11,12 +11,17 @@ module KubectlClient
 
   alias CMDResult = NamedTuple(status: Process::Status, output: String, error: String)
   alias BackgroundCMDResult = NamedTuple(process: Process, output: String, error: String)
+  alias ResourceDescendant = NamedTuple(kind: String, name: String, namespace: String?, uid: String )
 
-  WORKLOAD_RESOURCES = {deployment:      "Deployment",
-                        pod:             "Pod",
-                        replicaset:      "ReplicaSet",
-                        statefulset:     "StatefulSet",
-                        daemonset:       "DaemonSet"}
+  WORKLOAD_RESOURCES = {
+    deployment:  "Deployment",
+    pod:         "Pod",
+    replicaset:  "ReplicaSet",
+    statefulset: "StatefulSet",
+    daemonset:   "DaemonSet",
+    job:         "Job",
+    cronjob:     "CronJob"
+  }
 
   module ShellCMD
     # logger should have method name (any other scopes, if necessary) that is calling attached using .for() method.


### PR DESCRIPTION
## Description
- Original implementation of wait_for_deployment_uninstallation utilized label discovery to find descendant resources of some core resource, this introduced errors as labels werent a sufficient identifier. To resolve this issue we now search for descendants through UIDs and ownerRef.
- Utility functions to retrieve UIDs and recursively find descendants were introduced in the KubectlClient.Get module
- Minor refactors to existing code.
- constant WORKLOAD_RESOURCES was extended to include job and cronjob since they are also workload resources.
- spec test to verify that failing uninstallation gets caught was tagged incorrectly, resulting in it being skipped in actions (this discovery prompted some changes to it)

## Issues:
Refs: #2310

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
