### PR TITLE
Call kind delete cluster until success delete

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -320,7 +320,7 @@ jobs:
         docker ps -a
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get all -A || true
-        kind delete cluster --name $CLUSTER --verbosity 1
+        until kind delete cluster --name $CLUSTER --verbosity 1; do sleep 1; done
         rm -f /shared/pss/cluster-level-pss.$CLUSTER.yaml /tmp/cluster.yml
         rm -rf ~/.config/helm
       continue-on-error: true
@@ -408,7 +408,7 @@ jobs:
         docker ps -a
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get all -A || true
-        kind delete cluster --name $CLUSTER --verbosity 1
+        until kind delete cluster --name $CLUSTER --verbosity 1; do sleep 1; done
         rm -f /tmp/cluster.yml
         rm -rf ~/.config/helm
       continue-on-error: true
@@ -537,7 +537,7 @@ jobs:
         docker ps -a
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get all -A || true
-        kind delete cluster --name $CLUSTER --verbosity 1
+        until kind delete cluster --name $CLUSTER --verbosity 1; do sleep 1; done
         rm -f /tmp/cluster.yml
         rm -rf ~/.config/helm
       continue-on-error: true
@@ -632,7 +632,7 @@ jobs:
         docker ps -a
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get all -A || true
-        kind delete cluster --name $CLUSTER --verbosity 1
+        until kind delete cluster --name $CLUSTER --verbosity 1; do sleep 1; done
         rm -f /tmp/cluster.yml
         rm -rf ~/.config/helm
       continue-on-error: true
@@ -727,7 +727,7 @@ jobs:
         docker ps -a
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         kubectl get all -A || true
-        kind delete cluster --name $CLUSTER --verbosity 1
+        until kind delete cluster --name $CLUSTER --verbosity 1; do sleep 1; done
         rm -f /tmp/cluster.yml
         rm -rf ~/.config/helm
       continue-on-error: true


### PR DESCRIPTION
Docker sometimes fails deleting workers:
  - Container failed to exit within 10s of kill - trying direct SIGKILL
  - cannot remove container "kind-worker": could not kill container: tried to kill container, but did not receive an exit event

kind delete cluster is an idempotent operation, meaning it may be called multiple times without failing (like "rm -f").
If the cluster resources exist they will be deleted, and if the cluster is already gone it will just return success.