### PR TITLE
Free5gc sigterm_handled test optimization

### DIFF
--- a/src/modules/kubectl_client/modules/get.cr
+++ b/src/modules/kubectl_client/modules/get.cr
@@ -270,10 +270,18 @@ module KubectlClient
       else
         pods = resource("pods", namespace: namespace)["items"].as_a
       end
+      
+      # Try to get the specific pod selector labels first
+      selector_labels = resource_json.dig?("spec", "selector", "matchLabels")
+      
+      if selector_labels
+        logger.debug { "Found selector labels: #{selector_labels}" }
+        labels = selector_labels.as_h
+      else
+        # Get general labels if pod lacks selectors
+        labels = resource_spec_labels(resource_json["kind"].as_s, name.as_s, namespace: namespace).as_h
+      end
 
-      # todo deployment labels may not match template metadata labels.
-      # -- may need to match on selector matchlabels instead
-      labels = resource_spec_labels(resource_json["kind"].as_s, name.as_s, namespace: namespace).as_h
       filtered_pods = pods_by_labels(pods, labels)
 
       filtered_pods
@@ -284,21 +292,13 @@ module KubectlClient
       logger.debug { "Creating list of pods that have labels: #{labels}" }
 
       pods_json = pods_json.select do |pod|
-        if labels == Hash(String, JSON::Any).new
-          match = false
+        if labels.empty?
+          false
         else
-          match = true
-        end
-        # todo deployment labels may not match template metadata labels.
-        # -- may need to match on selector matchlabels instead
-        labels.map do |key, value|
-          if pod.dig?("metadata", "labels", key) == value
-            match = true
-          else
-            match = false
+          labels.all? do |key, value|
+            pod.dig?("metadata", "labels", key) == value
           end
         end
-        match
       end
       logger.info { "Matched #{pods_json.size} pods: #{KubectlClient.names_from_json_array_to_s(pods_json)}" }
 
@@ -310,23 +310,15 @@ module KubectlClient
       logger.debug { "Creating list of pods that have labels: #{labels}" }
 
       pods_json = pods_json.select do |pod|
-        if labels == Hash(String, String).new
-          match = false
+        if labels.empty?
+          false
         else
-          match = true
-        end
-        # todo deployment labels may not match template metadata labels.
-        # -- may need to match on selector matchlabels instead
-        labels.map do |key, value|
-          if pod.dig?("metadata", "labels", key) == value
-            match = true
-          else
-            match = false
+          labels.all? do |key, value|
+            pod.dig?("metadata", "labels", key) == value
           end
         end
-        match
       end
-      logger.debug { "Matched #{pods_json.size} pods: #{KubectlClient.names_from_json_array_to_s(pods_json)}" }
+      logger.info { "Matched #{pods_json.size} pods: #{KubectlClient.names_from_json_array_to_s(pods_json)}" }
 
       pods_json
     end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -556,6 +556,9 @@ task "sig_term_handled" do |t, args|
       test_reason: String | Nil
     )
 
+    #Track already tested pods
+    tested_pods = Set(String).new
+ 
     # Iterate over all resources
     task_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, container, _|
       kind = resource["kind"].downcase
@@ -583,13 +586,21 @@ task "sig_term_handled" do |t, args|
       pods.all? do |pod|
         pod_name      = pod.dig("metadata", "name").as_s
         pod_namespace = pod.dig("metadata", "namespace").as_s
+
+        # Skip already tested pods
+        pod_unique_id = "#{pod_namespace}/#{pod_name}"
+        if tested_pods.includes?(pod_unique_id)
+          logger.info { "Skipping already tested pod: #{pod_unique_id}" }
+          next true
+        end
+        
         KubectlClient::Wait.wait_for_resource_availability("pod", pod_name, pod_namespace, GENERIC_OPERATION_TIMEOUT)
 
         status = pod["status"]
         next true unless status["containerStatuses"]?
 
         container_statuses = status["containerStatuses"].as_a
-        container_statuses.all? do |c_stat|
+        pod_passed = status["containerStatuses"].as_a.all? do |c_stat|
           c_name = c_stat["name"].as_s
           ready  = c_stat["ready"].as_bool
           unless ready
@@ -693,6 +704,12 @@ task "sig_term_handled" do |t, args|
             false
           end
         end
+
+        #put tested pod ID into checking list
+        tested_pods << pod_unique_id
+
+        #return bool
+        pod_passed
       end
     end
 


### PR DESCRIPTION
sigterm_handled test optimization

## Description
Free5gc sigterm_handled test optimization achieved by:

- Bug fixing the pods_by_labels() function. It now correctly matches pods based on all labels, not just by last label.
- Clearing pods_by_resource_labels() TODO. It now checks selector labels instead of general labels, resulting in narrower pod selection
- Optimization in sigterm_handled test. Skips already tested pods, if previous precautions fail. Also avoids testing multiple instances of scaled pods

## Issues:
Refs: https://github.com/lfn-cnti/testsuite/issues/2345

The issue was not in not detecting MongoDB pod. The test would get to it eventually in about 17hours.
Also the test was not looping, just checking virtually every single pod for all pods, resulting in exponential runtime growth with every added pod. The runtime was now cut to about 1 hour 20 mins from previous 18 hours, by checking every pod only once. Runtime might be machine dependent.

## How has this been tested:
 - [*] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [*] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [*] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
