### PR TITLE
fix: forward CLI args from cert tasks to sub-tests

### DIFF
--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -85,7 +85,16 @@ describe "SampleUtils" do
   end
 
   it "'points_yml' should parse and return the points yaml file", tags: ["points"]  do
-    (CNFManager::Points.points_yml.find {|x| x["name"] =="liveness"}).should be_truthy 
+    (CNFManager::Points.points_yml.find {|x| x["name"] =="liveness"}).should be_truthy
+  end
+
+  it "cert tasks should forward CLI args to their sub-tests", tags: ["points"] do
+    # node_drain is the only cert-tagged state test, so excluding it must leave
+    # cert_state with nothing to run. Without arg forwarding the exclusion is
+    # dropped and node_drain aborts the run because no CNF is installed.
+    result = ShellCmd.run_testsuite("cert_state ~node_drain")
+    result[:status].success?.should be_true
+    result[:output].should_not contain("You must install a CNF first")
   end
 
   it  "'task_points' should return the amount of points for a passing test", tags: ["points"] do

--- a/src/tasks/cert/cert_compatibility.cr
+++ b/src/tasks/cert/cert_compatibility.cr
@@ -15,7 +15,7 @@ task "cert_compatibility" do |t, args|
   tags = ["compatibility", "cert"]
   tags << "essential" if essential_only
 
-  invoke_tasks_by_tag_list(t, tags, exclude_tasks: exclude)
+  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
   
   cert_stdout_score(tags, "Compatibility, Installability, and Upgradeability", exclude_warning: !exclude.empty?)
 

--- a/src/tasks/cert/cert_configuration.cr
+++ b/src/tasks/cert/cert_configuration.cr
@@ -17,7 +17,7 @@ task "cert_configuration" do |t, args|
   tags = ["configuration", "cert"]
   tags << "essential" if essential_only
 
-  invoke_tasks_by_tag_list(t, tags, exclude_tasks: exclude)
+  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   cert_stdout_score(tags, "configuration", exclude_warning: !exclude.empty?)
   case "#{ARGV.join(" ")}" 

--- a/src/tasks/cert/cert_microservice.cr
+++ b/src/tasks/cert/cert_microservice.cr
@@ -18,7 +18,7 @@ task "cert_microservice" do |t, args|
   tags = ["microservice", "cert"]
   tags << "essential" if essential_only
 
-  invoke_tasks_by_tag_list(t, tags, exclude_tasks: exclude)
+  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   cert_stdout_score(tags, "microservice", exclude_warning: !exclude.empty?)
   case "#{ARGV.join(" ")}" 

--- a/src/tasks/cert/cert_observability.cr
+++ b/src/tasks/cert/cert_observability.cr
@@ -15,7 +15,7 @@ task "cert_observability" do |t, args|
   tags = ["observability", "cert"]
   tags << "essential" if essential_only
 
-  invoke_tasks_by_tag_list(t, tags, exclude_tasks: exclude)
+  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   cert_stdout_score(tags, "Observability and Diagnostics", exclude_warning: !exclude.empty?)
   case "#{ARGV.join(" ")}" 

--- a/src/tasks/cert/cert_resilience.cr
+++ b/src/tasks/cert/cert_resilience.cr
@@ -14,7 +14,7 @@ desc "The CNF test suite checks to see if the CNFs are resilient to failures."
   tags = ["resilience", "cert"]
   tags << "essential" if essential_only
 
-  invoke_tasks_by_tag_list(t, tags, exclude_tasks: exclude)
+  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   Log.debug { "resilience" }
   Log.trace { "resilience args.raw: #{args.raw}" }

--- a/src/tasks/cert/cert_security.cr
+++ b/src/tasks/cert/cert_security.cr
@@ -15,7 +15,7 @@ task "cert_security" do |t, args|
   tags = ["security", "cert"]
   tags << "essential" if essential_only
 
-  invoke_tasks_by_tag_list(t, tags, exclude_tasks: exclude)
+  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   cert_stdout_score(tags, "security", exclude_warning: !exclude.empty?)
   case "#{ARGV.join(" ")}" 

--- a/src/tasks/cert/cert_state.cr
+++ b/src/tasks/cert/cert_state.cr
@@ -16,7 +16,7 @@ task "cert_state" do |t, args|
   tags = ["state", "cert"]
   tags << "essential" if essential_only
 
-  invoke_tasks_by_tag_list(t, tags, exclude_tasks: exclude)
+  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   cert_stdout_score(tags, "state", exclude_warning: !exclude.empty?)
   case "#{ARGV.join(" ")}" 

--- a/src/tasks/cert/cert_utils.cr
+++ b/src/tasks/cert/cert_utils.cr
@@ -25,11 +25,11 @@ def get_excluded_tasks(args)
 end
 
   
-def invoke_tasks_by_tag_list(parent_task, tags, exclude_tasks=[] of String)
+def invoke_tasks_by_tag_list(parent_task, args, tags, exclude_tasks=[] of String)
   tasks = CNFManager::Points.tasks_by_tag_intersection(tags)
   tasks.each do |task|
     unless exclude_tasks.includes? task
-      parent_task.invoke(task)
+      parent_task.invoke(task, args)
     end
   end
 end


### PR DESCRIPTION
## Description

`invoke_tasks_by_tag_list` (`src/tasks/cert/cert_utils.cr`) invoked each cert sub-test with `parent_task.invoke(task)`, which lands on Sam's `invoke(name, *args)` overload and constructs an **empty** `Args`. Every CLI argument was therefore silently dropped for tests running under `cert`/`cert_*`: `strict`, `cnf-config=`, `poc`/`wip`/`alpha`/`beta`, `destructive`, and all `~exclusions`. Only `exclude=` worked (handled separately before invocation).

The fix threads the parent task's `args` through `invoke_tasks_by_tag_list` to each sub-test invocation (the `cert` aggregate itself already forwards args to its declared deps since its block arity is 2, so this was the only gap). All seven `cert_*` call sites updated.

## Verification

Verified against a live binary with an unreachable `KUBECONFIG` (so nothing can touch a cluster):

- **pre-fix binary**: `cert_state ~node_drain` → exclusion dropped, `node_drain` invoked (fails on kubeconfig), exit 1
- **fixed binary**: same command → zero sub-tests run, `State results: 0 of 1 tests passed`, exit 0

Added a cluster-free regression spec (tag `points`, existing CI shard): `node_drain` is the only cert-tagged state test, so `cert_state ~node_drain` must run zero sub-tests and succeed; before the fix the dropped exclusion made `node_drain` abort the run with "You must install a CNF first".

## Issues

Fixes #2412

🤖 Generated with [Claude Code](https://claude.com/claude-code)