### PR TITLE
Make points.yml handling lazy and warn on silent CWD-dependent behavior

### DIFF
--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -33,7 +33,6 @@ EmbeddedFileManager.chaos_network_loss
 EmbeddedFileManager.chaos_cpu_hog
 EmbeddedFileManager.chaos_container_kill
 EmbeddedFileManager.points_yml
-EmbeddedFileManager.points_yml_write_file
 EmbeddedFileManager.enforce_image_tag
 EmbeddedFileManager.constraint_template
 EmbeddedFileManager.disable_cni

--- a/src/tasks/utils/cnf_manager/points.cr
+++ b/src/tasks/utils/cnf_manager/points.cr
@@ -187,7 +187,18 @@ module CNFManager
       end
     end
 
+    @@points_yml_ensured = false
+
     def self.points_yml
+      # points.yml used to be rewritten into the CWD at require time on every
+      # invocation, even for help/version. Materialize (or refresh, when a copy
+      # from another release lingers) the embedded points.yml only when scoring
+      # actually needs it, so non-scoring commands stay free of side effects
+      # and work from read-only directories.
+      unless @@points_yml_ensured
+        create_points_yml unless File.exists?("points.yml") && File.read("points.yml") == POINTSFILE
+        @@points_yml_ensured = true
+      end
       points = File.open("points.yml") { |f| YAML.parse(f) }
       points.as_a
     end
@@ -228,7 +239,13 @@ module CNFManager
 
     private def self.dynamic_task_points(task, status_name) : Int32?
       points = points_yml.find { |x| x["name"] == task }
-      @@logger.for("dynamic_task_points").warn { "Task: #{task} not found in points.yml" } unless points
+      unless points
+        # points.yml is kept in sync with the embedded copy, so a missing entry
+        # means the test genuinely has no scoring definition; surface it instead
+        # of silently falling back to default_scoring.
+        @@logger.for("dynamic_task_points").warn { "Task: #{task} not found in points.yml" }
+        stdout_warning "Test '#{task}' has no entry in points.yml, scoring it with default_scoring."
+      end
 
       if points && points[status_name]?
         resp = points[status_name].as_i if points

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -79,6 +79,16 @@ def check_cnf_config(args)
   cnf
 end
 
+module BaseConfigWarning
+  @@warned = false
+
+  def self.warn_missing_once
+    return if @@warned
+    @@warned = true
+    stdout_warning "No #{BASE_CONFIG} found in the current directory; feature toggles (wip, alpha, beta, poc, destructive, multi-cnf) default to disabled."
+  end
+end
+
 def toggle(toggle_name)
   toggle_on = false
   if File.exists?(BASE_CONFIG)
@@ -90,6 +100,7 @@ def toggle(toggle_name)
       toggle_on = feature_flag["toggle_on"].as_bool if feature_flag
     end
   else
+    BaseConfigWarning.warn_missing_once
     toggle_on = false
   end
   toggle_on


### PR DESCRIPTION
## Description

While implementing the issue, the investigation corrected part of its premise (see the issue comment): the reported `platform`/`cert` crash on a missing `points.yml` **cannot occur**, because `src/tasks/constants.cr` called `EmbeddedFileManager.points_yml_write_file` at require time — rewriting `points.yml` into the current directory on **every invocation**, even `help` and `version`, and hard-exiting 1 at startup from a read-only directory for any command.

This PR replaces that startup side effect with lazy self-healing in `Points.points_yml`:

- materialize `points.yml` from the embedded copy when missing,
- refresh it when its content differs from the embedded copy (so a copy from another release can't linger — this preserves the always-in-sync property the startup write provided),
- memoized per process; `setup:configuration_file_setup` still writes it explicitly.

Plus the two warnings the issue asks for:

- one-time stdout warning when `./config.yml` is absent and a feature toggle is consulted (previously all toggles silently read as disabled),
- stdout warning when a test has no `points.yml` entry and falls back to `default_scoring` (previously log-only at warn level, invisible at the default error level).

## Verification (main binary vs this branch, empty scratch dirs, unreachable KUBECONFIG)

| Scenario | main | this PR |
|---|---|---|
| `version` in empty dir | leaves `points.yml` behind | no files created |
| `version` in read-only dir | **exit 1** at startup | works, exit 0 |
| `cert_state exclude=node_drain` in empty dir | works (startup write) | works (lazy write), `points.yml` + `results/` created |
| stale/garbage `points.yml` in dir | refreshed at startup | refreshed on first scoring read |

Specs are unaffected: they invoke `setup:configuration_file_setup` explicitly (unchanged) or call `Points.points_yml` in-process (now self-healing). Compile-checked and behavior-verified with a built binary.

## Issues

Fixes #2413

🤖 Generated with [Claude Code](https://claude.com/claude-code)