### PR TITLE
perf(logging): remove duplicative full-structure dumps and gate color

### DIFF
--- a/src/modules/k8s_kernel_introspection/k8s_kernel_introspection.cr
+++ b/src/modules/k8s_kernel_introspection/k8s_kernel_introspection.cr
@@ -42,14 +42,13 @@ module KernelIntrospection
           proc_status[:output] if proc_status[:status].success?
         end.compact
 
-        Log.debug { "proc process_statuses_by_node: #{proc_statuses}" }
+        Log.debug { "proc process_statuses_by_node count: #{proc_statuses.size}" }
         proc_statuses
       end
 
       def self.status_by_pid(pid, node)
-        Log.info { "status_by_pid" }
+        Log.info { "status_by_pid pid: #{pid}" }
         status = ClusterTools.exec_by_node("cat /proc/#{pid}/status", node)
-        Log.info { "status_by_pid status: #{status}" }
         status[:output]
       end
 
@@ -69,10 +68,9 @@ module KernelIntrospection
           Log.for("proctree_by_pid").debug { "pids: #{pids}" }
           proc_statuses = all_statuses_by_pids(pids, node)
         end
-        Log.for("proctree_by_pid").debug { "proc_statuses: #{proc_statuses}" }
+        Log.for("proctree_by_pid").debug { "proc_statuses count: #{proc_statuses.size}" }
         proc_statuses.each do |proc_status|
           parsed_status = KernelIntrospection.parse_status(proc_status)
-          Log.for("proctree_by_pid").debug { "parsed_status: #{parsed_status}" }
           if parsed_status
             ppid = parsed_status["PPid"].strip
             current_pid = parsed_status["Pid"].strip
@@ -105,7 +103,7 @@ module KernelIntrospection
             end
           end
         end
-        Log.for("proctree_by_pid").debug { "proctree: #{proctree}" }
+        Log.for("proctree_by_pid").debug { "proctree size: #{proctree.size}" }
         proctree.each do |x|
           Log.for("proctree_by_pid").debug(&.emit(process_name: x["Name"], pid: x["Pid"], ppid: x["PPid"]))
         end
@@ -184,10 +182,9 @@ module KernelIntrospection
               process = ClusterTools.exec_by_node("cat /proc/#{pid}/cmdline", node)
               status = ClusterTools.exec_by_node("cat /proc/#{pid}/status", node)
               Log.for("find_first_process").debug(&.emit(
-                "process status and cmdline",
+                "process cmdline",
                 pid: pid,
                 cmdline: process[:output],
-                status: "#{status}",
               ))
               if process[:output] =~ /#{process_name}/
                 ret = {node: node, pod: pod, container_status: container_status, status: status[:output], pid: pid.to_s, cmdline: process[:output]}
@@ -227,7 +224,6 @@ module KernelIntrospection
               Log.for("find_matching_processes").debug(&.emit(
                 cat_cmdline_cmd: cat_cmdline_cmd,
                 process: "#{process[:output]}",
-                status: "#{status}"
               ))
               if process[:output] =~ /#{process_name}/
                 result = {node: node, pod: pod, container_status: container_status, status: status[:output], pid: pid.to_s, cmdline: process[:output]}

--- a/src/tasks/setup/cnf_setup.cr
+++ b/src/tasks/setup/cnf_setup.cr
@@ -42,7 +42,7 @@ task "validate_config" do |_, args|
   if args.named["cnf-config"]?
     config = CNFInstall::Config.parse_cnf_config_from_file(args.named["cnf-config"].to_s)
     stdout_success "Successfully validated CNF config"
-    SLOG.for("validate_config").info { "Config: #{config.inspect}" }
+    SLOG.for("validate_config").debug { "Config: #{config.inspect}" }
   else
     stdout_failure "cnf-config parameter needed"
     exit 1

--- a/src/tasks/utils/logging.cr
+++ b/src/tasks/utils/logging.cr
@@ -1,6 +1,13 @@
+require "colorize"
+
 private class CLILogLevel
   class_property level : String = ""
 end
