### PR TITLE
ci: remove dead task exclusions and stop swallowing install failures

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -518,7 +518,7 @@ jobs:
         ./cnf-testsuite setup
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
-        LOG_LEVEL=debug ./cnf-testsuite all ~compatibility ~resilience ~reasonable_startup_time ~reasonable_image_size ~platform ~increase_capacity ~decrease_capacity ~install_script_helm ~helm_chart_valid ~helm_chart_published
+        LOG_LEVEL=debug ./cnf-testsuite all ~compatibility ~resilience ~reasonable_startup_time ~reasonable_image_size ~platform ~helm_chart_valid ~helm_chart_published
         LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
         LOG_LEVEL=debug ./cnf-testsuite uninstall_all
     - name: Delete Cluster
@@ -604,7 +604,7 @@ jobs:
         ./cnf-testsuite setup
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
-        LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~compatibility ~pod_network_latency ~platform ~increase_capacity ~decrease_capacity ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~install_script_helm ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap
+        LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~compatibility ~pod_network_latency ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap
         LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
         LOG_LEVEL=debug ./cnf-testsuite uninstall_all
     - name: Delete Cluster

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -47,7 +47,7 @@ jobs:
           shards install
           crystal build src/cnf-testsuite.cr
           ./cnf-testsuite setup
-          ./cnf-testsuite cnf_install cnf-config=example-cnfs/coredns || true
+          ./cnf-testsuite cnf_install cnf-config=example-cnfs/coredns
           ./cnf-testsuite cert
           ./cnf-testsuite uninstall_all
         continue-on-error: true


### PR DESCRIPTION
## Description

Cleanup of the workflow invocations per the issue:

1. **Dead exclusions removed** from the binary smoke jobs in `actions.yml`: `~increase_capacity`, `~decrease_capacity` (the real task is `increase_decrease_capacity`) and `~install_script_helm` (no such task). SAM silently ignores exclusions that match nothing, so these never excluded anything — the smoke jobs have been running `increase_decrease_capacity` all along and passing. Removing them is behavior-neutral and stops the workflow from implying that test is skipped.
2. **arm64: `|| true` removed from `cnf_install`.** With the runner's default `bash -e`, an install failure now stops the step instead of proceeding to run `cert` against nothing. The step remains advisory (it has `continue-on-error: true`); whether to make the arm64 job blocking is a separate decision left untouched. The debian workflow already chains with `&&` and needed no change.

Note on `~resilience` (from the issue): exclusion matching is namespace-qualified, so `~resilience` covers only the workload resilience suite, while `platform:resilience` is separately covered by `~platform` in the same invocations. Recording that here rather than as comments in the workflow.

## Verification

- Cross-checked every remaining `~exclusion` in all workflows against the actual task definitions (including the dynamically-defined `rolling_update`/`rolling_downgrade`/`rolling_version_change` tasks) — all map to existing tasks.
- Both workflow files validated as parseable YAML.

Companion issue #2416 will add runtime validation so unmatched `~exclusions` warn instead of being silently ignored.

## Issues

Fixes #2417

🤖 Generated with [Claude Code](https://claude.com/claude-code)