### PR TITLE
Validate CLI arguments instead of silently ignoring mistakes

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -120,7 +120,7 @@ items:
 | `schema_version` | Integer version of this results-file schema; bumped on breaking changes. |
 | `status` | Overall run verdict, derived from `exit_code`: `passed` (0), `failed` (1), `error` (2). |
 | `command` | The command line that produced this file. |
-| `exit_code` | Process exit code: `0` passed, `1` failed (a required test failed), `2` error (a test raised). |
+| `exit_code` | Process exit code: `0` passed, `1` failed (a required test failed), `2` error (a test raised). Additionally, the process exits with `64` (usage error) on unknown or malformed command-line arguments, before any test runs. |
 | `summary` | Aggregate numbers for the whole run (see below). |
 | `items` | One entry per test that ran (see below). |
 

--- a/spec/utils/cli_args_spec.cr
+++ b/spec/utils/cli_args_spec.cr
@@ -1,0 +1,32 @@
+require "./../spec_helper"
+require "../../src/tasks/utils/sam_args_patch"
+
+describe "CLI argument validation" do
+  it "rejects unknown flags and named arguments with a usage error", tags: ["points"] do
+    result = ShellCmd.run_testsuite("version bogus_flag")
+    result[:status].exit_code.should eq(64)
+    result[:output].should contain("Unknown flag 'bogus_flag'")
+
+    result = ShellCmd.run_testsuite("version bogus_key=1")
+    result[:status].exit_code.should eq(64)
+    result[:output].should contain("Unknown argument 'bogus_key='")
+
+    result = ShellCmd.run_testsuite("cnf_install cnf-config=whatever timeout=abc")
+    result[:status].exit_code.should eq(64)
+    result[:output].should contain("not a number")
+  end
+
+  it "warns on unmatched exclusions and task names in argument positions", tags: ["points"] do
+    result = ShellCmd.run_testsuite("version ~no_such_task")
+    result[:status].success?.should be_true
+    result[:output].should contain("does not match any task")
+
+    result = ShellCmd.run_testsuite("version delete_results")
+    result[:status].success?.should be_true
+    result[:output].should contain("separate them with")
+  end
+
+  it "preserves '=' characters inside named argument values", tags: ["points"] do
+    Sam::Args.new(["cnf-config=a=b"]).named["cnf-config"].should eq("a=b")
+  end
+end

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -158,7 +158,7 @@ describe "Microservice" do
   end
 
   it "'reasonable_startup_time' should fail if the cnf doesn't has a reasonable startup time(helm_directory)", tags: ["reasonable_startup_time"] do
-    ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_envoy_slow_startup/cnf-testsuite.yml force=true")
+    ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_envoy_slow_startup/cnf-testsuite.yml")
     begin
       result = ShellCmd.run_testsuite("reasonable_startup_time")
       result[:status].success?.should be_true

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -120,6 +120,7 @@ end
 # Sam.help
 begin
   puts `#{PROGRAM_NAME} help` if ARGV.empty?
+  validate_cli_args!(ARGV)
   # See issue #426 for exit code requirement
   Sam.process_tasks(ARGV.clone)
 

--- a/src/tasks/utils/cli_args_validation.cr
+++ b/src/tasks/utils/cli_args_validation.cr
@@ -1,0 +1,68 @@
+require "sam"
+
+# Exit code for CLI usage errors (sysexits EX_USAGE).
+USAGE_EXIT_CODE = 64
+
+# Every key=value argument some task actually reads.
+KNOWN_CLI_NAMED_ARGS = [
+  "cnf-config", "cnf-path", "timeout", "input_config", "output_config",
+  "exclude", "pod_labels", "baseline_count",
+]
+# Named arguments whose value must be an integer.
+NUMERIC_CLI_NAMED_ARGS = ["timeout", "baseline_count"]
+# Every bare-word flag some task actually reads from the raw arguments.
+KNOWN_CLI_FLAGS = [
+  "strict", "essential", "poc", "wip", "alpha", "beta", "destructive",
+  "skip_wait_for_install", "skip_wait_for_uninstall",
+]
+
+# Validates raw CLI tokens before SAM processes them. Previously every typo was
+# silently ignored: unknown key=value args and flags did nothing, exclusions
+# matching no task were dropped, and a second task name on the command line was
+# swallowed as an argument. Unknown input is now a usage error; the two
+# warn-only cases stay warnings for compatibility.
+def validate_cli_args!(argv : Array(String))
+  task_paths = Sam.root_namespace.all_tasks.map(&.path)
+  errors = [] of String
+  expect_task = true
+
+  argv.each do |token|
+    if token == Sam::TASK_SEPARATOR
+      expect_task = true
+      next
+    end
+    if expect_task
+      # Task names themselves are validated by SAM (Sam::NotFound).
+      expect_task = false
+      next
+    end
+
+    if token.empty?
+      errors << "Empty argument given."
+    elsif token.starts_with?("~")
+      unless task_paths.includes?(token[1..])
+        stdout_warning "Exclusion '#{token}' does not match any task and will be ignored."
+      end
+    elsif token.includes?("=")
+      key, value = token.split("=", 2)
+      if !KNOWN_CLI_NAMED_ARGS.includes?(key)
+        errors << "Unknown argument '#{key}='. Known arguments: #{KNOWN_CLI_NAMED_ARGS.join(", ")}."
+      elsif NUMERIC_CLI_NAMED_ARGS.includes?(key) && value.to_i?.nil?
+        errors << "Invalid value for '#{key}=': '#{value}' is not a number."
+      end
+    elsif token.starts_with?("-")
+      errors << "Unknown option '#{token}'. Supported options: -l/--loglevel LEVEL, -h/--help."
+    elsif KNOWN_CLI_FLAGS.includes?(token)
+      # valid bare flag
+    elsif task_paths.includes?(token)
+      stdout_warning "'#{token}' is a task name in an argument position and will be ignored. To run multiple tasks, separate them with '#{Sam::TASK_SEPARATOR}': cnf-testsuite <task1> #{Sam::TASK_SEPARATOR} <task2>"
+    else
+      errors << "Unknown flag '#{token}'. Known flags: #{KNOWN_CLI_FLAGS.join(", ")}."
+    end
+  end
+
+  unless errors.empty?
+    errors.each { |error| stdout_failure error }
+    exit USAGE_EXIT_CODE
+  end
+end