+
+# Emit ANSI color only when stdout is an interactive terminal, and honor the
+# NO_COLOR convention (https://no-color.org). This keeps piped and CI output
+# free of escape codes so it stays greppable/machine-readable.
+Colorize.enabled = STDOUT.tty? && !ENV.has_key?("NO_COLOR")
 
 begin
   OptionParser.parse do |parser|

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -280,7 +280,7 @@ task "reasonable_image_size" do |t, args|
         image_pull_secrets = KubectlClient::Get.resource(resource[:kind], resource[:name], resource[:namespace]).dig?("spec", "template", "spec", "imagePullSecrets")
         if image_pull_secrets
           auths = image_pull_secrets.as_a.map { |secret|
-            puts secret["name"]
+            Log.debug { "image pull secret: #{secret["name"]}" }
             secret_data = KubectlClient::Get.resource("Secret", "#{secret["name"]}", resource[:namespace]).dig?("data")
             if secret_data
               dockerconfigjson = Base64.decode_string("#{secret_data[".dockerconfigjson"]}")
@@ -296,7 +296,7 @@ task "reasonable_image_size" do |t, args|
             str_auths = %({"auths":{#{auths.reduce("") { | acc, x|
             acc + x.to_s + ","
           }[0..-2]}}})
-            puts "str_auths: #{str_auths}"
+            Log.debug { "constructed docker auths config for #{auths.size} secret(s)" }
           end
           File.write(image_secrets_config_path, str_auths)
           Dockerd.exec("mkdir -p /root/.docker/")
@@ -345,9 +345,9 @@ end
 desc "Do the containers in a pod have only one process type?"
 task "process_search" do |_, args|
   pod_info = KernelIntrospection::K8s.find_first_process("sleep 30000")
-  puts "pod_info: #{pod_info}"
+  Log.debug { "pod_info: #{pod_info}" }
   proctree = KernelIntrospection::K8s::Node.proctree_by_pid(pod_info[:pid], pod_info[:node]) if pod_info
-  puts "proctree: #{proctree}"
+  Log.debug { "proctree size: #{proctree.try(&.size)}" }
 
 end
 

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -255,7 +255,7 @@ task "pod_network_duplication", ["install_litmus"] do |t, args|
         rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
         File.write(rbac_path, rbac_yaml)
         KubectlClient::Apply.file(rbac_path)
-        puts resource["name"]
+        Log.for(t.name).debug { "annotating resource for chaos: #{resource["name"]}" }
         KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
 
         chaos_experiment_name = "pod-network-duplication"

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -363,8 +363,8 @@ task "elastic_volumes" do |t, args|
     volumes_used = false
 
     task_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, _, volumes|
-      Log.for("elastic_volumes:test_resource").info { resource.inspect }
-      Log.for("elastic_volumes:volumes").info { volumes.inspect }
+      Log.for("elastic_volumes:test_resource").debug { resource.inspect }
+      Log.for("elastic_volumes:volumes").debug { volumes.inspect }
 
       next true if volumes.size == 0
       volumes_used = true


### PR DESCRIPTION
Debug logging could explode to ~1.5M lines per run because proctree_by_pid dumped the entire proc_statuses array (full /proc/<pid>/status for every process) and re-dumped it at every recursion level. The same raw data is already logged once per fetch by ClusterTools.exec_by_node, so replace these aggregated re-dumps with counts and keep the per-process id/cmdline emits. Also trim the full /proc/status dumps in find_first_process/find_matching_processes (retained via exec_by_node and the "status found" info log).

Demote info-level struct dumps (elastic_volumes resource/volumes, validate_config config) to debug, and replace stray puts in task code with gated Log calls -- one of which (str_auths) was printing registry credentials to stdout.

Emit ANSI color only on an interactive terminal and honor NO_COLOR, so piped/CI output stays clean and greppable.

## Description
(name of issue/change)

## Issues:
Refs: #2397 

## How has this been tested:
 - [ ] Covered by existing integration testing
 - [ ] Added integration testing to cover
 - [ ] Verified all A/C passes
     * [ ] develop
     * [ ] master
     * [ ] tag/other branch
 - [ ] Test environment
    * [ ] Shared Packet K8s cluster
    * [ ] New Packet K8s cluster
    * [ ] Kind cluster
 - [ ] Have not tested

## Types of changes:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update

## Checklist:
**Documentation**
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] No updates required.

**Code Review**
- [ ] Does the test handle fatal exceptions, ie. rescue block

**Issue**
- [ ] Tasks in issue are checked off
