### PR TITLE
Derive the exit code from whether the run met its objective

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -518,7 +518,8 @@ jobs:
         ./cnf-testsuite setup
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
-        LOG_LEVEL=debug ./cnf-testsuite all ~compatibility ~resilience ~reasonable_startup_time ~reasonable_image_size ~platform ~helm_chart_valid ~helm_chart_published
+        # The example CNF is expected to fail some tests (exit 1); only an errored test (exit 2+) fails the job
+        LOG_LEVEL=debug ./cnf-testsuite all ~compatibility ~resilience ~reasonable_startup_time ~reasonable_image_size ~platform ~helm_chart_valid ~helm_chart_published || [ $? -eq 1 ]
         LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
         LOG_LEVEL=debug ./cnf-testsuite uninstall_all
     - name: Delete Cluster
@@ -604,7 +605,8 @@ jobs:
         ./cnf-testsuite setup
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
-        LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~compatibility ~pod_network_latency ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap
+        # The example CNF is expected to fail some tests (exit 1); only an errored test (exit 2+) fails the job
+        LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~compatibility ~pod_network_latency ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap || [ $? -eq 1 ]
         LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
         LOG_LEVEL=debug ./cnf-testsuite uninstall_all
     - name: Delete Cluster
@@ -690,7 +692,8 @@ jobs:
         ./cnf-testsuite setup
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
-        LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size
+        # The example CNF is expected to fail some tests (exit 1); only an errored test (exit 2+) fails the job
+        LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size || [ $? -eq 1 ]
         LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
         LOG_LEVEL=debug ./cnf-testsuite uninstall_all
     - name: Delete Cluster

--- a/USAGE.md
+++ b/USAGE.md
@@ -69,7 +69,7 @@ testsuite_version: v1.2.3
 schema_version: 1                 # version of this results-file schema
 status: failed                    # overall run verdict: passed | failed | error
 command: ./cnf-testsuite all
-exit_code: 1                      # 0 = passed, 1 = failed, 2 = error (critical)
+exit_code: 1                      # 0 = run met its objective, 1 = did not, 2 = >=1 test errored
 summary:                          # aggregate numbers for the whole run
   total: 18                       # tests executed
   passed: 12
@@ -120,7 +120,7 @@ items:
 | `schema_version` | Integer version of this results-file schema; bumped on breaking changes. |
 | `status` | Overall run verdict, derived from `exit_code`: `passed` (0), `failed` (1), `error` (2). |
 | `command` | The command line that produced this file. |
-| `exit_code` | Process exit code: `0` passed, `1` failed (a required test failed), `2` error (a test raised). Additionally, the process exits with `64` (usage error) on unknown or malformed command-line arguments, before any test runs. |
+| `exit_code` | Process exit code, answering "did this run meet its objective?". `2` at least one test errored (raised) - the suite itself broke, which always wins. Otherwise, for a run with a pass criterion (`cert`): `0` the criterion was met, `1` it was not. For a run without one (`all`, `workload`, `platform`): `0` no test failed (passed/skipped/na), `1` at least one test failed. Additionally, the process exits with `64` (usage error) on unknown or malformed command-line arguments, before any test runs. |
 | `summary` | Aggregate numbers for the whole run (see below). |
 | `items` | One entry per test that ran (see below). |
 

--- a/spec/free5gc_cert_spec.cr
+++ b/spec/free5gc_cert_spec.cr
@@ -11,9 +11,11 @@ describe "Free5gc certification" do
       ShellCmd.cnf_install("cnf-config=./example-cnfs/free5gc/cnf-testsuite.yml timeout=1800")
       
       result = ShellCmd.run_testsuite("cert")
-      
-      # Ensure the testsuite binary didn't crash
-      result[:status].success?.should be_true
+
+      # `cert` exits 0 when the CNF is certified and 1 when it is not; both are
+      # acceptable here since this spec asserts the score, not the verdict.
+      # Exit 2 (an errored test) means the suite itself broke and is not.
+      result[:status].exit_code.should be < 2
       
       result[:output].should match(/PASSED/)
       result[:output].should match(/(17|18|19) of 19 total tests passed/)

