### PR TITLE
Fix deprecated warning

### DIFF
--- a/src/modules/cluster_tools/cluster_tools.cr
+++ b/src/modules/cluster_tools/cluster_tools.cr
@@ -358,7 +358,7 @@ module ClusterTools
         return match
       end
       Log.debug { "Waiting for sha256 of #{image_name} (attempt #{i+1})..." }
-      sleep wait
+      sleep(Time::Span.new(seconds: wait))
     end
     Log.warn { "sha256 for #{image_name} not found after waiting." }
     match

--- a/src/modules/k8s_netstat/k8s_netstat.cr
+++ b/src/modules/k8s_netstat/k8s_netstat.cr
@@ -169,7 +169,7 @@ module Netstat
 
       # get multiple call for a larger sample
       parsed_netstat = (1..30).map {
-        sleep 10
+        sleep(Time::Span.new(seconds: 10))
         netstat = ClusterTools.exec_by_node("nsenter -t #{pid} -n netstat -n", node_name)
         if netstat.nil?
           next

--- a/src/modules/kubectl_client/modules/wait.cr
+++ b/src/modules/kubectl_client/modules/wait.cr
@@ -293,7 +293,7 @@ module KubectlClient
           end
         end
 
-        sleep 1
+        sleep(Time::Span.new(seconds: 1))
         seconds += 1
       end
 

--- a/src/tasks/setup/litmus_setup.cr
+++ b/src/tasks/setup/litmus_setup.cr
@@ -68,15 +68,15 @@ module LitmusManager
   def self.get_target_node_to_cordon(deployment_label, deployment_value, namespace)
     app_nodeName_cmd = "kubectl get pods -l #{deployment_label}=#{deployment_value} -n #{namespace} -o=jsonpath='{.items[0].spec.nodeName}'"
     Log.info { "Getting the operator node name: #{app_nodeName_cmd}" }
-    status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
-    Log.debug { "status_code: #{status_code}" } 
+    status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
+    Log.debug { "status_code: #{status_code}" }
     appNodeName_response.to_s
   end
 
   private def self.get_status_info(chaos_resource, test_name, output_format, namespace) : {Int32, String}
     status_cmd = "kubectl get #{chaos_resource}.#{LITMUS_K8S_DOMAIN} #{test_name} -n #{namespace} -o '#{output_format}'"
     Log.info { "Getting litmus status info: #{status_cmd}" }
-    status_code = Process.run("#{status_cmd}", shell: true, output: status_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
+    status_code = Process.run("#{status_cmd}", shell: true, output: status_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
     status_response = status_response.to_s
     Log.info { "status_code: #{status_code}, response: #{status_response}" }
     {status_code, status_response}

--- a/src/tasks/utils/k8s_tshark.cr
+++ b/src/tasks/utils/k8s_tshark.cr
@@ -116,7 +116,7 @@ module K8sTshark
 
         # Some tshark captures were left in zombie states if only kill/kill -9 was invoked.
         ClusterTools.exec_by_node_bg("kill -15 #{@pid}", @node_match.not_nil!)
-        sleep 1
+        sleep(Time::Span.new(seconds: 1))
         ClusterTools.exec_by_node_bg("kill -9 #{@pid}", @node_match.not_nil!)
 
         @pid = nil

--- a/src/tasks/utils/timeouts.cr
+++ b/src/tasks/utils/timeouts.cr
@@ -20,7 +20,7 @@ def repeat_with_timeout(timeout, errormsg, reset_on_nil=false, delay=2, &block)
     elsif result
       return true
     end
-    sleep delay
+    sleep(Time::Span.new(seconds: delay))
     Log.debug { "Time left: #{timeout - (Time.utc - start_time).to_i} seconds" }
   end
   Log.error { errormsg }

--- a/src/tasks/workload/5g_validator.cr
+++ b/src/tasks/workload/5g_validator.cr
@@ -115,7 +115,7 @@ end
 
 def smf_up_heartbeat_capture_matches_count(smf_key : String, smf_value : String, command : String)
   K8sTshark::TsharkPacketCapture.begin_capture_by_label(smf_key, smf_value, command) do |capture|
-    sleep 60
+    sleep(Time::Span.new(seconds: 60))
     capture.regex_search(/"pfcp\.msg_type": "(1|2)"/).size
   end
 end
@@ -135,7 +135,7 @@ task "suci_enabled" do |t, args|
       K8sTshark::TsharkPacketCapture.begin_capture_by_label(core_key, core_value, command) do |capture|
         #todo put in prereq
         UERANSIM.install(config)
-        sleep 30.0
+        sleep(Time::Span.new(seconds: 30))
         # TODO 5g RAN (only) mobile traffic check ????
         # use suci encyption but don't use a null encryption key
         suci_found = capture.regex_match?(/"nas_5gs.mm.type_id": "1"/) && \

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -21,7 +21,7 @@ task "microservice", ["reasonable_image_size", "reasonable_startup_time", "singl
 end
 
 REASONABLE_STARTUP_BUFFER = 10.0
-STRACE_WAIT_BUFFER = 3.0
+STRACE_WAIT_BUFFER = 3
 
 enum StraceAttachResult
   Attached
@@ -435,7 +435,7 @@ task "zombie_handled" do |t, args|
       end
     end
 
-    sleep 10.0
+    sleep(Time::Span.new(seconds: 10))
 
     pods_to_restart = Set(Tuple(String, String)).new
     containers_to_restart = Set(Tuple(String, JSON::Any)).new
@@ -472,7 +472,7 @@ task "zombie_handled" do |t, args|
     end
 
     if !pods_to_restart.empty?
-      sleep 20.0
+      sleep(Time::Span.new(seconds: 20))
     end
 
     pods_to_restart.each do |pod_name, namespace|
@@ -666,11 +666,11 @@ task "sig_term_handled" do |t, args|
           end
 
           logger.info {"Attached strace to PIDs: #{attached_pids.join(", ")}"}
-          sleep STRACE_WAIT_BUFFER
+          sleep(Time::Span.new(seconds: STRACE_WAIT_BUFFER))
 
           # Send SIGTERM => wait => SIGKILL
           ClusterTools.exec_by_node("bash -c 'kill -TERM #{pid} || true; sleep 5; kill -9 #{pid} || true'", node)
-          sleep STRACE_WAIT_BUFFER
+          sleep(Time::Span.new(seconds: STRACE_WAIT_BUFFER))
 
           # If no processes were attached, treat that as "skip"
           if attached_pids.empty?

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -263,13 +263,13 @@ task "node_drain", ["install_litmus"] do |t, args|
           deployment_label_value="#{spec_labels.as_h.first_value}"
           app_nodeName_cmd = "kubectl get pods -l #{deployment_label}=#{deployment_label_value} -n #{resource["namespace"]} -o=jsonpath='{.items[0].spec.nodeName}'"
           Log.for("node_drain").debug { "Getting the app node name #{app_nodeName_cmd}" }
-          status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
+          status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
           Log.for("node_drain").debug { "status_code: #{status_code}" }
           app_nodeName = appNodeName_response.to_s
 
           litmus_nodeName_cmd = "kubectl get pods -n litmus -l app.kubernetes.io/name=litmus -o=jsonpath='{.items[0].spec.nodeName}'"
           Log.for("node_drain").debug { "Getting the app node name #{litmus_nodeName_cmd}" }
-          status_code = Process.run("#{litmus_nodeName_cmd}", shell: true, output: litmusNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
+          status_code = Process.run("#{litmus_nodeName_cmd}", shell: true, output: litmusNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
           Log.for("node_drain").debug { "status_code: #{status_code}" }
           litmus_nodeName = litmusNodeName_response.to_s
           Log.info { "Workload Node Name: #{app_nodeName}" }


### PR DESCRIPTION
Please see https://github.com/lfn-cnti/testsuite/actions/runs/26569399015/job/78272376524#step:5:907

```
In src/tasks/utils/timeouts.cr:23:5

 23 | sleep delay
      ^----
Warning: Deprecated ::sleep. Use `::sleep(Time::Span)` instead
```

```
In src/tasks/workload/state.cr:266:152

 266 | status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_status
                                                                                                                                                    ^----------
Warning: Deprecated Process::Status#exit_status. Use `#exit_reason`, `#exit_code`, or `#system_exit_status` instead
```