### PR TITLE
fix: decouple single_process_type from init system whitelist

### DIFF
--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -337,12 +337,14 @@ Ensure that your CNF gets into a running state within 30 seconds.
 
 #### Overview
 
-This verifies that there is only one process type within one container. This does not count against child processes. For example, nginx or httpd could have a parent process and then 10 child processes, but if both nginx and httpd were running, this test would fail.
-Expectation: CNF container has one process type
+This verifies that there is only one application process type within one container. This does not count against child processes of the same type, nor against the container's init/supervisor process. For example, nginx or httpd could have a parent process and then 10 child processes, but if both nginx and httpd were running, this test would fail.
+Expectation: CNF container has one application process type
+
+The container's own init/supervisor process (PID 1) is not counted as an application process type, regardless of which init system it uses. Whether that init system is a recommended, specialized one (e.g. tini, dumb-init, s6) is evaluated separately by the `specialized_init_system` test — using a home-grown init will not fail this test, but it is reported in the test output and results file.
 
 #### Rationale
 
-A microservice should have only one process (or set of parent/child processes) that is managed by a non-homegrown supervisor or orchestrator. The microservice should not spawn other process types (e.g., executables) as a way to contribute to the workload but rather should interact with other processes through a microservice API.
+A microservice should have only one application process (or set of parent/child processes of the same type), optionally managed by an init/supervisor. The microservice should not spawn other process types (e.g., executables) as a way to contribute to the workload but rather should interact with other processes through a microservice API.
 
 #### Remediation
 

--- a/sample-cnfs/k8s-multiple-processes/chart/templates/manifest.yml
+++ b/sample-cnfs/k8s-multiple-processes/chart/templates/manifest.yml
@@ -19,22 +19,24 @@ spec:
     spec:
       containers:
       - image: busybox
-        # command: ["/bin/sh -c sleep infinity & sleep 10000 & sleep 20000 & sleep 30000"]
-        # command: ["sleep infinity & sleep 10000 & sleep 20000 & sleep 30000"]
         command: ["/bin/sh"]
-        # args: ["-c", "sleep infinity & sleep 10000 & sleep 20000 & sleep 30000"]
-        args: ["-c", "sleep infinity & sleep 10000 & sleep 20000 & sleep 30000 & watch ps"]
+        # Two distinct long-running process types in one container (sleep + tail) --
+        # the multi-process anti-pattern that single_process_type must fail on.
+        # Both are backgrounded and the shell ends on the `wait` builtin so it cannot
+        # exec-optimize into one of them (which would make that child PID 1 instead).
+        args: ["-c", "sleep infinity & tail -f /dev/null & wait"]
         name: sidecar-container1
         resources: {}
         volumeMounts:
           - name: var-logs
             mountPath: /var/log
       - image: busybox
-        # command: ["/bin/sh -c sleep infinity & sleep 10000 & sleep 20000 & sleep 30000"]
-        # command: ["sleep infinity & sleep 10000 & sleep 20000 & sleep 30000"]
         command: ["/bin/sh"]
-        # args: ["-c", "sleep infinity & sleep 10000 & sleep 20000 & sleep 30000"]
-        args: ["-c", "sleep infinity & sleep 10000 & sleep 20000 & sleep 30000 & watch ps"]
+        # Two distinct long-running process types in one container (sleep + tail) --
+        # the multi-process anti-pattern that single_process_type must fail on.
+        # Both are backgrounded and the shell ends on the `wait` builtin so it cannot
+        # exec-optimize into one of them (which would make that child PID 1 instead).
+        args: ["-c", "sleep infinity & tail -f /dev/null & wait"]
         name: sidecar-container2
         resources: {}
         volumeMounts:

--- a/sample-cnfs/sample-nonspecialized-init/cnf-testsuite.yml
+++ b/sample-cnfs/sample-nonspecialized-init/cnf-testsuite.yml
@@ -1,0 +1,6 @@
+---
+config_version: v2
+deployments:
+  manifests:
+  - name: nonspecialized-init
+    manifest_directory: manifests

