### PR TITLE
Refactor cnf_install timeout parameter

### DIFF
--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -164,7 +164,7 @@ describe "Installation" do
   it "'cnf_install' should correctly handle deployment priority", tags: ["cnf_installation"] do
     # (kosstennbl) ELK stack requires to be installed with specific order, otherwise it would give errors
     begin
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-elk-stack/cnf-testsuite.yml timeout=600")
+      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-elk-stack/cnf-testsuite.yml", timeout: 600)
       result[:status].success?.should be_true
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
   

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -31,9 +31,8 @@ module ShellCmd
     run(cmd, log_prefix: "ShellCmd.run_testsuite", force_output: true, joined_output: true)
   end
 
-  def self.cnf_install(install_params, cmd_prefix="", expect_failure=false)
-    timeout_parameter = install_params.includes?("timeout") ? "" : "timeout=300"
-    result = run_testsuite("cnf_install #{install_params} #{timeout_parameter}", cmd_prefix)
+  def self.cnf_install(install_params, timeout=300, cmd_prefix="", expect_failure=false)
+    result = run_testsuite("cnf_install #{install_params} timeout=#{timeout}", cmd_prefix)
     if !expect_failure
       result[:status].success?.should be_true
     else


### PR DESCRIPTION
## Description
This PR updates the `cnf_install`  function in `spec_helper.cr` to mirror the behavior of `cnf_uninstall`, ensuring consistent handling of the timeout parameter.

## Issues:
Refs: #2280 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
