### PR TITLE
Fix Chart in fluent_manager.cr

### DIFF
--- a/spec/workload/observability_spec.cr
+++ b/spec/workload/observability_spec.cr
@@ -121,6 +121,17 @@ describe "Observability" do
     result[:status].success?.should be_true
   end
 
+  it "'routed_logs' should pass if cnfs logs are captured by fluentd", tags: ["observability"] do
+    ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml")
+    result = ShellCmd.run_testsuite("setup:install_fluentd")
+    result = ShellCmd.run_testsuite("routed_logs")
+    (/(PASSED).*(Your CNF's logs are being captured)/ =~ result[:output]).should_not be_nil
+  ensure
+    result = ShellCmd.cnf_uninstall()
+    result = ShellCmd.run_testsuite("setup:uninstall_fluentd")
+    result[:status].success?.should be_true
+  end
+
   it "'routed_logs' should pass if cnfs logs are captured by fluentd bitnami", tags: ["observability"] do
     ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml")
     result = ShellCmd.run_testsuite("setup:install_fluentdbitnami")

--- a/src/tasks/utils/fluent_manager.cr
+++ b/src/tasks/utils/fluent_manager.cr
@@ -45,7 +45,7 @@ module FluentManager
             "fluentd-values.yml",
             FLUENTD_VALUES,
             "fluent/fluentd-kubernetes-daemonset",
-            "fluent/fluentd")
+            "fluentd/fluentd")
     end
   end
 
@@ -56,7 +56,7 @@ module FluentManager
             "fluentd-bitnami-values.yml",
             FLUENTD_BITNAMI_VALUES,
             "bitnamilegacy/fluentd",
-            "bitnami/fluentd")
+            "fluentdbitnami/fluentd")
     end
   end
 


### PR DESCRIPTION
## Description

It falsely passed in gates because one issue is uncovered and the other because of a previous test in the observability_spec.

It adds a test to check if cnf logs are captured by fluentd.