### PR TITLE
spec: warn when a CNF is already installed before running specs

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -13,8 +13,13 @@ require "../src/modules/k8s_netstat"
 require "../src/modules/cluster_tools"
 require "../src/modules/kubectl_client"
 
-ENV["CRYSTAL_ENV"] = "TEST" 
+ENV["CRYSTAL_ENV"] = "TEST"
 
+# Specs assume no CNF is installed; a leftover installation can make them fail
+# in ways that are hard to trace back to the environment.
+if Dir.exists?(CNF_DIR)
+  Log.warn { "A CNF appears to be installed ('#{CNF_DIR}' directory present). Spec tests assume a clean environment and may behave unexpectedly. Consider running './cnf-testsuite cnf_uninstall' first.".colorize(:yellow) }
+end
 
 # Skip the build when a caller (e.g. CI) has already built the binary and sets
 # CNF_TESTSUITE_SKIP_BUILD, avoiding a redundant full recompile per spec run.


### PR DESCRIPTION
## Description

As proposed in the issue: spec tests behave incorrectly in some cases when a CNF is already installed, causing hard-to-trace errors. This adds an early warning in `spec/spec_helper.cr` — before the testsuite build step — when the `installed_cnf_files` directory (`CNF_DIR`) is present:

```
WARN - A CNF appears to be installed ('installed_cnf_files' directory present). Spec tests assume a clean environment and may behave unexpectedly. Consider running './cnf-testsuite cnf_uninstall' first.
```

Notes:
- The check is on directory presence rather than `CNFManager.cnf_installed?` so it also catches leftover artifacts from a partially removed installation, and costs nothing at spec startup.
- Warning only, as the issue suggests — the run is not aborted, so intentional setups (e.g. specs that expect a pre-installed CNF) keep working.
- Compile-checked with `crystal build --no-codegen spec/spec_helper.cr`.

## Issues

Fixes #2100

🤖 Generated with [Claude Code](https://claude.com/claude-code)