### PR TITLE
Replace shell commands with Crystal stdlib equivalents

### DIFF
--- a/src/modules/release_manager/release_manager.cr
+++ b/src/modules/release_manager/release_manager.cr
@@ -1,4 +1,5 @@
 require "halite"
+require "http/client"
 require "log"
 
 
@@ -209,21 +210,27 @@ module ReleaseManager
     results.strip("\n")
   end
 
-  # def self.upload_release_asset(release_id, asset_path, asset_name)
   def self.upload_release_asset(release_id, asset_name)
       # TODO Add test that checks for uploaded corrupted binary.
       # POST :server/repos/:owner/:repo/releases/:release_id/assets{?name,label}
-      # asset_resp = Halite.basic_auth(user: ENV["GITHUB_USER"], pass: ENV["GITHUB_TOKEN"]).
-      #   post("https://uploads.github.com/repos/lfn-cnti/testsuite/releases/#{found_release["id"]}/assets?name=#{cnf_tarball_name}",
-      #        headers: {
-      #           "Content-Type" => "application/gzip",
-      #           "Content-Length" => File.size("#{cnf_tarball_name}").to_s
-      #   }, raw: "#{File.open("#{cnf_tarball_name}")}")A
-    asset_resp = `curl --http1.1 -H "Authorization: Bearer #{ENV["GITHUB_TOKEN"]}" -H "Content-Type: $(file -b --mime-type #{asset_name})" --data-binary @#{asset_name} "https://uploads.github.com/repos/lfn-cnti/testsuite/releases/#{release_id}/assets?name=$(basename #{asset_name})"`
-    Log.info {"asset_resp: #{asset_resp}"}
-    asset = JSON.parse(asset_resp.strip)
-    Log.info {"asset: #{asset}"}
-    asset
+      uri = URI.parse("https://uploads.github.com/repos/lfn-cnti/testsuite/releases/#{release_id}/assets")
+      client = HTTP::Client.new(uri, tls: true)
+      mime_type = MIME.from_filename(asset_name) || "application/octet-stream"
+      asset_name_base = File.basename(asset_name)
+      response = client.post(
+        "#{uri.path}?name=#{asset_name_base}",
+        headers: HTTP::Headers{
+          "Authorization" => "Bearer #{ENV["GITHUB_TOKEN"]}",
+          "Content-Type" => mime_type,
+        },
+        body: File.read(asset_name)
+      )
+      client.close
+      asset_resp = response.body
+      Log.info {"asset_resp: #{asset_resp}"}
+      asset = JSON.parse(asset_resp.strip)
+      Log.info {"asset: #{asset}"}
+      asset
   end
 
 end 

--- a/src/modules/tar/tar.cr
+++ b/src/modules/tar/tar.cr
@@ -88,7 +88,7 @@ module TarClient
     TarClient.untar(tar_file, TAR_MODIFY_DIR)
     yield TAR_MODIFY_DIR
     FileUtils.rm_rf(tar_file)
-    file_list = `ls #{TAR_MODIFY_DIR}`.gsub("\n", " ") 
+    file_list = Dir.children(TAR_MODIFY_DIR).join(" ")
     TarClient.tar(tar_file, TAR_MODIFY_DIR, file_list)
     FileUtils.rm_rf(TAR_MODIFY_DIR)
   end

--- a/src/tasks/setup/kind_setup.cr
+++ b/src/tasks/setup/kind_setup.cr
@@ -22,10 +22,11 @@ task "install_kind" do |_, args|
     end
     Retriable.retry(on_retry: do_this_on_each_retry, times: 3, base_interval: 1.second) do
       download_file("#{url}","#{write_file}")
-      stderr = IO::Memory.new
-      status = Process.run("chmod +x #{write_file}", shell: true, output: stderr, error: stderr)
-      success = status.success?
-      raise "Unable to make #{write_file} executable" if success == false
+      begin
+        File.chmod(write_file, 0o755)
+      rescue
+        raise "Unable to make #{write_file} executable"
+      end
     end
   end
 end


### PR DESCRIPTION
- Replace curl with HTTP::Client and file command with MIME.from_filename.
- Replace backtick ls with Dir.children.
- Replace Process.run(find) with Dir.glob.
- Replace Process.run(chmod) with File.chmod.