### PR TITLE
fix: robustness of image name parsing and ensures version stability

### DIFF
--- a/embedded_files/fluentbit-values.yml
+++ b/embedded_files/fluentbit-values.yml
@@ -1,3 +1,7 @@
+image:
+  repository: cr.fluentbit.io/fluent/fluent-bit
+  tag: latest
+  digest: sha256:7d727245767ae632eb296c2ff4d206bf2e205b5f244c1f37b8fdd61f9fb33985
 config:
   outputs: |
     [OUTPUT]

--- a/embedded_files/fluentd-bitnami-values.yml
+++ b/embedded_files/fluentd-bitnami-values.yml
@@ -3,6 +3,8 @@ aggregator:
 
 image:
   repository: bitnamilegacy/fluentd
+  tag: latest
+  digest: sha256:6771c744cbd368eca969b49c160f3ffc24873c4b3743b1df04cc59721b9b73d0
 
 global:
   security:

--- a/embedded_files/fluentd-values.yml
+++ b/embedded_files/fluentd-values.yml
@@ -1,3 +1,8 @@
+image:
+  repository: fluent/fluentd-kubernetes-daemonset
+  tag: v1.19.1-debian-elasticsearch8-1.0
+  digest: sha256:4bad75452717d2de0e3c4857339d8e91f11b2712fa9319302a401d9c86388c90
+
 fileConfigs:
   04_outputs.conf: |-
     <label @OUTPUT>

--- a/spec/fixtures/fluentd-values-bad.yml
+++ b/spec/fixtures/fluentd-values-bad.yml
@@ -3,6 +3,8 @@ global:
     allowInsecureImages: true
 image:
   repository: bitnamilegacy/fluentd
+  tag: latest
+  digest: sha256:6771c744cbd368eca969b49c160f3ffc24873c4b3743b1df04cc59721b9b73d0
 aggregator:
   enabled: false
 forwarder:

--- a/spec/modules/cluster_tools_spec.cr
+++ b/spec/modules/cluster_tools_spec.cr
@@ -1,5 +1,55 @@
 require "../spec_helper.cr"
 
+# Builds a minimal fake node JSON whose status.images contains:
+#   - one sha256 entry: "registry/org/image@sha256:<digest>"
+#   - one tag entry:    "registry/org/image:<tag>"
+private def mock_nodes(registry_image : String, tag : String, digest : String) : Array(JSON::Any)
+  node_json = <<-JSON
+    {
+      "status": {
+        "images": [
+          {
+            "names": [
+              "#{registry_image}@#{digest}",
+              "#{registry_image}:#{tag}"
+            ],
+            "sizeBytes": 12345
+          }
+        ]
+      }
+    }
+  JSON
+  [JSON.parse(node_json)]
+end
+
+describe "ClusterTools.local_match_by_image_name" do
+  digest = "sha256:7d727245767ae632eb296c2ff4d206bf2e205b5f244c1f37b8fdd61f9fb33985"
+  other_digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  nodes = mock_nodes("cr.fluentbit.io/fluent/fluent-bit", "latest", digest)
+
+  it "returns found=true when image_name has tag+digest and digest matches a node imageID", tags: ["local_match_by_image_name"] do
+    match = ClusterTools.local_match_by_image_name("fluent/fluent-bit:latest@#{digest}", nodes)
+    match[:found].should be_true
+    match[:digest].should eq(digest)
+  end
+
+  it "returns found=true when image_name has digest only (no tag) and digest matches a node imageID", tags: ["local_match_by_image_name"] do
+    match = ClusterTools.local_match_by_image_name("fluent/fluent-bit@#{digest}", nodes)
+    match[:found].should be_true
+    match[:digest].should eq(digest)
+  end
+
+  it "returns found=false when image_name has tag+digest but digest does NOT match any node imageID", tags: ["local_match_by_image_name"] do
+    match = ClusterTools.local_match_by_image_name("fluent/fluent-bit:latest@#{other_digest}", nodes)
+    match[:found].should be_false
+  end
+
+  it "returns found=false when image_name has no tag and no digest and no image is present on nodes", tags: ["local_match_by_image_name"] do
+    match = ClusterTools.local_match_by_image_name("some/unknown-image", [] of JSON::Any)
+    match[:found].should be_false
+  end
+end
+
 describe "ClusterTools" do
   before_all do
     KubectlClient::Apply.namespace(ClusterTools.namespace)

--- a/src/modules/cluster_tools/cluster_tools.cr
+++ b/src/modules/cluster_tools/cluster_tools.cr
@@ -252,8 +252,41 @@ module ClusterTools
     Log.info { "local_match_by_image_name image_name: #{image_name}" }
 
     match = Hash{:found => false, :digest => "", :release_name => ""}