--- a/spec/platform/security_spec.cr
+++ b/spec/platform/security_spec.cr
@@ -17,7 +17,7 @@ describe "Platform" do
   it "'cluster_admin' should fail on a cnf that uses a cluster admin binding", tags: ["platform:security"] do
     begin
       result = ShellCmd.run_testsuite("platform:cluster_admin")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Users with cluster-admin RBAC permissions found)/ =~ result[:output]).should_not be_nil
     end
   end
@@ -26,7 +26,7 @@ describe "Platform" do
     ShellCmd.run("kubectl run tiller --image=rancher/tiller:v2.11.0", "create_tiller")
     KubectlClient::Wait.resource_wait_for_install("pod", "tiller")
     result = ShellCmd.run_testsuite("platform:helm_tiller")
-    result[:status].success?.should be_true
+    result[:status].exit_code.should eq(1)
     (/(FAILED).*(Containers with the Helm Tiller image are running)/ =~ result[:output]).should_not be_nil
   ensure
     KubectlClient::Delete.resource("pod", "tiller")
@@ -67,7 +67,7 @@ describe "Platform" do
 
       with_kubeconfig(cluster.kubeconfig) { 
         result = ShellCmd.run_testsuite("platform:verify_configmaps_encryption")
-        result[:status].success?.should be_true
+        result[:status].exit_code.should eq(1)
         (/(FAILED).*(ConfigMaps are not encrypted in etcd)/ =~ result[:output]).should_not be_nil
       }
       
@@ -106,7 +106,7 @@ describe "verify_secrets_encryption", tags: ["platform:security"] do
 
     with_kubeconfig(cluster.kubeconfig) { 
       result = ShellCmd.run_testsuite("platform:verify_secrets_encryption")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Secret\/etcd encryption disabled)/ =~ result[:output]).should_not be_nil
     }
 

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -97,6 +97,59 @@ describe "SampleUtils" do
     result[:output].should_not contain("You must install a CNF first")
   end
 
+  it "'write_summary!' should derive the exit code from item outcomes", tags: ["points"] do
+    results_backup = File.read(CNFManager::Points::Results.file)
+    begin
+      failed_result = CNFManager::TestCaseResult.new(
+        "fake_exit_code_derivation_test", CNFManager::ResultStatus::Failed, "fake failure",
+        [] of String, Time.utc, Time.utc)
+      CNFManager::Points.upsert_task(failed_result)
+      yaml = YAML.parse(File.read(CNFManager::Points::Results.file))
+      yaml["exit_code"].as_i.should eq(1)
+      yaml["status"].as_s.should eq("failed")
+
+      # The derivation is pure: once no failed/errored items remain, the exit
+      # code returns to 0 instead of sticking at the highest value seen.
+      CNFManager::Points.clean_results_yml
+      CNFManager::Points.write_summary!
+      yaml = YAML.parse(File.read(CNFManager::Points::Results.file))
+      yaml["exit_code"].as_i.should eq(0)
+      yaml["status"].as_s.should eq("passed")
+    ensure
+      File.write(CNFManager::Points::Results.file, results_backup)
+    end
+  end
+
+  it "'write_summary!' should derive the exit code from the run's pass criterion", tags: ["points"] do
+    results_backup = File.read(CNFManager::Points::Results.file)
+    begin
+      failed_result = CNFManager::TestCaseResult.new(
+        "fake_pass_criterion_test", CNFManager::ResultStatus::Failed, "fake failure",
+        [] of String, Time.utc, Time.utc)
+      CNFManager::Points.upsert_task(failed_result)
+      # Without a criterion, a failed test alone means the run missed its objective.
+      YAML.parse(File.read(CNFManager::Points::Results.file))["exit_code"].as_i.should eq(1)
+
+      # With a criterion (cert), the group is judged by that criterion alone:
+      # the same failed test no longer forces exit 1 once the threshold is met.
+      CNFManager::Points.pass_threshold = 0
+      CNFManager::Points.write_summary!
+      yaml = YAML.parse(File.read(CNFManager::Points::Results.file))
+      yaml["exit_code"].as_i.should eq(0)
+      yaml["status"].as_s.should eq("passed")
+
+      # An unmet criterion exits 1 even when no individual test failed.
+      CNFManager::Points.pass_threshold = Int32::MAX
+      CNFManager::Points.write_summary!
+      yaml = YAML.parse(File.read(CNFManager::Points::Results.file))
+      yaml["exit_code"].as_i.should eq(1)
+      yaml["status"].as_s.should eq("failed")
+    ensure
+      CNFManager::Points.pass_threshold = nil
+      File.write(CNFManager::Points::Results.file, results_backup)
+    end
+  end
+
   it  "'task_points' should return the amount of points for a passing test", tags: ["points"] do
     # default
     (CNFManager::Points.task_points("liveness")).should eq(100)