--- a/src/tasks/utils/sam_args_patch.cr
+++ b/src/tasks/utils/sam_args_patch.cr
@@ -1,0 +1,31 @@
+require "sam"
+
+# In-repo fixes for the vendored SAM argument parser (vulk/sam.cr, pinned by
+# commit in shard.yml). lib/ is not part of this repository, so the parser
+# methods are reopened here; drop this file if the fixes land upstream.
+class Sam::Args
+  # Upstream crashes with IndexError on an empty argument.
+  private def option_name(str)
+    return nil if str.empty?
+    if str[0] == '-'
+      str[1..-1]
+    elsif str =~ /=/
+      str.split("=", 2)[0]
+    end
+  end
+
+  # Upstream splits on every "=", truncating values that contain one
+  # (e.g. cnf-config=path=with=equals ended up as just "path").
+  private def option_value(str : String, same_string = true)
+    return nil if str.empty?
+    if same_string
+      if str =~ /=/
+        str.split("=", 2)[1]
+      elsif str[0] != '-'
+        str
+      end
+    elsif str[0] != '-' && !(str =~ /=/)
+      str
+    end
+  end
+end

--- a/src/tasks/workload/5g_validator.cr
+++ b/src/tasks/workload/5g_validator.cr
@@ -21,8 +21,6 @@ task "smf_upf_core_validator" do |t, args|
 
 		# todo add other resilience and compatiblity tests
 
-    args.named["reslience_tests"]="pod_network_latency, pod_delete"
-
 		# todo find heartbeat for ran
     t.invoke("smf_upf_heartbeat", args)
   end


### PR DESCRIPTION
## Description

Implements the issue: a pre-flight validator now runs in the entry point before `Sam.process_tasks`, closing the class of silently-swallowed CLI mistakes.

**Usage errors** (exit `64` = sysexits `EX_USAGE`, message lists the accepted inputs):
- unknown `key=value` argument (`bogus_key=1`)
- unknown bare flag (`stricT`, `essentials`)
- unknown dash option (`--bogus` — previously this cascaded into "Task -l was not found")
- non-numeric value for `timeout=`/`baseline_count=` (previously a raw backtrace)
- empty argument (previously `IndexError`)

**Warnings** (run continues — kept non-fatal for compatibility with existing scripts/CI):
- `~exclusion` matching no task ("will be ignored")
- a task name in an argument position, pointing at the `@` multi-task separator (previously `cnf-testsuite state security` silently ran only `state`)

**Parser fixes**: the vendored SAM shard (`lib/` is not committed; pinned fork `vulk/sam.cr`) is reopened in `src/tasks/utils/sam_args_patch.cr` to split values on the *first* `=` only (`cnf-config=a=b` previously became `a`) and to survive empty arguments. The file documents that it can be dropped if the fixes land upstream.

**Cleanup**: removed the misspelled dead argument write `reslience_tests` (written, read by nothing) in `5g_validator.cr` and the stray `force=true` (read by nothing) in `microservice_spec.cr`. Exit code 64 documented in USAGE.md.

The allowlists were built from a sweep of every `args.named`/`args.raw` read in `src/` (8 named args, 9 flags); all spec and workflow invocations were cross-checked against them.

## Verification

Built binary, all scenarios exercised:

| Input | Result |
|---|---|
| `version bogus_flag` / `version bogus_key=1` / `version \"\"` / `version --bogus` / `timeout=abc` | exit 64 + descriptive message |
| `version ~no_such_task` / `version delete_results` | warning printed, task still runs, exit 0 |
| `version strict ~resilience` (valid flag + matching exclusion) | silent, exit 0 |
| `Sam::Args.new([\"cnf-config=a=b\"])` | value preserved as `a=b` |

New spec `spec/utils/cli_args_spec.cr` (tag `points`, existing CI shard) covers the usage errors, both warnings, and the `=`-preservation fix.

## Issues

Fixes #2416

Related: #2417 removed the dead exclusions the in-repo CI itself carried; this PR adds the runtime warning that would have caught them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)