### PR TITLE
Fix: recognize *.yaml config files as valid

### DIFF
--- a/spec/fixtures/cnf-testsuite.yaml
+++ b/spec/fixtures/cnf-testsuite.yaml
@@ -1,0 +1,6 @@
+---
+release_name: coredns
+helm_repository:
+  name: stable
+  repo_url: https://cncf.gitlab.io/stable
+helm_chart: stable/coredns

--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -38,9 +38,19 @@ describe "Installation" do
     (/All CNF deployments were uninstalled/ =~ result[:output]).should_not be_nil
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config (.yml)", tags: ["cnf_installation"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=example-cnfs/coredns/cnf-testsuite.yml")
+      (/CNF installation complete/ =~ result[:output]).should_not be_nil
+    ensure
+      result = ShellCmd.cnf_uninstall()
+      (/All CNF deployments were uninstalled/ =~ result[:output]).should_not be_nil
+    end
+  end
+
+  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config (.yaml)", tags: ["cnf_installation"] do
+    begin
+      result = ShellCmd.cnf_install("cnf-path=spec/fixtures/cnf-testsuite.yaml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -52,6 +62,15 @@ describe "Installation" do
     begin
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/sample-bad-config.yml", expect_failure: true)
       (/Error during parsing CNF config/ =~ result[:output]).should_not be_nil
+    ensure
+      result = ShellCmd.cnf_uninstall()
+    end
+  end
+
+  it "'cnf_install/cnf_uninstall' should fail on invalid config path", tags: ["cnf_installation"] do
+    begin
+      result = ShellCmd.cnf_install("cnf-path=spec/fixtures/bad-config-path", expect_failure: true)
+      (/Invalid CNF configuration file: spec\/fixtures\/bad-config-path\./ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
     end

--- a/src/tasks/utils/cnf_installation/install_common.cr
+++ b/src/tasks/utils/cnf_installation/install_common.cr
@@ -61,8 +61,11 @@ module CNFInstall
   def self.ensure_cnf_config_path_file(path)
     if CNFManager.path_has_yml?(path)
       yml = path
-    else
+    elsif File.directory?(path)
       yml = File.join(path, CONFIG_FILE)
+    else
+      stdout_failure "Invalid CNF configuration file: #{path}."
+      exit(1)
     end
   end
 

--- a/src/tasks/utils/cnf_manager/cnf_manager.cr
+++ b/src/tasks/utils/cnf_manager/cnf_manager.cr
@@ -131,9 +131,8 @@ module CNFManager
     !cnf_config_list(false).empty?
   end
 
-  # (rafal-lal) TODO: why are we not accepting *.yaml
   def self.path_has_yml?(config_path)
-    config_path =~ /\.yml/
+    config_path =~ /\.ya?ml$/
   end
 
   # (kosstennbl) TODO: Redesign this method using new installation.


### PR DESCRIPTION
## Description
Previously, cnf-testsuite assumed that any path not ending with cnf-testsuite.yml was a directory and automatically appended cnf-testsuite.yml. This caused issues when users passed a full config filename, e.g., `/sample-cnfs/sample_coredns/cnf-testsuite.yaml`, resulting in an invalid path like `/sample-cnfs/sample_coredns/cnf-testsuite.yaml/cnf-testsuite.yml`.

In this PR, the config path handling logic has been updated to accept both `.yml` and `.yaml` extensions as valid CNF configuration files. When a directory is provided, the default config filename is appended to the path. If an invalid file is provided, an error message is printed instead of appending a default filename.

## Issues:
Refs: #2278

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
