### PR TITLE
Fix latent path bugs in tool and setup constants

### DIFF
--- a/src/modules/docker_client/constants.cr
+++ b/src/modules/docker_client/constants.cr
@@ -1,4 +1,4 @@
 module DockerClient
-	DEFAULT_LOCAL_BINARY_PATH = "tools/git/linux-amd64/docker"
+	DEFAULT_LOCAL_BINARY_PATH = "tools/docker/linux-amd64/docker"
 	BASE_CONFIG = "./config.yml"
 end

--- a/src/modules/docker_client/utils/utils.cr
+++ b/src/modules/docker_client/utils/utils.cr
@@ -12,5 +12,5 @@ def local_docker_path
     end
   end
 
-  FileUtils.pwd + DockerClient::DEFAULT_LOCAL_BINARY_PATH
+  File.join(FileUtils.pwd, DockerClient::DEFAULT_LOCAL_BINARY_PATH)
 end

--- a/src/modules/git/utils/utils.cr
+++ b/src/modules/git/utils/utils.cr
@@ -28,5 +28,5 @@ def local_git_path
     end
   end
 
-  FileUtils.pwd + GitClient::DEFAULT_LOCAL_BINARY_PATH
+  File.join(FileUtils.pwd, GitClient::DEFAULT_LOCAL_BINARY_PATH)
 end

--- a/src/modules/kubectl_client/constants.cr
+++ b/src/modules/kubectl_client/constants.cr
@@ -1,5 +1,5 @@
 module KubectlClient
-  DEFAULT_LOCAL_BINARY_PATH  = "tools/git/linux-amd64/docker"
+  DEFAULT_LOCAL_BINARY_PATH  = "tools/kubectl/linux-amd64/kubectl"
   BASE_CONFIG                = "./config.yml"
   RESOURCE_WAIT_LOG_INTERVAL = 10
   # https://www.capitalone.com/tech/cloud/container-runtime/

--- a/src/modules/kubectl_client/utils/utils.cr
+++ b/src/modules/kubectl_client/utils/utils.cr
@@ -28,5 +28,5 @@ def local_kubectl_path
     end
   end
 
-  FileUtils.pwd + KubectlClient::DEFAULT_LOCAL_BINARY_PATH
+  File.join(FileUtils.pwd, KubectlClient::DEFAULT_LOCAL_BINARY_PATH)
 end

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -13,7 +13,6 @@ DEPLOYMENT_MANIFEST_FILE_NAME = "deployment_manifest.yml"
 # CHART_YAML = "Chart.yaml"
 DEFAULT_POINTSFILENAME = "points_v1.yml"
 SONOBUOY_K8S_VERSION = "0.56.14"
-SONOBUOY_OS = "linux"
 IGNORED_SECRET_TYPES = ["kubernetes.io/service-account-token", "kubernetes.io/dockercfg", "kubernetes.io/dockerconfigjson", "helm.sh/release.v1"]
 EMPTY_JSON = JSON.parse(%({}))
 EMPTY_JSON_ARRAY = JSON.parse(%([]))

--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -28,7 +28,7 @@ task "k8s_conformance" do |t, args|
   CNFManager::Task.task_runner(args, task: t, check_cnf_installed: false) do |args, config, result|
     current_dir = FileUtils.pwd
     Log.for(t.name).debug { "current dir: #{current_dir}" }
-    sonobuoy = "#{tools_path}/sonobuoy/sonobuoy"
+    sonobuoy = Setup::SONOBUOY_BINARY
 
     # Clean up old results
     delete_cmd = "#{sonobuoy} delete --all --wait"

--- a/src/tasks/setup/constants.cr
+++ b/src/tasks/setup/constants.cr
@@ -40,11 +40,10 @@ module Setup
   # Useful consts grouped by tools
   CLUSTER_API_URL    = "https://github.com/kubernetes-sigs/cluster-api/releases/download/" +
                        "v#{CLUSTER_API_VERSION}/clusterctl-#{TARGET_OS}-#{TARGET_ARCH}"
-  CLUSTER_API_DIR    = "\#{tools_path}/cluster-api"
-  CLUSTERCTL_BINARY  = "#{CLUSTER_API_DIR}/clusterctl"
 
   KIND_DOWNLOAD_URL  = "https://github.com/kubernetes-sigs/kind/releases/download/v#{KIND_VERSION}/kind-#{TARGET_OS}-#{TARGET_ARCH}"
   KIND_DIR           = "#{tools_path}/kind"
+  KIND_BINARY        = "#{KIND_DIR}/kind"
 
   KUBESCAPE_DIR      = "#{tools_path}/kubescape"
   KUBESCAPE_URL      = "https://github.com/kubescape/kubescape/releases/download/" +
@@ -56,7 +55,7 @@ module Setup
 
   SONOBUOY_DIR       = "#{tools_path}/sonobuoy"
   SONOBUOY_URL       = "https://github.com/vmware-tanzu/sonobuoy/releases/download/" +
