### PR TITLE
Cover CNTi testsuite vs all Debian releases

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -1,0 +1,80 @@
+name: debian
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '**'
+  pull_request:
+jobs:
+  debian:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        release:
+          - bullseye
+          - bookworm
+          - trixie
+          - forky
+          - sid
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.31.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          cat << EOF > /tmp/cluster.yml
+          kind: Cluster
+          apiVersion: kind.x-k8s.io/v1alpha4
+          nodes:
+            - role: control-plane
+              extraMounts:
+                - containerPath: /var/lib/kubelet/config.json
+                  hostPath: $HOME/.docker/config.json
+            - role: worker
+              extraMounts:
+                - containerPath: /var/lib/kubelet/config.json
+                  hostPath: $HOME/.docker/config.json
+            - role: worker
+              extraMounts:
+                - containerPath: /var/lib/kubelet/config.json
+                  hostPath: $HOME/.docker/config.json
+          EOF
+          kind create cluster --name debian-${{ matrix.release }} --config=/tmp/cluster.yml
+          rm /tmp/cluster.yml
+      - uses: actions/checkout@v4
+      - run: |
+            docker run --network host --name debian-${{ matrix.release }} \
+              -v ~/.docker/config.json:/root/.docker/config.json -v $(pwd):/testsuite \
+              -v ~/.kube/config:/root/.kube/config debian:${{ matrix.release }} /bin/bash -c "\
+            apt update && DEBIAN_FRONTEND=noninteractive apt install git curl \
+              gcc pkg-config libpcre2-dev libxml2-dev libyaml-dev zlib1g-dev libssl-dev -y && \
+            case ${{ matrix.release }} in \
+            bullseye) \
+              curl -LO https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-1-linux-x86_64.tar.gz && \
+              tar zxf crystal-1.19.1-1-linux-x86_64.tar.gz && \
+              export PATH=/crystal-1.19.1-1/bin:$PATH && \
+              rm -rf crystal-1.19.1-1-linux-x86_64.tar.gz ;; \
+            bookworm | forky) \
+              DEBIAN_FRONTEND=noninteractive apt install crystal -y && \
+              curl -LO https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-1-linux-x86_64.tar.gz && \
+              tar zxf crystal-1.19.1-1-linux-x86_64.tar.gz && \
+              mv crystal-1.19.1-1/bin/shards /usr/local/bin && \
+              rm -rf crystal-1.19.1-1 crystal-1.19.1-1-linux-x86_64.tar.gz ;; \
+            *) \
+                DEBIAN_FRONTEND=noninteractive apt install crystal shards -y ;; \
+            esac && \
+            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+            install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
+            curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash && \
+            git config --global --add safe.directory /testsuite
+            (cd testsuite && shards install && crystal build src/cnf-testsuite.cr && \
+            ./cnf-testsuite setup && ./cnf-testsuite cnf_install cnf-config=example-cnfs/coredns && ./cnf-testsuite cert && ./cnf-testsuite uninstall_all)"
+      - run: |
+          kind delete cluster --name debian-${{ matrix.release }}
+          docker stop debian-${{ matrix.release }}
+          docker rm -fv debian-${{ matrix.release }}


### PR DESCRIPTION
It covers CNTi Test Suite against all active Debian releases from bullseye to sid (unstable).

Please note they are 3 cases:
- no crystal nor shards package available
- only crystal package is available
- both packages are available (stable and newer)

https://packages.debian.org/fr/trixie/crystal
https://packages.debian.org/fr/trixie/shards

It runs on ubuntu-latest but the same logics would work vs v1.0.0 if any quota is reached.
https://docs.github.com/en/actions/reference/limits