### PR TITLE
Fix: Invalid sonobuoy result parsing

### DIFF
--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -180,7 +180,7 @@ end
   end
 
   desc "Verify if Secrets are encrypted"
-  task "verify_secrets_encryption", ["kubescape_scan"] do |t, args|
+  task "verify_secrets_encryption", ["setup:kubescape_scan"] do |t, args|
     CNFManager::Task.task_runner(args, task: t, check_cnf_installed: false) do |args, config|
       namespace="kube-system"
       Kubescape.scan(namespace: namespace)


### PR DESCRIPTION

## Description
- The k8s_conformance task in platform tests was failing under some circumstances, this was caused by a grep that was catching all results in the format "Failed: *", the * was sometimes not a numeric value which would crash the original *.to_s.to_i chain, it is still unknown what value would be there (maybe "NA/Error").
- The "fix" adds more robust handling of erroneous values, namely they will get printed through a log.warn and not cause an exception, further changes will be done if more precise errors are reported.

## Issues:
Refs: #2314

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