--- a/sample-cnfs/sample-nonspecialized-init/manifests/manifest.yml
+++ b/sample-cnfs/sample-nonspecialized-init/manifests/manifest.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nsi-test
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+
+---
+# A container whose init/supervisor process (PID 1) is a plain shell -- a
+# home-grown, non-specialized init that is NOT on the SPECIALIZED_INIT_SYSTEMS
+# whitelist. The shell supervises a single application process type (sleep).
+# single_process_type must PASS here: there is only one application process
+# type. The choice of init system is scored separately by specialized_init_system.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nonspecialized-init
+  namespace: nsi-test
+  labels:
+    app: nonspecialized-init
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nonspecialized-init
+  template:
+    metadata:
+      labels:
+        app: nonspecialized-init
+    spec:
+      containers:
+      - name: nonspecialized-init
+        image: busybox
+        command: ["/bin/sh"]
+        args: ["-c", "while true; do sleep 30; done"]

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -104,6 +104,20 @@ describe "Microservice" do
     end
   end
 
+  it "'single_process_type' should pass if a container uses a non-specialized init system supervising a single process type", tags: ["process_check"]  do
+    begin
+      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-nonspecialized-init")
+      result = ShellCmd.run_testsuite("single_process_type")
+      result[:status].success?.should be_true
+      (/(PASSED).*(Only one process type used)/ =~ result[:output]).should_not be_nil
+      (/uses non-specialized init system/ =~ result[:output]).should_not be_nil
+      verify_task_result("single_process_type", "passed")
+    ensure
+      result = ShellCmd.cnf_uninstall()
+      result[:status].success?.should be_true
+    end
+  end
+
   it "'single_process_type' should fail if the containers in the cnf have more than one process type", tags: ["process_check"]  do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/k8s-multiple-processes")

--- a/src/modules/k8s_kernel_introspection/k8s_kernel_introspection.cr
+++ b/src/modules/k8s_kernel_introspection/k8s_kernel_introspection.cr
@@ -42,14 +42,13 @@ module KernelIntrospection
           proc_status[:output] if proc_status[:status].success?
         end.compact
 
-        Log.debug { "proc process_statuses_by_node: #{proc_statuses}" }
+        Log.debug { "proc process_statuses_by_node count: #{proc_statuses.size}" }
         proc_statuses
       end
 
       def self.status_by_pid(pid, node)
-        Log.info { "status_by_pid" }
+        Log.info { "status_by_pid pid: #{pid}" }
         status = ClusterTools.exec_by_node("cat /proc/#{pid}/status", node)
-        Log.info { "status_by_pid status: #{status}" }
         status[:output]
       end
 
@@ -69,10 +68,9 @@ module KernelIntrospection
           Log.for("proctree_by_pid").debug { "pids: #{pids}" }
           proc_statuses = all_statuses_by_pids(pids, node)
         end
-        Log.for("proctree_by_pid").debug { "proc_statuses: #{proc_statuses}" }
+        Log.for("proctree_by_pid").debug { "proc_statuses count: #{proc_statuses.size}" }
         proc_statuses.each do |proc_status|
           parsed_status = KernelIntrospection.parse_status(proc_status)
-          Log.for("proctree_by_pid").debug { "parsed_status: #{parsed_status}" }
           if parsed_status
             ppid = parsed_status["PPid"].strip
             current_pid = parsed_status["Pid"].strip
@@ -105,7 +103,7 @@ module KernelIntrospection
             end
           end
         end
-        Log.for("proctree_by_pid").debug { "proctree: #{proctree}" }
+        Log.for("proctree_by_pid").debug { "proctree size: #{proctree.size}" }
         proctree.each do |x|
           Log.for("proctree_by_pid").debug(&.emit(process_name: x["Name"], pid: x["Pid"], ppid: x["PPid"]))
         end
@@ -184,10 +182,9 @@ module KernelIntrospection
               process = ClusterTools.exec_by_node("cat /proc/#{pid}/cmdline", node)
               status = ClusterTools.exec_by_node("cat /proc/#{pid}/status", node)
               Log.for("find_first_process").debug(&.emit(
-                "process status and cmdline",
+                "process cmdline",
                 pid: pid,
                 cmdline: process[:output],
-                status: "#{status}",
               ))
               if process[:output] =~ /#{process_name}/
                 ret = {node: node, pod: pod, container_status: container_status, status: status[:output], pid: pid.to_s, cmdline: process[:output]}