--- a/spec/workload/compatibility_spec.cr
+++ b/spec/workload/compatibility_spec.cr
@@ -56,7 +56,7 @@ describe "Compatibility" do
     it "should fail if the CNF uses any deprecated K8s features (no matter the installation type)" do
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-deprecated-k8s-v1.32/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("deprecated_k8s_features")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(CNF uses deprecated K8s features)/ =~ result[:output]).should_not be_nil
       (/annotation "kubernetes.io\/ingress.class" is deprecated/ =~ result[:output]).should_not be_nil
       (/metadata\.annotations\[kubernetes\.io\/enforce-mountable-secrets\]: deprecated in v1\.32\+/ =~

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -30,7 +30,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-testsuite.yml skip_wait_for_install")
       result = ShellCmd.run_testsuite("liveness")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(One or more workload resources have no containers with a liveness probe)/ =~ result[:output]).should_not be_nil
       verify_task_result("liveness", "failed")
     ensure
@@ -54,7 +54,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_coredns_bad_liveness/cnf-testsuite.yml skip_wait_for_install")
       result = ShellCmd.run_testsuite("readiness")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(One or more workload resources have no containers with a readiness probe)/ =~ result[:output]).should_not be_nil
       verify_task_result("readiness", "failed")
     ensure
@@ -77,7 +77,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_rolling_invalid_version/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("rolling_update")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/Failed/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -108,7 +108,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_rolling_invalid_version/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("rolling_downgrade")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/Failed/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -130,7 +130,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_rolling_invalid_version/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("rolling_version_change")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/Failed/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -154,7 +154,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_nodeport")
       result = ShellCmd.run_testsuite("nodeport_not_used")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(NodePort is being used)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -177,7 +177,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_hostport")
       result = ShellCmd.run_testsuite("hostport_not_used")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(HostPort is being used)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -200,7 +200,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns_hardcoded_ips")
       result = ShellCmd.run_testsuite("hardcoded_ip_addresses_in_k8s_runtime_configuration", cmd_prefix: "LOG_LEVEL=info")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Hard-coded IP addresses found in the runtime K8s configuration)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -278,7 +278,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/ndn-mutable-configmap")
       result = ShellCmd.run_testsuite("immutable_configmap")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Found mutable configmap)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -300,7 +300,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_nonroot/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("require_labels")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Pods should have the app.kubernetes.io\/name label)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -323,7 +323,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_coredns_default_namespace")
       result = ShellCmd.run_testsuite("default_namespace")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Resources are created in the default namespace)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -347,7 +347,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_latest_tag")
       result = ShellCmd.run_testsuite("latest_tag")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Container images are using the latest tag)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()

--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -10,7 +10,7 @@ describe CnfTestSuite do
   it "'helm_deploy' should fail on a manifest CNF", tags: ["helm_validation"] do
     ShellCmd.cnf_install("cnf-path=./sample-cnfs/k8s-non-helm")
     result = ShellCmd.run_testsuite("helm_deploy")
-    result[:status].success?.should be_true
+    result[:status].exit_code.should eq(1)
     (/(FAILED).*(CNF has deployments that are not installed with helm)/ =~ result[:output]).should_not be_nil
   ensure
     result = ShellCmd.cnf_uninstall()
