### PR TITLE
Avoid kernel functions that might block when running lsof

### DIFF
--- a/src/modules/cluster_tools/templates/manifest.yml.ecr
+++ b/src/modules/cluster_tools/templates/manifest.yml.ecr
@@ -22,8 +22,15 @@ spec:
             - /bin/bash
             - -c
             - |
-              [ -S /host/run/containerd/containerd.sock ] && ln -s /host/run/containerd /run/containerd
-              [ -S /host/run/crio/crio.sock ] && ln -s /host/run/crio /run/crio
+              CONTAINERD_SOCKET_DIR=$(lsof -U -bw | grep -E "/containerd\.sock\s" | awk '{print $9}' | head -n 1 | xargs -r dirname)
+              if [ -n "$CONTAINERD_SOCKET_DIR" ]; then
+                ln -s /host/$CONTAINERD_SOCKET_DIR /run/containerd
+              else
+                CRIO_SOCKET_DIR=$(lsof -U -bw | grep -E "/crio\.sock\s" | awk '{print $9}' | head -n 1 | xargs -r dirname)
+                if [ -n "$CRIO_SOCKET_DIR" ]; then
+                  ln -s /host/$CRIO_SOCKET_DIR /var/run/crio
+                fi
+              fi
               sleep infinity
           volumeMounts:
           - name: systemd


### PR DESCRIPTION
## Description

It partially reverts "Stop leveraging lsof which may hang when listing sockets" and now leverage -b  which causes lsof to avoid kernel functions that might block lstat, readlink, and stat.
https://lsof.readthedocs.io/en/stable/faq/

## Issues:
Refs: #2331 