### PR TITLE
Fix: cnf-setup wrong error message when k8s not reachable via kubectl

### DIFF
--- a/src/modules/helm/utils.cr
+++ b/src/modules/helm/utils.cr
@@ -141,12 +141,12 @@ module Helm
       combined  = resp[:output] + resp[:error]
 
       if combined =~ /WARNING: Kubernetes configuration file is/
-        return {"For this version of Helm you must set your K8s config file permissions to chmod 700", nil}
+        return { "For this version of Helm you must set your K8s config file permissions to chmod 700", nil }
       end
 
       {nil, nil}
     rescue
-      {nil, "Please use newer version of Helm"}
+        { "Helm was found, but it could not be executed successfully. Please use newer version of Helm or check your Kubernetes configuration.", nil }
     end
   end
 

--- a/src/modules/kubectl_client/utils/system_information.cr
+++ b/src/modules/kubectl_client/utils/system_information.cr
@@ -49,6 +49,8 @@ def kubectl_installation(verbose = false, offline_mode = false)
     stdout_warning lmsg
   end
 
+  ensure_kubeconfig! unless global_kubectl_version.empty? && local_kubectl_version.empty?
+
   # uncomment to fail the installation check
   # global_kubectl_version = nil
   # local_kubectl_version = nil

--- a/src/tasks/setup/prereqs.cr
+++ b/src/tasks/setup/prereqs.cr
@@ -6,8 +6,8 @@ require "../../modules/helm"
 
 namespace "setup" do
   task "prereqs" do |_, args|
-    helm_ok = Helm.installation_found?
     kubectl_ok = KubectlClient.installation_found?
+    helm_ok = Helm.installation_found?
     git_ok = GitClient.installation_found?
 
     if [helm_ok, kubectl_ok, git_ok].includes?(false)

--- a/src/tasks/setup/setup.cr
+++ b/src/tasks/setup/setup.cr
@@ -12,7 +12,6 @@ namespace "setup" do
     logger = SLOG.for("create_namespace")
     logger.info { "Creating namespace for CNTI testsuite" }
 
-    ensure_kubeconfig!
     begin
       KubectlClient::Apply.namespace(TESTSUITE_NAMESPACE)
     rescue ex : KubectlClient::ShellCMD::K8sClientCMDException

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -60,7 +60,7 @@ def ensure_kubeconfig!
   begin
     KubectlClient::Get.resource("nodes")
   rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
-    stdout_failure "Cluster liveness check failed: '#{ex.message}'. Check the cluster and/or KUBECONFIG environment variable."
+    stdout_failure "Cluster liveness check failed. Check the cluster and/or KUBECONFIG environment variable."
     exit 1
   end
 end


### PR DESCRIPTION
## Description
Previously, if Kubernetes was not reachable via kubectl, the Helm installation check would fail and display misleading error messages. This PR modifies the `helm_gives_k8s_warning?` function so that Helm installation checks no longer fail when Kubernetes is unreachable and the output messages are more informative, guiding the user to check the Helm version or their Kubernetes configuration.

## Issues:
Refs: #2315

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