@@ -18,7 +18,7 @@ describe CnfTestSuite do
 
   it "'helm_deploy' should fail if command is not supplied cnf-config argument", tags: ["helm_validation"] do
     result = ShellCmd.run_testsuite("helm_deploy")
-    result[:status].success?.should be_true
+    result[:status].exit_code.should eq(1)
     (/No cnf_testsuite.yml found! Did you run the \"cnf_install\" task?/ =~ result[:output]).should_not be_nil
   end
 
@@ -44,7 +44,7 @@ describe CnfTestSuite do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-bad_helm_coredns-cnf/cnf-testsuite.yml skip_wait_for_install", expect_failure: true)
       result = ShellCmd.run_testsuite("helm_chart_valid")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/Helm chart lint failed on one or more charts/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -68,7 +68,7 @@ describe CnfTestSuite do
       ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-bad-helm-repo skip_wait_for_install", expect_failure: true)
       result = ShellCmd.run("helm search repo stable/coredns", force_output: true)
       result = ShellCmd.run_testsuite("helm_chart_published")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(One or more Helm charts are not published)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.run("#{Helm::Binary.get} repo remove badrepo")

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -56,7 +56,7 @@ describe "Microservice" do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/ndn-multi-db-connections-fail/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("shared_database")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Found a shared database)/ =~ result[:output]).should_not be_nil
       verify_task_result("shared_database", "failed")
     ensure
@@ -122,7 +122,7 @@ describe "Microservice" do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/k8s-multiple-processes")
       result = ShellCmd.run_testsuite("single_process_type")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(More than one process type used)/ =~ result[:output]).should_not be_nil
       verify_task_result("single_process_type", "failed")
     ensure
@@ -135,7 +135,7 @@ describe "Microservice" do
     begin
       ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-multiple-processes")
       result = ShellCmd.run_testsuite("single_process_type")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(More than one process type used)/ =~ result[:output]).should_not be_nil
       verify_task_result("single_process_type", "failed")
     ensure
@@ -161,7 +161,7 @@ describe "Microservice" do
     ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_envoy_slow_startup/cnf-testsuite.yml")
     begin
       result = ShellCmd.run_testsuite("reasonable_startup_time")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(CNF had a startup time of)/ =~ result[:output]).should_not be_nil
       verify_task_result("reasonable_startup_time", "failed")
     ensure
@@ -192,7 +192,7 @@ describe "Microservice" do
   it "'reasonable_image_size' should fail if image is larger than 5gb", tags: ["reasonable_image_size"] do
     ShellCmd.cnf_install("cnf-path=./sample-cnfs/ndn-reasonable-image-size skip_wait_for_install")
     result = ShellCmd.run_testsuite("reasonable_image_size")
-    result[:status].success?.should be_true
+    result[:status].exit_code.should eq(1)
     (/Image size too large/ =~ result[:output]).should_not be_nil
     verify_task_result("reasonable_image_size", "failed")
   end
@@ -225,7 +225,7 @@ describe "Microservice" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-operator/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("specialized_init_system")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
 
       latest_results = Dir.glob("results/cnf-testsuite-results-*.yml").max_by { |path| File.info(path).modification_time }
       latest_results.should_not be_nil
@@ -261,7 +261,7 @@ describe "Microservice" do
     begin
       ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample-ndn-privileged")
       result = ShellCmd.run_testsuite("service_discovery")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(No containers exposed as a service)/ =~ result[:output]).should_not be_nil
       verify_task_result("service_discovery", "failed")
     ensure
@@ -297,7 +297,7 @@ describe "Microservice" do
       #todo 4. Make sure that threads are not counted as new processes.  A thread does not get a signal (sigterm or sigkill)
       ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample_bad_signal_handling/")
       result = ShellCmd.run_testsuite("sig_term_handled")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Sig Term not handled)/ =~ result[:output]).should_not be_nil
       verify_task_result("sig_term_handled", "failed")
     ensure
@@ -347,7 +347,7 @@ describe "Microservice" do
 
       ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample-bad-zombie/")
       result = ShellCmd.run_testsuite("zombie_handled")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Zombie not handled)/ =~ result[:output]).should_not be_nil
       verify_task_result("zombie_handled", "failed")
     ensure