+
+    # Parse explicit tag and/or digest from image_name.
+    # Supported formats:
+    #   "org/image"
+    #   "org/image:tag"
+    #   "org/image:tag@sha256:digest"
+    #   "org/image@sha256:digest"
+    explicit_digest = ""
+    explicit_tag = ""
+    base_image_name = image_name
+
+    if (at_idx = image_name.index("@"))
+      base_part = image_name[0...at_idx]
+      explicit_digest = image_name[at_idx + 1..]  # e.g. "sha256:abc123"
+      last_slash = base_part.rindex("/") || -1
+      last_seg = base_part[last_slash + 1..]
+      if (colon_idx = last_seg.index(":"))
+        explicit_tag = last_seg[colon_idx + 1..]
+        base_image_name = base_part[0...last_slash + 1] + last_seg[0...colon_idx]
+      else
+        base_image_name = base_part
+      end
+    else
+      last_slash = image_name.rindex("/") || -1
+      last_seg = image_name[last_slash + 1..]
+      if (colon_idx = last_seg.index(":"))
+        explicit_tag = last_seg[colon_idx + 1..]
+        base_image_name = image_name[0...last_slash + 1] + last_seg[0...colon_idx]
+      end
+    end
+
+    Log.info { "local_match_by_image_name base_image_name: #{base_image_name}, explicit_tag: #{explicit_tag}, explicit_digest: #{explicit_digest}" }
+
     # Group all imageIDs on passed 'nodes' into array.
-    # If 'image_name' matches the name with tag, save its first occurence.
+    # If 'base_image_name' matches the name with tag, save its first occurence.
     # node.status.images is in following format:
     #  {
     #  "names": [
@@ -262,16 +295,16 @@ module ClusterTools
     #  ],
     #  "sizeBytes": 51212837
     #  }
-    tag = ""
+    tag = explicit_tag
     imageIDs = [] of String
     nodes.each do |node|
       begin
-        images = node.dig("status", "images").as_a.each do |image|
+        node.dig("status", "images").as_a.each do |image|
           image.dig("names").as_a.each do |name|
             if name.as_s.includes?("sha256")
               imageIDs << name.as_s
             else
-              next unless name.as_s.includes?(image_name)
+              next unless name.as_s.includes?(base_image_name)
               tag = DockerClient.parse_image(name.as_s)["tag"] if tag.empty?
             end
           end
@@ -282,11 +315,16 @@ module ClusterTools
     end
     Log.info { "local_match_by_image_name imageIDs : #{imageIDs}" }
 
-    if !tag.empty?
+    if !explicit_digest.empty?
+      # Use the digest provided in image_name directly; skip the skopeo registry call.
+      Log.info { "local_match_by_image_name using explicit digest: #{explicit_digest}" }
+      sha_list = [{"name" => base_image_name, "manifest_digest" => explicit_digest}]
+      match = DockerClient::K8s.local_digest_match(sha_list, imageIDs)
+      Log.info { "local_match_by_image_name match : #{match}"}
+    elsif !tag.empty?
       Log.info { "container tag: #{tag}" }
-  
-      resp = ClusterTools.official_content_digest_by_image_name(image_name + ":" + tag)
-      sha_list = [{"name" => image_name, "manifest_digest" => resp["Digest"].as_s}]
+      resp = ClusterTools.official_content_digest_by_image_name(base_image_name + ":" + tag)
+      sha_list = [{"name" => base_image_name, "manifest_digest" => resp["Digest"].as_s}]
       Log.info { "jaeger_pods sha_list : #{sha_list}"}
       match = DockerClient::K8s.local_digest_match(sha_list, imageIDs)
       Log.info { "local_match_by_image_name match : #{match}"}

--- a/src/tasks/utils/fluent_manager.cr
+++ b/src/tasks/utils/fluent_manager.cr
@@ -40,11 +40,11 @@ module FluentManager
 
   class FluentD < FluentBase
     def initialize
-      super("fluentd", 
-            "https://fluent.github.io/helm-charts", 
+      super("fluentd",
+            "https://fluent.github.io/helm-charts",
             "fluentd-values.yml",
             FLUENTD_VALUES,
-            "fluent/fluentd-kubernetes-daemonset",
+            "fluent/fluentd-kubernetes-daemonset:v1.19.1-debian-elasticsearch8-1.0@sha256:4bad75452717d2de0e3c4857339d8e91f11b2712fa9319302a401d9c86388c90",
             "fluentd/fluentd")
     end
   end
@@ -55,18 +55,18 @@ module FluentManager
             "https://charts.bitnami.com/bitnami",
             "fluentd-bitnami-values.yml",
             FLUENTD_BITNAMI_VALUES,
-            "bitnamilegacy/fluentd",
+            "bitnamilegacy/fluentd:latest@sha256:6771c744cbd368eca969b49c160f3ffc24873c4b3743b1df04cc59721b9b73d0",
             "fluentdbitnami/fluentd")
     end
   end
 
   class FluentBit < FluentBase
     def initialize
-      super("fluent-bit", 
+      super("fluent-bit",
             "https://fluent.github.io/helm-charts",
             "fluentbit-values.yml",
             FLUENTBIT_VALUES,
-            "fluent/fluent-bit",
+            "fluent/fluent-bit:latest@sha256:7d727245767ae632eb296c2ff4d206bf2e205b5f244c1f37b8fdd61f9fb33985",
             "fluent-bit/fluent-bit")
     end
   end


### PR DESCRIPTION
## Description
This PR improves the robustness of image name parsing and ensures version stability for logging components.

Specifically:
- Updated `local_match_by_image_name` to support parsing images that use the tag@digest format.
- Pinned Fluent images to specific versions to avoid unexpected behavior from upstream updates.

## Issues:
Refs: [#2360](https://github.com/lfn-cnti/testsuite/pull/2360) (Fixes support for digests in Docker images)

## How has this been tested:
- [x] Covered by existing integration testing
- [] Verified all A/C passes
- [] Kind cluster

## Types of changes:
 - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
**Documentation**
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [x] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [x] Tasks in issue are checked off
