### PR TITLE
Fix: uninstall_all eats up command line

### DIFF
--- a/src/tasks/utils/cnf_installation/install_common.cr
+++ b/src/tasks/utils/cnf_installation/install_common.cr
@@ -247,7 +247,7 @@ module CNFInstall
 
       stdout_success(
         "Waiting deletion for \"#{deployment_name}\" (#{idx+1}/#{total}): [#{kind}] #{name}",
-        same_line: true
+        same_line: idx > 0
       )
 
       ok = KubectlClient::Wait.resource_wait_for_uninstall(


### PR DESCRIPTION
## Description
The first uninstall progress message was printed with `same_line: true`, which overwrote the shell prompt. This PR updates the print logic to apply `same_line: true` only after the first message, ensuring the shell prompt remains visible.

## Issues:
Refs: #2316

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