@@ -227,7 +224,6 @@ module KernelIntrospection
               Log.for("find_matching_processes").debug(&.emit(
                 cat_cmdline_cmd: cat_cmdline_cmd,
                 process: "#{process[:output]}",
-                status: "#{status}"
               ))
               if process[:output] =~ /#{process_name}/
                 result = {node: node, pod: pod, container_status: container_status, status: status[:output], pid: pid.to_s, cmdline: process[:output]}

--- a/src/modules/k8s_kernel_introspection/k8s_kernel_introspection.cr
+++ b/src/modules/k8s_kernel_introspection/k8s_kernel_introspection.cr
@@ -60,30 +60,6 @@ module KernelIntrospection
         cmdline
       end
 
-      def self.verify_single_proc_tree(original_parent_pid, name, proctree : Array(Hash(String, String)), excluded_processes = [] of String)
-        Log.info { "verify_single_proc_tree pid, name: #{original_parent_pid}, #{name}" }
-        verified = true
-        proctree.each do |pt|
-          current_pid = "#{pt["Pid"]}".strip
-          ppid = "#{pt["PPid"]}".strip
-          status_name = "#{pt["Name"]}".strip
-
-          if current_pid == original_parent_pid && ppid != "" &&
-             status_name != name
-            if excluded_processes.includes?(status_name)
-              next
-            end
-            Log.info { "top level parent (i.e. superviser -- first parent with different name): #{status_name}" }
-            verified = false
-          elsif current_pid == original_parent_pid && ppid != "" &&
-                status_name == name
-            verified = verify_single_proc_tree(ppid, name, proctree, excluded_processes)
-          end
-        end
-        Log.info { "verified?: #{verified}" }
-        verified
-      end
-
       def self.proctree_by_pid(potential_parent_pid : String, node : JSON::Any, proc_statuses : (Array(String) | Nil) = nil) : Array(Hash(String, String)) # array of status hashes
         Log.for("proctree_by_pid").info { "proctree_by_pid potential_parent_pid: #{potential_parent_pid}" }
         proctree = [] of Hash(String, String)

--- a/src/tasks/setup/cnf_setup.cr
+++ b/src/tasks/setup/cnf_setup.cr
@@ -42,7 +42,7 @@ task "validate_config" do |_, args|
   if args.named["cnf-config"]?
     config = CNFInstall::Config.parse_cnf_config_from_file(args.named["cnf-config"].to_s)
     stdout_success "Successfully validated CNF config"
-    SLOG.for("validate_config").info { "Config: #{config.inspect}" }
+    SLOG.for("validate_config").debug { "Config: #{config.inspect}" }
   else
     stdout_failure "cnf-config parameter needed"
     exit 1

--- a/src/tasks/utils/logging.cr
+++ b/src/tasks/utils/logging.cr
@@ -1,6 +1,13 @@
+require "colorize"
+
 private class CLILogLevel
   class_property level : String = ""
 end
+
+# Emit ANSI color only when stdout is an interactive terminal, and honor the
+# NO_COLOR convention (https://no-color.org). This keeps piped and CI output
+# free of escape codes so it stays greppable/machine-readable.
+Colorize.enabled = STDOUT.tty? && !ENV.has_key?("NO_COLOR")
 
 begin
   OptionParser.parse do |parser|

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -355,6 +355,7 @@ desc "Do the containers in a pod have only one process type?"
 task "single_process_type" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     fail_msgs = Set(String).new
+    ignored_init_msgs = Set(String).new
     resources_checked = false
     test_passed = true
 
@@ -374,45 +375,72 @@ task "single_process_type" do |t, args|
 
       Log.info { "Constructed resource_named_tuple: #{resource_named_tuple}" }
 
-      # Iterate over every container and verify there is only one process type
+      # Iterate over every container and verify there is only one application process type.
       ClusterTools.all_containers_by_resource?(resource_named_tuple, namespace, only_container_pids:true) do |container_id, container_pid_on_node, node, container_proctree_statuses, container_status|
-        previous_process_type = "initial_name"
         container_name = container_status["name"]?
+        next if container_proctree_statuses.empty?
+        resources_checked = true
 