--- a/spec/workload/observability_spec.cr
+++ b/spec/workload/observability_spec.cr
@@ -26,7 +26,7 @@ describe "Observability" do
     begin
       ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_no_logs/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("log_output")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Resources do not output logs to stdout and stderr)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -19,7 +19,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_privileged_cnf/cnf-testsuite.yml skip_wait_for_install")
       result = ShellCmd.run_testsuite("privileged_containers")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/Found.*privileged containers.*/ =~ result[:output]).should_not be_nil
       (/impacted: .*\(container privileged-coredns\): privileged container/ =~ result[:output]).should_not be_nil
     ensure
@@ -42,7 +42,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-privilege-escalation/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("privilege_escalation")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(PASSED).*(No containers that allow privilege escalation were found)/ =~ result[:output]).should be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -86,7 +86,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-insecure-capabilities/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("insecure_capabilities")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(PASSED).*(Containers with insecure capabilities were not found)/ =~ result[:output]).should be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -97,7 +97,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-coredns-cnf")
       result = ShellCmd.run_testsuite("linux_hardening")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(PASSED).*(Security services are being used to harden applications)/ =~ result[:output]).should be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -108,7 +108,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-appliciation-credentials/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("application_credentials")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Found applications credentials in configuration files)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -130,7 +130,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-service-accounts/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("service_account_mapping")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Service accounts automatically mapped)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -152,7 +152,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-operator/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("cpu_limits")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (result[:output].scan(/Failed resource: Deployment demo-labeled in cnf-default namespace/).size > 0).should be_true
       (result[:output].scan(/Failed resource: Deployment demo-owned in cnf-default namespace/).size > 0).should be_true
       (/remediation: Set the CPU limits or use exception mechanism to avoid unnecessary notifications\./ =~ result[:output]).should_not be_nil
@@ -176,7 +176,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-coredns-cnf")
       result = ShellCmd.run_testsuite("ingress_egress_blocked")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(PASSED).*(Ingress and Egress traffic blocked on pods)/ =~ result[:output]).should be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -209,7 +209,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-coredns-cnf")
       result = ShellCmd.run_testsuite("non_root_containers")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(PASSED).*(Containers are running with non-root user with non-root group membership)/ =~ result[:output]).should be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -220,7 +220,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-coredns-cnf")
       result = ShellCmd.run_testsuite("immutable_file_systems")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(PASSED).*(Containers have immutable file systems)/ =~ result[:output]).should be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -256,7 +256,7 @@ describe "Security" do
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-hostpath")
       ClusterTools.uninstall
       result = ShellCmd.run_testsuite("hostpath_mounts")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Found containers with hostPath mounts)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -279,7 +279,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_container_sock_mount/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("container_sock_mounts")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Container engine daemon sockets are mounted as volumes)/ =~ result[:output]).should_not be_nil
       (/Unix socket is not allowed/ =~ result[:output]).should_not be_nil
     ensure
@@ -302,7 +302,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_external_ips/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("external_ips")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Services are using external IPs)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -313,7 +313,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_latest_tag")
       result = ShellCmd.run_testsuite("selinux_options")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Pods are using custom SELinux options that can be used for privilege escalations)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -346,7 +346,7 @@ describe "Security" do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_sysctls")
       result = ShellCmd.run_testsuite("sysctls")
