### PR TITLE
Remove unused process_search task

### DIFF
--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -343,15 +343,6 @@ task "reasonable_image_size" do |t, args|
 end
 
 desc "Do the containers in a pod have only one process type?"
-task "process_search" do |_, args|
-  pod_info = KernelIntrospection::K8s.find_first_process("sleep 30000")
-  Log.debug { "pod_info: #{pod_info}" }
-  proctree = KernelIntrospection::K8s::Node.proctree_by_pid(pod_info[:pid], pod_info[:node]) if pod_info
-  Log.debug { "proctree size: #{proctree.try(&.size)}" }
-
-end
-
-desc "Do the containers in a pod have only one process type?"
 task "single_process_type" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     fail_msgs = Set(String).new


### PR DESCRIPTION
## Description

Removes the `process_search` task from `src/tasks/workload/microservice.cr`.

It was added in #1580 as scaffolding for the `prometheus_traffic` test (#1567), but `prometheus_traffic` has long handled its process search itself. Verified before removal:

- No aggregate task depends on `process_search`, and it has no entry in `points.yml`, no spec, and no documentation entry (the only other "process_search" occurrence in the repo is an unrelated log label inside `prometheus_traffic`).
- It also carried a copy-pasted description from `single_process_type` ("Do the containers in a pod have only one process type?"), which it never implemented — it just probed for a hardcoded `sleep 30000` process and logged the proctree size.

Compile-checked with `crystal build --no-codegen`.

## Issues

Fixes #2152
Closes #2071 — that issue asks to *document* `process_search` in USAGE.md; with the task removed per #2152's reasoning, there is nothing left to document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)