### PR TITLE
Remove redundant runtime aggregate task

### DIFF
--- a/src/tasks/workload/runtime.cr
+++ b/src/tasks/workload/runtime.cr
@@ -1,9 +1,0 @@
-require "sam"
-require "file_utils"
-require "colorize"
-require "totem"
-
-desc "Runtime tests"
-task "runtime", ["increase_decrease_capacity"] do  |_, args|
-end
-


### PR DESCRIPTION
## Description

Deletes `src/tasks/workload/runtime.cr`, as proposed in the issue.

The file defined a single aggregate task `runtime` whose only effect was to invoke `increase_decrease_capacity` — which lives in `src/tasks/workload/compatibility.cr` and is already reachable directly, via the `compatibility` category, and via `cert_compatibility`. Verified before removal:

- `grep -rn '"runtime"' src/ spec/ embedded_files/` — the only match was the task definition itself.
- No points.yml entry, no spec, no documentation entry for the `runtime` task (all remaining "runtime" mentions in docs refer to container runtimes / `hardcoded_ip_addresses_in_k8s_runtime_configuration`).
- Compile-checked with `crystal build --no-codegen`.

## Issues

Fixes #2076

🤖 Generated with [Claude Code](https://claude.com/claude-code)