-        container_proctree_statuses.each do |status|
-          status_name = status["Name"].strip
-          ppid = status["PPid"].strip
-          Log.for(t.name).info { "status name: #{status_name}" }
-          Log.for(t.name).info { "previous status name: #{previous_process_type}" }
-          resources_checked = true
+        root_pid = container_pid_on_node.strip
 
-          if status_name != previous_process_type && previous_process_type != "initial_name"
-            verified = KernelIntrospection::K8s::Node.verify_single_proc_tree(ppid, status_name, container_proctree_statuses, SPECIALIZED_INIT_SYSTEMS)
-            unless verified
-              Log.for(t.name).info { "multiple proc types detected verified: #{verified}" }
+        # The container's own init/supervisor process (PID 1, whose host pid ==
+        # container_pid_on_node) is not an application process type, regardless of
+        # which init binary it uses. A specialized init system (tini/dumb-init/s6) is
+        # also excused wherever it appears in the tree. Whatever remains is the set of
+        # application process types -- more than one means the container runs multiple
+        # process types.
+        app_process_types = container_proctree_statuses.reject do |status|
+          status["Pid"].strip == root_pid ||
+            SPECIALIZED_INIT_SYSTEMS.includes?(status["Name"].strip)
+        end.map { |status| status["Name"].strip }.uniq
 
-              proc_list = container_proctree_statuses.map do |proc|
-                proc_name = proc["Name"]?
-                proc_pid  = proc["Pid"]?
-                proc_ppid = proc["PPid"]?
-                proc_cmd = proc["cmdline"]?.try do |cmd|
-                  cmd.split("\0").join(" ").gsub("\n", "\\n").strip
-                end || "N/A"
-                "NAME=#{proc_name}, PID=#{proc_pid}, PPID=#{proc_ppid}, CMD=#{proc_cmd}"
-              end.join("\n")
-              
-              fail_msg = "Container `#{container_name}` in `#{kind}`: `#{name}` (namespace: `#{namespace}`) has multiple process types.\n"
-              fail_msg += "Running processes detected:\n"
-              fail_msg += "#{proc_list}"
+        Log.for(t.name).info { "container '#{container_name}' application process types: #{app_process_types}" }
 
-              fail_msgs.add?(fail_msg)
-              test_passed = false
-            end
+        # When the container's init process (PID 1) is a real init/supervisor that is
+        # NOT one of the recommended specialized init systems, record that we saw it and
+        # are deliberately not counting it against this test. Whether the init system is
+        # a specialized one is scored separately by the specialized_init_system test.
+        root_status = container_proctree_statuses.find { |status| status["Pid"].strip == root_pid }
+        if root_status
+          root_name = root_status["Name"].strip
+          init_cmd = root_status["cmdline"]?.try do |cmd|
+            cmd.split("\0").join(" ").gsub("\n", "\\n").strip
           end
-          previous_process_type = status_name
+          init_cmd = root_name if init_cmd.nil? || init_cmd.empty?
+          if !SPECIALIZED_INIT_SYSTEMS.includes?(root_name) && app_process_types.any? { |ptype| ptype != root_name }
+            ignored_init_msgs.add?(
+              "Container `#{container_name}` in `#{kind}`: `#{name}` (namespace: `#{namespace}`) " \
+              "uses non-specialized init system `#{init_cmd}` as its init process (PID 1). " \
+              "This is not counted against single_process_type; whether the init system is a " \
+              "recommended one is evaluated by the specialized_init_system test."
+            )
+          end
+        end
+
+        if app_process_types.size > 1
+          proc_list = container_proctree_statuses.map do |proc|
+            proc_name = proc["Name"]?
+            proc_pid  = proc["Pid"]?
+            proc_ppid = proc["PPid"]?
+            proc_cmd = proc["cmdline"]?.try do |cmd|
+              cmd.split("\0").join(" ").gsub("\n", "\\n").strip
+            end || "N/A"
+            "NAME=#{proc_name}, PID=#{proc_pid}, PPID=#{proc_ppid}, CMD=#{proc_cmd}"
+          end.join("\n")
+
+          fail_msg = "Container `#{container_name}` in `#{kind}`: `#{name}` (namespace: `#{namespace}`) has multiple process types.\n"
+          fail_msg += "Running processes detected:\n"
+          fail_msg += "#{proc_list}"
+
+          fail_msgs.add?(fail_msg)
+          test_passed = false
         end
       end
     end