-                       "v#{SONOBUOY_K8S_VERSION}/sonobuoy_#{SONOBUOY_K8S_VERSION}_#{TARGET_OS}-#{TARGET_ARCH}.tar.gz"
+                       "v#{SONOBUOY_K8S_VERSION}/sonobuoy_#{SONOBUOY_K8S_VERSION}_#{TARGET_OS}_#{TARGET_ARCH}.tar.gz"
   SONOBUOY_BINARY    = "#{SONOBUOY_DIR}/sonobuoy"
 
   HELM_DIR           = "#{tools_path}/helm"

--- a/src/tasks/setup/kind_setup.cr
+++ b/src/tasks/setup/kind_setup.cr
@@ -10,12 +10,12 @@ desc "Install Kind"
 task "install_kind" do |_, args|
   Log.info {"install_kind"}
   current_dir = FileUtils.pwd 
-  unless Dir.exists?("#{tools_path}/kind")
-    FileUtils.mkdir_p("#{tools_path}/kind")
-    write_file = "#{tools_path}/kind/kind"
+  unless Dir.exists?("#{Setup::KIND_DIR}")
+    FileUtils.mkdir_p("#{Setup::KIND_DIR}")
+    write_file = Setup::KIND_BINARY
     Log.info { "write_file: #{write_file}" }
     Log.info { "install kind" }
-    url = "https://github.com/kubernetes-sigs/kind/releases/download/v#{Setup::KIND_VERSION}/kind-linux-amd64"
+    url = Setup::KIND_DOWNLOAD_URL
     Log.info { "url: #{url}" }
     do_this_on_each_retry = ->(ex : Exception, attempt : Int32, elapsed_time : Time::Span, next_interval : Time::Span) do
         Log.info { "#{ex.class}: '#{ex.message}' - #{attempt} attempt in #{elapsed_time} seconds and #{next_interval} seconds until the next try."}
@@ -35,7 +35,7 @@ desc "Uninstall Kind"
 task "uninstall_kind" do |_, args|
   current_dir = FileUtils.pwd 
   Log.debug { "uninstall_kind" }
-  FileUtils.rm_rf("#{tools_path}/kind")
+  FileUtils.rm_rf("#{Setup::KIND_DIR}")
 end
 
 # USAGE:
@@ -50,14 +50,14 @@ class KindManager
   property kind : String
 
   def initialize
-    @kind = "#{tools_path}/kind/kind"
+    @kind = Setup::KIND_BINARY
   end
 
   #totod make a create cluster with flannel
 
   def create_cluster(name : String, kind_config : String?, k8s_version = "1.21.1") : KindManager::Cluster?
     Log.info { "Creating Kind Cluster" }
-    kubeconfig = "#{tools_path}/kind/#{name}_admin.conf"
+    kubeconfig = "#{Setup::KIND_DIR}/#{name}_admin.conf"
     Log.for("kind_kubeconfig").info { kubeconfig }
 
     kind_config_opt = ""
@@ -80,14 +80,14 @@ class KindManager
     Log.info {"Deleting Kind Cluster: #{name}"}
     ShellCmd.run("#{kind} delete cluster --name #{name}", "KindManager#delete_cluster")
 
-    if File.exists? "#{tools_path}/kind/#{name}_admin.conf"
+    if File.exists? "#{Setup::KIND_DIR}/#{name}_admin.conf"
       Log.info {"Deleting kubeconfig for kind cluster: #{name}"}
-      File.delete "#{tools_path}/kind/#{name}_admin.conf"
+      File.delete "#{Setup::KIND_DIR}/#{name}_admin.conf"
     end
   end
 
   def self.disable_cni_config
-    kind_config = "#{tools_path}/kind/disable_cni.yml"
+    kind_config = "#{Setup::KIND_DIR}/disable_cni.yml"
     unless File.exists?(kind_config)
       File.write(kind_config, DISABLE_CNI)
     end

--- a/src/tasks/setup/sonobuoy_setup.cr
+++ b/src/tasks/setup/sonobuoy_setup.cr
@@ -23,14 +23,12 @@ task "install_sonobuoy" do |_, args|
   Log.trace { SONOBUOY_K8S_VERSION }
   current_dir = FileUtils.pwd 
   Log.trace { current_dir }
-  unless Dir.exists?("#{tools_path}/sonobuoy")
+  unless Dir.exists?("#{Setup::SONOBUOY_DIR}")
     Log.trace { "toolsdir : #{tools_path}" }
