### PR TITLE
docs: introduce free5GC as the reference CNF

### DIFF
--- a/EXAMPLE-CNFS.md
+++ b/EXAMPLE-CNFS.md
@@ -1,5 +1,20 @@
 ### EXAMPLE-CNFs
 
+## Example CNFs included in this repository
+
+The [example-cnfs/](example-cnfs/) directory contains curated, ready-to-run CNF configurations, each with its own `cnf-testsuite.yml` (and a README where applicable):
+
+- **[free5GC](example-cnfs/free5gc/)** — an open source 5G core and the **reference CNF** for the CNTi Test Suite ([LF Networking announcement](https://lfnetworking.org/introducing-free5gc-as-a-reference-cnf-for-the-cnti-test-suite/)). Validated nightly in CI against the certification test set.
+- [CoreDNS](example-cnfs/coredns/) — DNS server; the lightweight example used in the quick install steps.
+- [Envoy](example-cnfs/envoy/) — L3/L4/L7 proxy.
+- [linkerd2](example-cnfs/linkerd2/) — service mesh.
+- [NSM](example-cnfs/nsm/) — Network Service Mesh.
+- [Pantheon NSM NAT](example-cnfs/pantheon-nsm-nat/) — NSM-based NAT.
+- [IP Forwarder](example-cnfs/ip-forwarder/) — VPP-based IP forwarder.
+- [VPP 3c2n-csp use case](example-cnfs/vpp-3c2n-csp-use-case/) — VPP-based CNF Testbed use case.
+
+## CNF samples by OSI layer
+
 This is a preliminary list of CNF samples for each layer in the [OSI model](https://www.osi-model.com/presentation-layer/) which we plan to test in the CNF Test Suite. CNFs can be thought of as functionality occupying one or more of the following network layers:
 
 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8d/OSI_Model_v1.svg/440px-OSI_Model_v1.svg.png" width="25%" height="25%"><img src="https://cnf-test-suite.s3-us-west-2.amazonaws.com/inet-protocol.png" width="25%" height="25%">
@@ -47,7 +62,7 @@ This is a preliminary list of CNF samples for each layer in the [OSI model](http
 - [Tungsten Fabric](https://tungsten.io/)
 - [OpenSwitch NAS Layer 3](https://github.com/open-switch/opx-nas-l3)
 - CNI K8s add-ons operating on Layer 3 such as the Calico kube-policy-controller container
-- [A dockerized version of free5gc](https://github.com/free5gc/free5gc-compose/)
+- [free5GC](example-cnfs/free5gc/) — 5G core; included in this repo as the reference CNF (see above)
 
 ## [Layer 2 - Data](https://en.wikipedia.org/wiki/Data_link_layer)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Main                                                                                                                                        |
 | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| [![Build Status](https://github.com/lfn-cnti/testsuite/workflows/Crystal%20Specs/badge.svg)](https://github.com/lfn-cnti/testsuite/actions) |
+| [![Build Status](https://github.com/lfn-cnti/testsuite/workflows/Crystal%20Specs/badge.svg)](https://github.com/lfn-cnti/testsuite/actions) [![free5GC validation](https://github.com/lfn-cnti/testsuite/actions/workflows/nightly_free5gc.yml/badge.svg)](https://github.com/lfn-cnti/testsuite/actions/workflows/nightly_free5gc.yml) |
 
 The CNTi Test Suite is an open source and vendor neutral tool that can be used to validate a telco application's adherence to [cloud native principles](https://networking.cloud-native-principles.org/) and best practices. 
 
@@ -39,6 +39,16 @@ The CNTi Test Suite will inspect CNFs for the following characteristics:
 - **Security** - CNF containers should be isolated from one another and the host. CNFs are to be verified against any common CVE or other vulnerabilities.
 
 See the [Test Documentation](docs/TEST_DOCUMENTATION.md) for a complete overview of the tests.
+
+## Reference CNF: free5GC
+
+[free5GC](https://free5gc.org/), an open source 5G core, is the **reference CNF** for the CNTi Test Suite: a realistic telecom workload used to validate that the suite's tests work against carrier-grade CNFs, demonstrate cloud native best practices, and serve as a worked example for onboarding your own CNF.
+
+- Try it: [example-cnfs/free5gc](example-cnfs/free5gc/README.md) — deployment guide (Helm chart via git submodule, kind cluster configuration, known limitations) and a ready-to-use `cnf-testsuite.yml`.
+- It is exercised nightly in CI against the certification test set (see the badge above).
+- Read the announcements: [LF Networking](https://lfnetworking.org/introducing-free5gc-as-a-reference-cnf-for-the-cnti-test-suite/) · [free5GC blog](https://free5gc.org/blog/20260415/20260415/)
+
+For a lightweight first try of the test suite itself, start with the CoreDNS example from the quick install steps above — free5GC has additional host requirements (the `gtp5g` kernel module and unsafe sysctls for the UPF).
 
 ## Contributing
 

--- a/example-cnfs/free5gc/README.md
+++ b/example-cnfs/free5gc/README.md
@@ -5,6 +5,8 @@ This example demonstrates how free5GC can be deployed as a Cloud-Native Network 
 
 The goal of this example is to provide a working reference deployment that is compatible with Kubernetes environments, including **kind clusters**.
 
+> **free5GC is the official reference CNF for the CNTi Test Suite** — a realistic telecom workload used to validate the suite's tests against carrier-grade CNFs and to demonstrate cloud native best practices. Read the announcements: [LF Networking](https://lfnetworking.org/introducing-free5gc-as-a-reference-cnf-for-the-cnti-test-suite/) · [free5GC blog](https://free5gc.org/blog/20260415/20260415/). This deployment is validated nightly in the test suite's CI.
+
 ---
 
 # Architecture Overview


### PR DESCRIPTION
## Description

free5GC was recently announced as a **reference CNF** for the CNTi Test Suite ([LF Networking announcement](https://lfnetworking.org/introducing-free5gc-as-a-reference-cnf-for-the-cnti-test-suite/), [free5GC blog](https://free5gc.org/blog/20260415/20260415/)), but this is not yet visible anywhere in the repo docs. This PR makes it visible:

- **README.md** — new "Reference CNF: free5GC" section (what a reference CNF is, link to the in-repo example, announcement links, nightly CI validation note) and the `free5GC validation` workflow badge next to the build-status badge. First-time users are still pointed at the CoreDNS quick start, since free5GC has extra host requirements (`gtp5g` kernel module, unsafe sysctls for the UPF).
- **EXAMPLE-CNFS.md** — new section listing the example CNFs actually shipped in `example-cnfs/`, with free5GC first and flagged as the reference CNF; the stale link to the dockerized `free5gc-compose` is replaced with the in-repo example.
- **example-cnfs/free5gc/README.md** — callout at the top stating free5GC is the official reference CNF, with announcement links, for visitors landing on the example directly.

Docs-only change; the CI markdown lint only covers `docs/TEST_DOCUMENTATION.md`, so no CI impact.

## Issues

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)