+
+    # Report every non-specialized init system that was found and ignored, so the
+    # decision is visible in both stdout and the results file.
+    ignored_init_msgs.each { |msg| result.append_description(msg) }
 
     if resources_checked
       if test_passed

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -280,7 +280,7 @@ task "reasonable_image_size" do |t, args|
         image_pull_secrets = KubectlClient::Get.resource(resource[:kind], resource[:name], resource[:namespace]).dig?("spec", "template", "spec", "imagePullSecrets")
         if image_pull_secrets
           auths = image_pull_secrets.as_a.map { |secret|
-            puts secret["name"]
+            Log.debug { "image pull secret: #{secret["name"]}" }
             secret_data = KubectlClient::Get.resource("Secret", "#{secret["name"]}", resource[:namespace]).dig?("data")
             if secret_data
               dockerconfigjson = Base64.decode_string("#{secret_data[".dockerconfigjson"]}")
@@ -296,7 +296,7 @@ task "reasonable_image_size" do |t, args|
             str_auths = %({"auths":{#{auths.reduce("") { | acc, x|
             acc + x.to_s + ","
           }[0..-2]}}})
-            puts "str_auths: #{str_auths}"
+            Log.debug { "constructed docker auths config for #{auths.size} secret(s)" }
           end
           File.write(image_secrets_config_path, str_auths)
           Dockerd.exec("mkdir -p /root/.docker/")
@@ -345,9 +345,9 @@ end
 desc "Do the containers in a pod have only one process type?"
 task "process_search" do |_, args|
   pod_info = KernelIntrospection::K8s.find_first_process("sleep 30000")
-  puts "pod_info: #{pod_info}"
+  Log.debug { "pod_info: #{pod_info}" }
   proctree = KernelIntrospection::K8s::Node.proctree_by_pid(pod_info[:pid], pod_info[:node]) if pod_info
-  puts "proctree: #{proctree}"
+  Log.debug { "proctree size: #{proctree.try(&.size)}" }
 
 end
 

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -255,7 +255,7 @@ task "pod_network_duplication", ["install_litmus"] do |t, args|
         rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
         File.write(rbac_path, rbac_yaml)
         KubectlClient::Apply.file(rbac_path)
-        puts resource["name"]
+        Log.for(t.name).debug { "annotating resource for chaos: #{resource["name"]}" }
         KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
 
         chaos_experiment_name = "pod-network-duplication"

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -363,8 +363,8 @@ task "elastic_volumes" do |t, args|
     volumes_used = false
 
     task_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, _, volumes|
-      Log.for("elastic_volumes:test_resource").info { resource.inspect }
-      Log.for("elastic_volumes:volumes").info { volumes.inspect }
+      Log.for("elastic_volumes:test_resource").debug { resource.inspect }
+      Log.for("elastic_volumes:volumes").debug { volumes.inspect }
 
       next true if volumes.size == 0
       volumes_used = true


### PR DESCRIPTION
single_process_type previously excused a container's init/supervisor process only when it was one of the whitelisted SPECIALIZED_INIT_SYSTEMS (tini/dumb-init/s6-svscan). A container using any other real init system was penalized twice: once (correctly) by specialized_init_system, and again by single_process_type, which wrongly counted the init as a second process type.

Rework the check to count distinct *application* process types per container, excluding the container's own init/root process (PID 1, whose host pid == container_pid_on_node) regardless of which init binary it is, and still excusing whitelisted specialized inits anywhere in the tree. The test fails only when more than one application process type remains, so genuine multi-process containers are still caught while a single app under a home-grown init now passes.

When a non-whitelisted init is found and ignored, report it via result.append_description so the decision is visible in both stdout and the results file. The choice of init system remains scored solely by specialized_init_system.

- remove now-unused KernelIntrospection::K8s::Node.verify_single_proc_tree
- add sample-cnfs/sample-nonspecialized-init + spec (non-specialized init supervising a single process now passes)
- update TEST_DOCUMENTATION for the decoupled behavior

## Description
(name of issue/change)

## Issues:
Refs: #2384 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
