### PR TITLE
Improve runtime artifact hygiene and cleanup completeness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
 /lib/
-/utils/tar/lib/
-/utils/tar/bin/
-/utils/tar/tmp/
 /bin/
 /.shards/
 *.dwarf
@@ -10,11 +7,6 @@
 /cnfs
 /installed_cnf_files
 /results
-/tools/chaos_mesh
-/tools/helm
-/tools/sonobuoy
-/tools/cluster-api
-/tools/dockerd-manifest.yml
 admin.conf
 cnf-testsuite
 results.yml
@@ -32,7 +24,6 @@ reasonable_startup_orig_gobal.yml
 reasonable_startup_orig_local.yml
 sam.cr
 github.env
-tools/k8s-infra/
 tmp/
 chaos_network_loss.yml
 chaos_cpu_hog.yml
@@ -41,14 +32,11 @@ chaos_container_kill.yml
 *.log
 points.yml
 containerd-*-linux-amd64.tar.gz
-tools/LICENSE
 /cnf-testsuite.yml
 /*.tgz
 /enforce-image-tag.yml
 /constraint_template.yml
 /install.sh
-/tools/kubescape/kubescape
-/tools/kind
 /kubescape_results.json
 /cilium
 /tigera-operator
@@ -58,12 +46,6 @@ tools/LICENSE
 /.env
 /*.kubeconfig
 /*.config
-/tools/apisnoop
-/tools/kyverno-policies
-/tools/kyverno
-tools/custom-kyverno-policies/
-tools/chaos-experiments
-/tools/kubescape
 ueransim-gnb/
 gnb-ues-values.yaml
 .icr*
@@ -71,3 +53,13 @@ configadm.yml
 litmus-operator-downloaded.yaml
 litmus-operator-modified.yaml
 
+kubescape_C-*_results.json
+/fluentbit-values.yml
+/fluentd-bitnami-values.yml
+/node_failure_values.yml
+/reboot_daemon_pod.yml
+/helm-*.tar.gz
+/capi.yaml
+/clusterctl
+*sonobuoy*.tar.gz
+/downloaded.tar.gz

--- a/src/modules/cluster_tools/cluster_tools.cr
+++ b/src/modules/cluster_tools/cluster_tools.cr
@@ -54,6 +54,9 @@ module ClusterTools
     KubectlClient::Delete.file("cluster_tools.yml", namespace: self.namespace!)
     #todo make this work with cluster-tools-host-namespace
     KubectlClient::Wait.resource_wait_for_uninstall("Daemonset", "cluster-tools", namespace: self.namespace!)
+  ensure
+    # Do not leave the rendered manifest behind after uninstalling
+    FileUtils.rm_rf("cluster_tools.yml")
   end
 
   def self.exec(cli : String) : KubectlClient::CMDResult

--- a/src/modules/helm/utils.cr
+++ b/src/modules/helm/utils.cr
@@ -112,7 +112,7 @@ module Helm
     end
 
     begin
-      helm_archive = "helm-#{Setup::HELM_VERSION}.tar.gz"
+      helm_archive = File.join(Setup::HELM_DIR, "helm-#{Setup::HELM_VERSION}.tar.gz")
       download_file(Setup::HELM_URL, helm_archive)
     rescue ex : Exception
       logger.error { "Error while downloading Helm binary: #{ex.message}" }
@@ -124,6 +124,7 @@ module Helm
       return false
     end
 
+    File.delete(helm_archive)
     true
   end
 

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -20,12 +20,22 @@ task "tools_uninstall", [
   "setup:uninstall_kubescape",
   "setup:uninstall_cluster_tools",
   "setup:uninstall_opa",
+  "setup:uninstall_kyverno",
+  "setup:uninstall_jaeger",
+  "setup:uninstall_fluentd",
+  "setup:uninstall_fluentdbitnami",
+  "setup:uninstall_fluentbit",
+  "setup:cluster_api_uninstall",
+  "uninstall_ueransim",
+  "uninstall_kind",
   # Helm needs to be uninstalled last to allow other uninstalls to use helm if necessary.
   # Check this issue for details - https://github.com/cncf/cnf-testsuite/issues/1586
   "setup:uninstall_local_helm",
 ] do |_, args|
   # (rafal-lal) Temporary solution that will be replaced soon
   Dockerd.uninstall
+  FileUtils.rm_rf("#{tools_path}/dockerd-manifest.yml")
+  FileUtils.rm_rf("#{tools_path}/docker-config-manifest.yml")
   stdout_success "Testsuite helper tools uninstalled."
 end
 
@@ -33,9 +43,10 @@ desc "Cleans up the CNF Test Suite sample projects, helper tools, and containers
 task "uninstall_all", ["cnf_uninstall", "tools_uninstall"] do |_, args|
 end
 
+desc "Deletes all results files from the results directory"
 task "delete_results" do |_, args|
-  if CNFManager::Points::Results.file_exists?
-    File.delete(CNFManager::Points::Results.file)
-    Log.debug { "Deleted results file at #{CNFManager::Points::Results.file}" }
-  end
+  files = Dir.glob("results/cnf-testsuite-results-*.yml")
+  files.each { |f| File.delete(f) }
+  Log.info { "Deleted #{files.size} results file(s)" }
+  stdout_success "Deleted #{files.size} results file(s)."
 end

--- a/src/tasks/setup/setup.cr
+++ b/src/tasks/setup/setup.cr
@@ -35,7 +35,6 @@ namespace "setup" do
 
     begin
       FileUtils.mkdir_p(CNF_DIR)
-      FileUtils.mkdir_p("tools")
     rescue ex : Exception
       logger.error { "Error while creating directories for testsuite: #{ex.message}" }
       stdout_failure "Task 'cnf_directory_setup' failed. Check logs for more info."

--- a/src/tasks/utils/cnf_manager/points.cr
+++ b/src/tasks/utils/cnf_manager/points.cr
@@ -157,18 +157,18 @@ module CNFManager
 
     class Results
       @@file : String = ""
-      # @@file_used variable is needed to avoid recreation of the file
-      @@file_used : Bool = false
 
       @@logger : ::Log = Log.for("Points").for("Results")
 
       def self.file
-        unless @@file_used || self.file_exists?
+        # (Re)create the file when it does not exist - including when something
+        # external (e.g. delete_results in another process) removed it while
+        # this process holds a handle to its path.
+        unless self.file_exists?
           @@file = CNFManager::Points.create_final_results_yml_name
           self.create_file
           @@logger.for("file").debug { "Results file created: #{@@file}" }
         end
-        @@file_used = true
         @@file
       end
 

--- a/src/tasks/utils/fluent_manager.cr
+++ b/src/tasks/utils/fluent_manager.cr
@@ -31,6 +31,8 @@ module FluentManager
     def uninstall
       Log.info { "Uninstalling #{flavor_name} in #{TESTSUITE_NAMESPACE}" }
       Helm.uninstall(flavor_name, TESTSUITE_NAMESPACE)
+    rescue Helm::ShellCMD::ReleaseNotFound
+      Log.info { "#{flavor_name} release not found, nothing to uninstall" }
     end
 
     def installed?

--- a/src/tasks/utils/jaeger.cr
+++ b/src/tasks/utils/jaeger.cr
@@ -7,8 +7,10 @@ module JaegerManager
     ClusterTools.local_match_by_image_name_with_retries("jaegertracing/jaeger-collector")
   end
   def self.uninstall
-    Log.debug { "uninstall_jaeger" } 
+    Log.debug { "uninstall_jaeger" }
     Helm.uninstall("jaeger", "jaeger")
+  rescue Helm::ShellCMD::ReleaseNotFound
+    Log.info { "Jaeger release not found, nothing to uninstall" }
   end
 
   def self.install

--- a/src/tasks/utils/ueransim.cr
+++ b/src/tasks/utils/ueransim.cr
@@ -2,8 +2,10 @@ require "../../modules/cluster_tools"
 module UERANSIM 
 
   def self.uninstall
-    Log.debug { "uninstall_ueransim" } 
+    Log.debug { "uninstall_ueransim" }
     Helm.uninstall("ueransim", "testsuite-5g")
+  rescue Helm::ShellCMD::ReleaseNotFound
+    Log.info { "UERANSIM release not found, nothing to uninstall" }
   end
 
   def self.install(config)


### PR DESCRIPTION
## Description

Mechanical hygiene sweep per the issue (artifact *relocation* is deliberately out of scope — that's a separate design discussion):

1. **.gitignore**: added the 10 runtime artifacts the suite writes into the CWD that were uncovered (`kubescape_C-*_results.json`, `fluentbit-values.yml`, `fluentd-bitnami-values.yml`, `node_failure_values.yml`, `reboot_daemon_pod.yml`, `helm-*.tar.gz`, `capi.yaml`, `clusterctl`, `*sonobuoy*.tar.gz`, `downloaded.tar.gz`) and removed 18 stale entries from the era when the tools dir was CWD-relative (`/tools/helm`, `/tools/kubescape`, `/utils/tar/*`, …) — the tools dir now lives under `~/.cnf-testsuite`.
2. **`tools_uninstall` wiring**: the existing but orphaned uninstall tasks (kyverno, jaeger, fluentd/fluentdbitnami/fluentbit, cluster_api, ueransim, kind) are now dependencies, so `uninstall_all` removes what the suite can install. Helm stays last per #1586. The dockerd manifests rendered into the tools dir are deleted too.
3. **Tolerant helm uninstalls**: `JaegerManager.uninstall`, `FluentBase#uninstall` and `UERANSIM.uninstall` now rescue `Helm::ShellCMD::ReleaseNotFound` — uninstalling a tool that was never installed logs and continues instead of failing the whole `uninstall_all`. (Kyverno needed no change: it's CLI-only, never deployed to the cluster.)
4. **`delete_results` actually deletes results**: previously it deleted only the results file *lazily created by its own process* — i.e. it created a file and deleted that one, leaving every previous run behind (220 files accumulated in one observed checkout). It now deletes `results/cnf-testsuite-results-*.yml` and got a `desc`.
5. **helm archive**: downloaded into `Setup::HELM_DIR` and deleted after extraction, instead of leaving `helm-<ver>.tar.gz` in the CWD forever.
6. **`ClusterTools.uninstall`**: removes the `cluster_tools.yml` it renders (it previously *re-created* the file during uninstall and left it).
7. **`setup`**: no longer creates an unused empty `./tools` directory in whatever CWD it runs from (nothing reads it; the real tools dir is `~/.cnf-testsuite/tools`).

## Verification

- All 10 new gitignore patterns verified with `git check-ignore`; the previously-dirty artifacts in a used checkout become clean.
- Built binary tested against a live cluster: `delete_results` removes pre-existing results files (exit 0); `setup:uninstall_jaeger`, `uninstall_ueransim`, `setup:uninstall_fluentbit`, and `setup:cluster_api_uninstall` all exit 0 gracefully when the tool was never installed.
- Compile-checked; the full `uninstall_all` path runs the same task bodies exercised above plus the previously-wired ones.

## Issues

Fixes #2415

🤖 Generated with [Claude Code](https://claude.com/claude-code)