-      result[:status].success?.should be_true
+      result[:status].exit_code.should eq(1)
       (/(FAILED).*(Restricted values for are being used for sysctls)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()

--- a/src/tasks/cert/cert.cr
+++ b/src/tasks/cert/cert.cr
@@ -9,6 +9,11 @@ desc "The CNF Test Suite program certifies a CNF based on passing some percentag
 task "cert", ["version", "cert_compatibility", "cert_state", "cert_security", "cert_configuration", "cert_observability", "cert_microservice", "cert_resilience"] do  |_, args|
   Log.debug { "cert" }
 
+  # `cert` is judged by its certification criterion rather than by individual
+  # test failures, so the run exits 0 exactly when the CNF is certified.
+  # See Points.write_summary! for the derivation.
+  CNFManager::Points.pass_threshold = ESSENTIAL_PASSED_THRESHOLD
+
   stdout_success "RESULTS SUMMARY"
   total = CNFManager::Points.total_points("cert")
   max_points = CNFManager::Points.total_max_points("cert")
@@ -26,17 +31,6 @@ task "cert", ["version", "cert_compatibility", "cert_state", "cert_security", "c
     stdout_failure "Certification failed! Passing threshold is #{ESSENTIAL_PASSED_THRESHOLD} essential tests"
   end
 
-  if CNFManager::Points.failed_required_tasks.size > 0
-    stdout_failure "Test Suite failed!"
-    stdout_failure "Failed required tasks: #{CNFManager::Points.failed_required_tasks.inspect}"
-    yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
-      YAML.parse(file)
-    end
-    Log.debug { "results yaml: #{yaml}" }
-    if (yaml["exit_code"]) != 2
-      update_yml("#{CNFManager::Points::Results.file}", "exit_code", "1")
-    end
-  end
   CNFManager::Points.write_summary!
   stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
 end

--- a/src/tasks/utils/cnf_manager/points.cr
+++ b/src/tasks/utils/cnf_manager/points.cr
@@ -187,6 +187,19 @@ module CNFManager
       end
     end
 
+    # Pass criteria for the running task group, when it has one. `cert` sets the
+    # essential-test threshold it certifies against; runs without a criterion
+    # (all/workload/platform) leave this nil and fall back to "no test failed".
+    @@pass_threshold : Int32? = nil
+
+    def self.pass_threshold : Int32?
+      @@pass_threshold
+    end
+
+    def self.pass_threshold=(threshold : Int32?)
+      @@pass_threshold = threshold
+    end
+
     @@points_yml_ensured = false
 
     def self.points_yml
@@ -226,11 +239,13 @@ module CNFManager
       if File.exists?("#{Results.file}")
         results = File.open("#{Results.file}") { |f| YAML.parse(f) }
         File.open("#{Results.file}", "w") do |f|
+          # With no items left, the derived verdict is passed/0; carrying the
+          # previous status/exit_code over would contradict the (empty) items.
           YAML.dump({name:              results["name"],
                      testsuite_version: ReleaseManager::VERSION,
                      schema_version:    RESULTS_SCHEMA_VERSION,
-                     status:            results["status"],
-                     exit_code:         results["exit_code"],
+                     status:            "passed",
+                     exit_code:         0,
                      items:             [] of YAML::Any},
             f)
         end
@@ -504,12 +519,37 @@ module CNFManager
         maximum_points:       max_points,
       }
 
+      # Derive the exit code purely from the run's outcomes, so it stays an exact
+      # function of the recorded items: it drops back to 0 when the items are
+      # cleaned, and cannot be clobbered by a later aggregate.
+      #
+      # An errored test always wins with 2 - that means the suite itself broke,
+      # which is never an acceptable result. Otherwise the exit code answers
+      # "did this run meet its objective?":
+      #
+      #   * A task group with a pass criterion (cert) is judged by that criterion
+      #     alone. Individual test failures are inputs to the verdict, not a
+      #     separate failure mode - the threshold already accounts for them - so
+      #     `cnf-testsuite cert` exits 0 exactly when the CNF is certified.
+      #   * Without a criterion (all/workload/platform) the objective is simply
+      #     that nothing failed (issue #2411 - failures previously only mapped to
+      #     exit 1 via the unused `required:` points.yml field, so failing runs
+      #     exited 0).
+      exit_code =
+        if error > 0
+          2
+        elsif threshold = @@pass_threshold
+          essential_passed >= threshold ? 0 : 1
+        else
+          failed > 0 ? 1 : 0
+        end
+
       # Top-level `status` is the overall run verdict, derived from the exit code:
       # 0 -> passed, 2 -> error (critical), anything else (1) -> failed.
-      exit_code = results["exit_code"]?.try(&.as_i?) || 0
       run_status = exit_code == 0 ? "passed" : (exit_code == 2 ? "error" : "failed")
 
       merged = results.as_h
+      merged[YAML::Any.new("exit_code")] = YAML::Any.new(exit_code.to_i64)
       merged[YAML::Any.new("status")] = YAML::Any.new(run_status)
       merged[YAML::Any.new("summary")] = YAML.parse(summary.to_yaml)
       File.open("#{Results.file}", "w") { |f| YAML.dump(merged, f) }

--- a/src/tasks/utils/cnf_manager/task.cr
+++ b/src/tasks/utils/cnf_manager/task.cr
@@ -93,11 +93,8 @@ module CNFManager
         end
       ensure
         result.set_end_time()
-        # An errored task is a critical failure; record it before the summary is
-        # written so the run status/exit code reflect it even outside strict mode.
-        if result.status == CNFManager::ResultStatus::Error
-          update_yml("#{CNFManager::Points::Results.file}", "exit_code", "#{CRITICAL_FAILURE_CODE}")
-        end
+        # Recording the result is what drives the run's exit code: the summary
+        # (recomputed on every upsert) derives it from the item outcomes.
         upsert_decorated_task(result)
       end
 
@@ -109,9 +106,9 @@ module CNFManager
           if CNFManager::Points.failed_required_tasks.size > 0
             stdout_failure "Failed required tasks: #{CNFManager::Points.failed_required_tasks.inspect}"
           end
+          # The failing/erroring item was upserted above, so the summary already
+          # carries the derived exit code; exit with the matching value.
           exit_code = result.status == CNFManager::ResultStatus::Error ? CRITICAL_FAILURE_CODE : FAILURE_CODE
-          update_yml("#{CNFManager::Points::Results.file}", "exit_code", "#{exit_code}")
-          CNFManager::Points.write_summary!
           exit exit_code
         end
       end


### PR DESCRIPTION
Closes #2411.

## Problem

Failing runs exited 0. Failures only mapped to exit 1 via the unused `required:` field in `points.yml`, so a run full of failed tests still looked successful to CI.

## Approach

The exit code is now derived from the recorded items, making it an exact function of the run's outcomes — it drops back to 0 when items are cleaned, and can't be clobbered by a later aggregate writing to the results file.

An **errored test always wins with exit 2**: the suite itself broke, which is never an acceptable result. Otherwise the exit code answers *"did this run meet its objective?"* — and the objective depends on the task group:

| run | objective | exit 0 | exit 1 |
|---|---|---|---|
| `cert` | meet the certification criterion | certified | not certified |
| `all` / `workload` / `platform` | nothing failed | no test failed | ≥1 test failed |

A group with a pass criterion is judged **by that criterion alone**. `cert` certifies against an essential-test threshold, so individual test failures are *inputs to the verdict*, not a separate failure mode — the threshold already accounts for them.

That keeps the flagship check trivial, which is the point:

```bash
./cnf-testsuite cert     # exit 0 ⟺ certified. No output parsing, no guards.
```

Any CI runner, `set -e`, or `&&` chain handles that directly, while 2-vs-1 still separates "the suite broke" from "the CNF isn't certified".

## Changes

- `Points.pass_threshold` carries the criterion; `cert` sets it, everything else leaves it `nil`.
- New derivation in `Points.write_summary!`.
- Removed the dead `failed_required_tasks` block in `cert`: its `update_yml` was immediately overwritten by the derivation, and its "Test Suite failed!" line would now contradict a certified run exiting 0.
- `task.cr`: dropped the redundant `update_yml` exit-code writes that pure derivation makes dead.
- USAGE.md exit-code contract updated.

## CI

The coredns `cert` runs in the portability workflows stay **bare** — coredns is expected to certify, so `./cnf-testsuite cert` exiting 0 is exactly the assertion those jobs want. As a result this PR leaves `arm64.yml` and `debian.yml` untouched.

The `all ~...` smoke runs in `actions.yml` keep `|| [ $? -eq 1 ]`: they have no criterion, and the example CNFs are expected to fail some of those tests.

## Verification

- Full binary builds.
- `crystal spec --tag points` — 20 examples, 0 failures, including a new spec covering both directions: a failed test no longer forces exit 1 once a criterion is met, and an unmet criterion exits 1 even with nothing failed.
- All three workflow files re-validated as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)