### PR TITLE
Optimize the gate duration

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,10 +38,10 @@ jobs:
         TEST_ARRAY=("${TEST_ARRAY[@]/pod_network_latency/}")
         TEST_ARRAY=("${TEST_ARRAY[@]/zombie/}")
         TEST_ARRAY=("${TEST_ARRAY[@]/oran/}")
-        # Skip 5g, core, shared_database2 tags because they are flaky
+        # Skip 5g, core, shared_database_flaky tags because they are flaky
         TEST_ARRAY=("${TEST_ARRAY[@]/5g/}")
         TEST_ARRAY=("${TEST_ARRAY[@]/core/}")
-        TEST_ARRAY=("${TEST_ARRAY[@]/shared_database2/}")
+        TEST_ARRAY=("${TEST_ARRAY[@]/shared_database_flaky/}")
         TEST_LIST=$(for i in ${TEST_ARRAY[@]}
         do
                  echo "{\"spec\":\"$i\"}," | tr -d '\n'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -279,15 +279,6 @@ jobs:
         kind create cluster --name $CLUSTER --config=/tmp/cluster.yml --kubeconfig ./$CLUSTER.conf --retain --wait 5m
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get nodes
-    - name: Cache crystal shards
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-crystal-shards
-      with:
-        path: ./lib
-        key: lib-${{ hashFiles('**/shard.lock') }}
-        restore-keys: |
-          lib-
     - name: Setup CNF-Conformance
       run: |
         git fetch --all --tags --force
@@ -308,11 +299,6 @@ jobs:
         export PROTECTED_DOCKERHUB_PASSWORD=$DOCKERHUB_PASSWORD
         export PROTECTED_DOCKERHUB_EMAIL=${EMAIL_ARRAY[$RANDOMIZER]}
         export PROTECTED_IMAGE_REPO=${IMAGE_ARRAY[$RANDOMIZER]}
-
-        echo get ratelimit anonymously
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
-
         source cluster.env
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         until [[ $(kubectl get pods -l app=local-path-provisioner --namespace=local-path-storage -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') == "True" ]]; do
@@ -327,17 +313,10 @@ jobs:
         crystal build src/cnf-testsuite.cr 
         ./cnf-testsuite setup 
         LOG_LEVEL=debug crystal spec --tag ${{ matrix.spec }} -v
-        echo get ratelimit anonymously
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
-        echo get ratelimit with a user account $DOCKERHUB_USERNAME
-        TOKEN=$(curl --user "$DOCKERHUB_USERNAME:$DOCKERHUB_PASSWORD" "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
         source cluster.env
-        kind export logs --name $CLUSTER /tmp/output-dir
         docker ps -a
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get all -A || true
@@ -345,14 +324,6 @@ jobs:
         rm -f /shared/pss/cluster-level-pss.$CLUSTER.yaml /tmp/cluster.yml
         rm -rf ~/.config/helm
       continue-on-error: true
-
-    - name: upload artifact
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: log_${{ matrix.spec }}
-        path: /tmp/output-dir
-        
   chaos:
     name: Chaos & Oran Tests
     needs: [tests]
@@ -412,15 +383,6 @@ jobs:
         kind create cluster --name $CLUSTER --config=/tmp/cluster.yml --kubeconfig ./$CLUSTER.conf --retain --wait 5m
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get nodes
-    - name: Cache crystal shards
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-crystal-shards
-      with:
-        path: ./lib
-        key: lib-${{ hashFiles('**/shard.lock') }}
-        restore-keys: |
-          lib-
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
@@ -432,10 +394,6 @@ jobs:
         echo "RUNNER: $RUNNER_NAME"
     - name: Run Crystal Spec
       run: |
-        echo get ratelimit anonymously
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
-
         source cluster.env
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         until [[ $(kubectl get pods -l app=kindnet --namespace=kube-system -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') == "True" ]]; do
@@ -443,14 +401,10 @@ jobs:
             sleep 1
         done
         LOG_LEVEL=debug crystal spec --tag ${{ matrix.tag }} -v
-        echo get ratelimit anonymously
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
         source cluster.env
-        kind export logs --name $CLUSTER /tmp/output-dir
         docker ps -a
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get all -A || true
@@ -458,13 +412,6 @@ jobs:
         rm -f /tmp/cluster.yml
         rm -rf ~/.config/helm
       continue-on-error: true
-    - name: upload artifact
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: log_oran_${{ matrix.tag }}
-        path: /tmp/output-dir
-
   build:
     name: Build Release
     runs-on: ubuntu-24.04
@@ -486,15 +433,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Cache crystal shards
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-crystal-shards
-      with:
-        path: ./lib
-        key: lib-${{ hashFiles('**/shard.lock') }}
-        restore-keys: |
-          lib-
     - name: Build Release
       run: |
         docker pull $CRYSTAL_IMAGE
@@ -528,15 +466,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Cache crystal shards
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-crystal-shards
-      with:
-        path: ./lib
-        key: lib-${{ hashFiles('**/shard.lock') }}
-        restore-keys: |
-          lib-
     - name: Install Latest Kind
       env:
         KIND_VERSION: v0.29.0
@@ -587,10 +516,6 @@ jobs:
         kubectl get nodes
     - name: Run Test Suite without source(config_lifecycle)
       run: |
-        echo get ratelimit anonymously
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
-
         source cluster.env
         echo "SHARDS_INSTALL_PATH: $SHARDS_INSTALL_PATH"
         export KUBECONFIG=/tmp/$CLUSTER.conf
@@ -603,14 +528,10 @@ jobs:
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
         LOG_LEVEL=debug ./cnf-testsuite all ~compatibility ~resilience ~reasonable_startup_time ~reasonable_image_size ~platform ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published
-        echo get ratelimit anonymously
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
         source cluster.env
-        kind export logs --name $CLUSTER /tmp/output-dir
         docker ps -a
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get all -A || true
@@ -618,13 +539,6 @@ jobs:
         rm -f /tmp/cluster.yml
         rm -rf ~/.config/helm
       continue-on-error: true
-    - name: upload artifact
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: log_test_binary_configuration_lifecycle
-        path: /tmp/output-dir
-
   test_binary_microservice:
     name: Test Binary Without Source(microservice)
     runs-on: [v1.0.0]
@@ -647,15 +561,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Cache crystal shards
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-crystal-shards
-      with:
-        path: ./lib
-        key: lib-${{ hashFiles('**/shard.lock') }}
-        restore-keys: |
-          lib-
     - name: Install Latest Kind
       env:
         KIND_VERSION: v0.29.0
@@ -705,10 +610,6 @@ jobs:
         kubectl get nodes
     - name: Run Test Suite without source(microservice)
       run: |
-        echo get ratelimit anonymously
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
-
         source cluster.env
         export KUBECONFIG=/tmp/$CLUSTER.conf
         export DIR=$(uuidgen)
@@ -720,14 +621,10 @@ jobs:
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
         LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~compatibility ~pod_network_latency ~platform ~increase_capacity ~decrease_capacity ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap
-        echo get ratelimit anonymously
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
         source cluster.env
-        kind export logs --name $CLUSTER /tmp/output-dir
         docker ps -a
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get all -A || true
@@ -735,13 +632,6 @@ jobs:
         rm -f /tmp/cluster.yml
         rm -rf ~/.config/helm
       continue-on-error: true
-    - name: upload artifact
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: log_test_binary_microservice
-        path: /tmp/output-dir
-
   test_binary_all:
     name: Test Binary Without Source(all)
     runs-on: [v1.0.0]
@@ -764,15 +654,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    - name: Cache crystal shards
-      uses: actions/cache@v4
-      env:
-        cache-name: cache-crystal-shards
-      with:
-        path: ./lib
-        key: lib-${{ hashFiles('**/shard.lock') }}
-        restore-keys: |
-          lib-
     - name: Install Latest Kind
       env:
         KIND_VERSION: v0.29.0
@@ -822,10 +703,6 @@ jobs:
         kubectl get nodes
     - name: Run Test Suite without source(all)
       run: |
-        echo get ratelimit anonymously
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
-
         source cluster.env
         export KUBECONFIG=/tmp/$CLUSTER.conf
         export DIR=$(uuidgen)
@@ -837,14 +714,10 @@ jobs:
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
         LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size
-        echo get ratelimit anonymously
-        TOKEN=$(curl "https://auth.docker.io/token?service=registry.docker.io&scope=repository:ratelimitpreview/test:pull" | jq -r .token)
-        curl --head -H "Authorization: Bearer $TOKEN" https://registry-1.docker.io/v2/ratelimitpreview/test/manifests/latest
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
         source cluster.env
-        kind export logs --name $CLUSTER /tmp/output-dir
         docker ps -a
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get all -A || true
@@ -852,13 +725,6 @@ jobs:
         rm -f /tmp/cluster.yml
         rm -rf ~/.config/helm
       continue-on-error: true
-    - name: upload artifact
-      if: ${{ always() }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: log_test_binary_all
-        path: /tmp/output-dir
-
   release:
     name: Publish Release
     needs: [spec, build]

--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -21,13 +21,13 @@ def fetch_nginx_chart_tgz(dest_dir : String, version = "15.10.0") : String
 end
 
 describe "Installation" do
-  it "'setup' should install all cnf-testsuite dependencies before installing cnfs", tags: ["cnf_installation"]  do
+  it "'setup' should install all cnf-testsuite dependencies before installing cnfs", tags: ["cnf_installation1"]  do
     result = ShellCmd.run_testsuite("setup")
     result[:status].success?.should be_true
     (/Dependency installation complete/ =~ result[:output]).should_not be_nil
   end
 
-  it "'uninstall_all' should uninstall CNF and testsuite dependencies", tags: ["cnf_installation"] do
+  it "'uninstall_all' should uninstall CNF and testsuite dependencies", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-minimal-cnf/")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -38,7 +38,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install' should pass with a minimal cnf-testsuite.yml", tags: ["cnf_installation"] do
+  it "'cnf_install' should pass with a minimal cnf-testsuite.yml", tags: ["cnf_installation1"] do
     result = ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample-minimal-cnf/")
     (/CNF installation complete/ =~ result[:output]).should_not be_nil
   ensure
@@ -46,7 +46,7 @@ describe "Installation" do
     (/All CNF deployments were uninstalled/ =~ result[:output]).should_not be_nil
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-config arg as an alias for cnf-path", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-config arg as an alias for cnf-path", tags: ["cnf_installation1"] do
     result = ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-minimal-cnf/")
     (/CNF installation complete/ =~ result[:output]).should_not be_nil
   ensure
@@ -54,7 +54,7 @@ describe "Installation" do
     (/All CNF deployments were uninstalled/ =~ result[:output]).should_not be_nil
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config (.yml)", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config (.yml)", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=example-cnfs/coredns/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -64,7 +64,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config (.yaml)", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config (.yaml)", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/cnf-testsuite.yaml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -74,7 +74,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should fail on incorrect config", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should fail on incorrect config", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/sample-bad-config.yml", expect_failure: true)
       (/Error during parsing CNF config/ =~ result[:output]).should_not be_nil
@@ -83,7 +83,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should fail on invalid config path", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should fail on invalid config path", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/bad-config-path", expect_failure: true)
       (/Invalid CNF configuration file: spec\/fixtures\/bad-config-path\./ =~ result[:output]).should_not be_nil
@@ -92,7 +92,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall a cnf with a cnf-testsuite.yml", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall a cnf with a cnf-testsuite.yml", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-config=example-cnfs/coredns/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -102,7 +102,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should work with cnf-testsuite.yml that has no directory associated with it", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should work with cnf-testsuite.yml that has no directory associated with it", tags: ["cnf_installation1"] do
     begin
       #TODO force cnfs/<name> to be deployment name and not the directory name
       result = ShellCmd.cnf_install("cnf-config=spec/fixtures/cnf-testsuite.yml")
@@ -113,7 +113,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall with helm_directory that descends multiple directories", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall with helm_directory that descends multiple directories", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/multi_helm_directories/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -123,7 +123,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should properly install/uninstall old versions of cnf configs", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should properly install/uninstall old versions of cnf configs", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/cnf-testsuite-v1-example.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -133,7 +133,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install' should fail if another CNF is already installed", tags: ["cnf_installation"] do
+  it "'cnf_install' should fail if another CNF is already installed", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -145,7 +145,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall a cnf with multiple deployments", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall a cnf with multiple deployments", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_multiple_deployments/cnf-testsuite.yml")
       (/All "coredns" deployment resources are up/ =~ result[:output]).should_not be_nil
@@ -161,7 +161,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall deployment with mixed installation methods", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall deployment with mixed installation methods", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-nginx-redis/cnf-testsuite.yml")
       (/All "nginx" deployment resources are up/ =~ result[:output]).should_not be_nil
@@ -175,7 +175,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should handle partial deployment failures gracefully", tags: ["cnf_installation"] do
+  it "'cnf_install/cnf_uninstall' should handle partial deployment failures gracefully", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-partial-deployment-failure/cnf-testsuite.yml", expect_failure: true)
       (/All "nginx" deployment resources are up/ =~ result[:output]).should_not be_nil
@@ -187,7 +187,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install' should detect and report conflicts between deployments", tags: ["cnf_installation"] do
+  it "'cnf_install' should detect and report conflicts between deployments", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("cnf-path=spec/fixtures/sample-conflicting-deployments.yml", expect_failure: true)
       (/Deployment names should be unique/ =~ result[:output]).should_not be_nil
@@ -196,7 +196,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install' should correctly handle deployment priority", tags: ["cnf_installation"] do
+  it "'cnf_install' should correctly handle deployment priority", tags: ["cnf_installation_priority"] do
     # (kosstennbl) ELK stack requires to be installed with specific order, otherwise it would give errors
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-elk-stack/cnf-testsuite.yml", timeout: 600)
@@ -249,14 +249,14 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_uninstall' should warn user if no CNF is found", tags: ["cnf_installation"] do
+  it "'cnf_uninstall' should warn user if no CNF is found", tags: ["cnf_installation2"] do
     begin
       result = ShellCmd.cnf_uninstall()
       (/CNF uninstallation skipped/ =~ result[:output]).should_not be_nil
     end
   end
 
-  it "'cnf_uninstall' should fail for a stuck manifest deployment", tags: ["cnf_installation"] do
+  it "'cnf_uninstall' should fail for a stuck manifest deployment", tags: ["cnf_installation2"] do
     result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_stuck_finalizer/cnf-testsuite.yml")
     result[:status].success?.should be_true
 
@@ -276,7 +276,7 @@ describe "Installation" do
     (/CNF uninstallation skipped/ =~ result[:output]).should_not be_nil
   end
 
-  it "'cnf_uninstall' should fail for a stuck helm deployment", tags: ["cnf_installation"] do
+  it "'cnf_uninstall' should fail for a stuck helm deployment", tags: ["cnf_installation2"] do
     result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_stuck_helm_deployment/")
     result[:status].success?.should be_true
 
@@ -308,7 +308,7 @@ describe "Installation" do
     (/CNF uninstallation skipped/ =~ result[:output]).should_not be_nil
   end
 
-  it "'cnf_install' should pass for oci repository", tags: ["cnf_installation"] do
+  it "'cnf_install' should pass for oci repository", tags: ["cnf_installation2"] do
     local_registry_port = 53123
     tgz = fetch_nginx_chart_tgz("sample-cnfs/sample_oci_repo")
 
@@ -355,7 +355,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install' should pass for private helm repository", tags: ["cnf_installation"] do
+  it "'cnf_install' should pass for private helm repository", tags: ["cnf_installation2"] do
     chart_museum_port = 53124
     tgz = fetch_nginx_chart_tgz("sample-cnfs/sample_private_repo")
 
@@ -400,7 +400,7 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install' should require client cert for OCI registry (mTLS)", tags: ["cnf_installation"] do
+  it "'cnf_install' should require client cert for OCI registry (mTLS)", tags: ["cnf_installation2"] do
     registry_port = 54125
     reg_host      = "127.0.0.1.nip.io"
     reg_host_port = "#{reg_host}:#{registry_port}"

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -13,7 +13,7 @@ describe "Microservice" do
     process_result.should be_true
   end
 
-  it "'shared_database' should be skipped no MariaDB containers are found", tags: ["shared_database"]  do
+  it "'shared_database' should be skipped no MariaDB containers are found", tags: ["shared_database1"]  do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("shared_database")
@@ -25,7 +25,7 @@ describe "Microservice" do
     end
   end
 
-  it "'shared_database' should pass if no database is used by two microservices", tags: ["shared_database"]  do
+  it "'shared_database' should pass if no database is used by two microservices", tags: ["shared_database2"]  do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-statefulset-cnf/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("shared_database")
@@ -37,7 +37,7 @@ describe "Microservice" do
     end
   end
 
-  it "'shared_database' should pass if one service connects to a database but other non-service connections are made to the database", tags: ["shared_database"]  do
+  it "'shared_database' should pass if one service connects to a database but other non-service connections are made to the database", tags: ["shared_database3"]  do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-multi-db-connections-exempt/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("shared_database")
@@ -49,7 +49,7 @@ describe "Microservice" do
     end
   end
 
-  it "'shared_database' should fail if two services on the cluster connect to the same database", tags: ["shared_database2"]  do
+  it "'shared_database' should fail if two services on the cluster connect to the same database", tags: ["shared_database_flaky"]  do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/ndn-multi-db-connections-fail/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("shared_database")
@@ -62,7 +62,7 @@ describe "Microservice" do
     end
   end
 
-  it "'shared_database' should pass if two services on the cluster connect to the same database but they are not in the helm chart of the cnf", tags: ["shared_database"]  do
+  it "'shared_database' should pass if two services on the cluster connect to the same database but they are not in the helm chart of the cnf", tags: ["shared_database4"]  do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns")
       KubectlClient::Apply.namespace(DEFAULT_CNF_NAMESPACE)

--- a/spec/workload/observability_spec.cr
+++ b/spec/workload/observability_spec.cr
@@ -10,7 +10,7 @@ describe "Observability" do
     result[:status].success?.should be_true
   end
 
-  it "'log_output' should pass with a cnf that outputs logs to stdout", tags: ["observability"]  do
+  it "'log_output' should pass with a cnf that outputs logs to stdout", tags: ["observability_log_output"]  do
     begin
       ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("log_output")
@@ -21,7 +21,7 @@ describe "Observability" do
     end
   end
 
-  it "'log_output' should fail with a cnf that does not output logs to stdout", tags: ["observability"]  do
+  it "'log_output' should fail with a cnf that does not output logs to stdout", tags: ["observability_log_output"]  do
     begin
       ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_no_logs/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("log_output")
@@ -32,7 +32,7 @@ describe "Observability" do
     end
   end
 
-  it "'prometheus_traffic' should pass if there is prometheus traffic", tags: ["observability"] do
+  it "'prometheus_traffic' should pass if there is prometheus traffic", tags: ["observability_prometheus_traffic"] do
     ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml")
     helm = Helm::Binary.get
 
@@ -54,7 +54,7 @@ describe "Observability" do
     result[:status].success?.should be_true
   end
 
-  it "'prometheus_traffic' should skip if there is no prometheus installed", tags: ["observability"] do
+  it "'prometheus_traffic' should skip if there is no prometheus installed", tags: ["observability_prometheus_traffic"] do
 
       ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml")
       helm = Helm::Binary.get
@@ -66,7 +66,7 @@ describe "Observability" do
       result = ShellCmd.cnf_uninstall()
   end
 
-  it "'prometheus_traffic' should fail if the cnf is not registered with prometheus", tags: ["observability"] do
+  it "'prometheus_traffic' should fail if the cnf is not registered with prometheus", tags: ["observability_prometheus_traffic"] do
 
       ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml")
       Log.info { "Installing prometheus server" }
@@ -85,7 +85,7 @@ describe "Observability" do
       result[:status].success?.should be_true
   end
 
-  it "'open_metrics' should fail if there is not a valid open metrics response from the cnf", tags: ["observability"] do
+  it "'open_metrics' should fail if there is not a valid open metrics response from the cnf", tags: ["observability_open_metrics"] do
     ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml")
     result = ShellCmd.run("helm repo add prometheus-community https://prometheus-community.github.io/helm-charts", force_output: true)
     Log.info { "Installing prometheus server" }
@@ -103,7 +103,7 @@ describe "Observability" do
     result[:status].success?.should be_true
   end
 
-  it "'open_metrics' should pass if there is a valid open metrics response from the cnf", tags: ["observability"] do
+  it "'open_metrics' should pass if there is a valid open metrics response from the cnf", tags: ["observability_open_metrics"] do
     ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-openmetrics/cnf-testsuite.yml")
     result = ShellCmd.run("helm repo add prometheus-community https://prometheus-community.github.io/helm-charts", force_output: true)
     Log.info { "Installing prometheus server" }
@@ -121,7 +121,7 @@ describe "Observability" do
     result[:status].success?.should be_true
   end
 
-  it "'routed_logs' should pass if cnfs logs are captured by fluentd", tags: ["observability"] do
+  it "'routed_logs' should pass if cnfs logs are captured by fluentd", tags: ["observability_routed_logs"] do
     ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml")
     result = ShellCmd.run_testsuite("setup:install_fluentd")
     result = ShellCmd.run_testsuite("routed_logs")
@@ -132,7 +132,7 @@ describe "Observability" do
     result[:status].success?.should be_true
   end
 
-  it "'routed_logs' should pass if cnfs logs are captured by fluentd bitnami", tags: ["observability"] do
+  it "'routed_logs' should pass if cnfs logs are captured by fluentd bitnami", tags: ["observability_routed_logs"] do
     ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml")
     result = ShellCmd.run_testsuite("setup:install_fluentdbitnami")
     result = ShellCmd.run_testsuite("routed_logs")
@@ -143,7 +143,7 @@ describe "Observability" do
     result[:status].success?.should be_true
   end
 
-  it "'routed_logs' should pass if cnfs logs are captured by fluentbit", tags: ["observability"] do
+  it "'routed_logs' should pass if cnfs logs are captured by fluentbit", tags: ["observability_routed_logs"] do
     ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-fluentbit")
     result = ShellCmd.run_testsuite("setup:install_fluentbit")
     result = ShellCmd.run_testsuite("routed_logs")
@@ -154,7 +154,7 @@ describe "Observability" do
     result[:status].success?.should be_true
   end
 
-  it "'routed_logs' should fail if cnfs logs are not captured", tags: ["observability"] do
+  it "'routed_logs' should fail if cnfs logs are not captured", tags: ["observability_routed_logs"] do
     ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml")
     Helm.helm_repo_add("bitnami","https://charts.bitnami.com/bitnami")
     #todo  #helm install --values ./override.yml fluentd ./fluentd

--- a/src/modules/cluster_tools/cluster_tools.cr
+++ b/src/modules/cluster_tools/cluster_tools.cr
@@ -298,17 +298,17 @@ module ClusterTools
     match
   end
 
-  def self.local_match_by_image_name_with_retries(image_names : Array(String), retries : Int32 = 20, wait : Int32 = 3)
+  def self.local_match_by_image_name_with_retries(image_names : Array(String), retries : Int32 = 10, wait : Int32 = 3)
     image_names.map{|x| local_match_by_image_name_with_retries(x)}.flatten.find{|m|m[:found]==true}
   end
 
-  def self.local_match_by_image_name_with_retries(image_name, retries : Int32 = 20, wait : Int32 = 3)
+  def self.local_match_by_image_name_with_retries(image_name, retries : Int32 = 10, wait : Int32 = 3)
     Log.info { "local_match_by_image_names_with_retries image_name: #{image_name}" }
     nodes = KubectlClient::Get.nodes["items"].as_a
     local_match_by_image_name_with_retries(image_name)
   end
 
-  def self.local_match_by_image_name_with_retries(image_name, retries : Int32 = 20, wait : Int32 = 3)
+  def self.local_match_by_image_name_with_retries(image_name, retries : Int32 = 10, wait : Int32 = 3)
     # Retry up to 60 seconds because kubectl get nodes -o json can return
     # the image digest with a delay.
     # See https://github.com/lfn-cnti/testsuite/issues/2337


### PR DESCRIPTION
It spits ["cnf_installation"], ["observability"] and ["shared_database"]
to optimize the gates. All the jobs end before 13 min now.

It also reduces the retries when searching image digests to
avoid wasting too much time in the negative testing.

It renames shared_database2 to shared_database_flaky to avoid breaking
the numbering.