### PR TITLE
Update crinja to 0.9.0

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -6,7 +6,7 @@ shards:
 
   crinja:
     git: https://github.com/straight-shoota/crinja.git
-    version: 0.8.1
+    version: 0.9.0
 
   halite:
     git: https://github.com/icyleaf/halite.git


### PR DESCRIPTION
crinja 0.8.1 now fails:
```
In lib/crinja/src/runtime/resolver.cr:58:32

 58 | return Value.new object[name.to_s]
                             ^
Error: no overload matches 'Proc(Crinja::Arguments, Crinja::Value)#[]' with type String

Overloads are:
 - Proc(*T, R)#[](*args : *T)
```