-    Log.trace { "full path?: #{tools_path}/sonobuoy" }
-    FileUtils.mkdir_p("#{tools_path}/sonobuoy")
-    # curl = `VERSION="#{LITMUS_K8S_VERSION}" OS=linux ; curl -L "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${VERSION}/sonobuoy_${VERSION}_${OS}_amd64.tar.gz" --output #{tools_path}/sonobuoy/sonobuoy.tar.gz`
-    # os="linux"
-    url = "https://github.com/vmware-tanzu/sonobuoy/releases/download/v#{SONOBUOY_K8S_VERSION}/sonobuoy_#{SONOBUOY_K8S_VERSION}_#{SONOBUOY_OS}_amd64.tar.gz"
-    write_file = "#{tools_path}/sonobuoy/sonobuoy.tar.gz"
+    Log.trace { "full path?: #{Setup::SONOBUOY_DIR}" }
+    FileUtils.mkdir_p("#{Setup::SONOBUOY_DIR}")
+    url = Setup::SONOBUOY_URL
+    write_file = "#{Setup::SONOBUOY_DIR}/sonobuoy.tar.gz"
     Log.info { "url: #{url}" }
     Log.info { "write_file: #{write_file}" }
     # todo change this to work with rel 
@@ -38,10 +36,10 @@ task "install_sonobuoy" do |_, args|
      #  i think any url can do a redirect  ....
     # it could be that http.get 'just works' now.  keyword just
     download_file("#{url}","#{write_file}")
-    `tar -xzf #{tools_path}/sonobuoy/sonobuoy.tar.gz -C #{tools_path}/sonobuoy/ && \
-     chmod +x #{tools_path}/sonobuoy/sonobuoy && \
-     rm #{tools_path}/sonobuoy/sonobuoy.tar.gz`
-    sonobuoy = "#{tools_path}/sonobuoy/sonobuoy"
+    `tar -xzf #{Setup::SONOBUOY_DIR}/sonobuoy.tar.gz -C #{Setup::SONOBUOY_DIR}/ && \
+     chmod +x #{Setup::SONOBUOY_DIR}/sonobuoy && \
+     rm #{Setup::SONOBUOY_DIR}/sonobuoy.tar.gz`
+    sonobuoy = Setup::SONOBUOY_BINARY
     sonobuoy_details(sonobuoy)
   end
 end
@@ -49,7 +47,7 @@ end
 desc "Uninstalls Sonobuoy"
 task "uninstall_sonobuoy" do |_, args|
   current_dir = FileUtils.pwd 
-  sonobuoy = "#{tools_path}/sonobuoy/sonobuoy"
+  sonobuoy = Setup::SONOBUOY_BINARY
   status = Process.run(
     "#{sonobuoy} delete --wait 2>&1",
     shell: true,
@@ -57,6 +55,6 @@ task "uninstall_sonobuoy" do |_, args|
     error: stderr = IO::Memory.new
   ) if File.exists?(sonobuoy)
   Log.debug { stdout }
-  FileUtils.rm_rf("#{tools_path}/sonobuoy")
+  FileUtils.rm_rf("#{Setup::SONOBUOY_DIR}")
 end
 


### PR DESCRIPTION
## Description

Sweep of the latent path bugs catalogued in the issue:

1. **Missing path separator**: `local_kubectl_path` / `local_docker_path` / `local_git_path` computed `FileUtils.pwd + "tools/..."`, yielding e.g. `/home/usertools/git/...`. Now `File.join`.
2. **Copy-paste constant**: `KubectlClient::DEFAULT_LOCAL_BINARY_PATH` pointed at the *docker* binary under the *git* tool dir (`tools/git/linux-amd64/docker`). kubectl and docker now each point at their own path (`tools/kubectl/...`, `tools/docker/...`).
3. **Escaped interpolation**: `Setup::CLUSTER_API_DIR = "\\#{tools_path}/cluster-api"` evaluated to the literal string `#{tools_path}/cluster-api`; it and `CLUSTERCTL_BINARY` were referenced nowhere — removed (the cluster-api installer's relocation is a separate discussion).
4. **Unused constants vs hardcoded installers**: `KIND_DOWNLOAD_URL`/`KIND_DIR` and `SONOBUOY_DIR/URL/BINARY` existed but the installers hardcoded their own URLs/paths with `linux-amd64` / `_amd64` baked in — broken on arm64 (which CI now covers via `arm64.yml`). The `SONOBUOY_URL` constant itself used the wrong asset-name format (`linux-amd64.tar.gz` — hyphens — where sonobuoy releases use `linux_amd64.tar.gz`). Fixed the URL format, added `KIND_BINARY`, and made `kind_setup.cr`, `sonobuoy_setup.cr` and `platform.cr` consume the `TARGET_OS`/`TARGET_ARCH`-aware constants. Dropped the now-unused top-level `SONOBUOY_OS`.

## Verification

- `grep` confirms no remaining references to removed constants and no remaining `\\#{` escaped interpolations in `src/`.
- All four constructed release URLs verified reachable (HTTP 200): kind v0.27.0 linux-amd64 + linux-arm64, sonobuoy v0.56.14 linux_amd64 + linux_arm64.
- Compile-checked with `crystal build --no-codegen`.

## Issues

Fixes #2414

🤖 Generated with [Claude Code](https://claude.com/claude-code)