### PR TITLE
Refactor litmus setup tasks

### DIFF
--- a/spec/workload/resilience/disk_fill_spec.cr
+++ b/spec/workload/resilience/disk_fill_spec.cr
@@ -26,7 +26,7 @@ describe "Resilience Disk Fill Chaos" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      result = ShellCmd.run_testsuite("uninstall_litmus")
+      result = ShellCmd.run_testsuite("setup:uninstall_litmus")
       result[:status].success?.should be_true
     end
   end

--- a/spec/workload/resilience/node_drain_spec.cr
+++ b/spec/workload/resilience/node_drain_spec.cr
@@ -27,7 +27,7 @@ describe "Resilience Node Drain Chaos" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      result = ShellCmd.run_testsuite("uninstall_litmus")
+      result = ShellCmd.run_testsuite("setup:uninstall_litmus")
       result[:status].success?.should be_true
     end
   end

--- a/spec/workload/resilience/pod_delete_spec.cr
+++ b/spec/workload/resilience/pod_delete_spec.cr
@@ -26,7 +26,7 @@ describe "Resilience pod delete Chaos" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      result = ShellCmd.run_testsuite("uninstall_litmus")
+      result = ShellCmd.run_testsuite("setup:uninstall_litmus")
       result[:status].success?.should be_true
     end
   end

--- a/spec/workload/resilience/pod_dns_error_spec.cr
+++ b/spec/workload/resilience/pod_dns_error_spec.cr
@@ -33,7 +33,7 @@ describe "Resilience pod dns error Chaos" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      result = ShellCmd.run_testsuite("uninstall_litmus")
+      result = ShellCmd.run_testsuite("setup:uninstall_litmus")
       result[:status].success?.should be_true
     end
   end

--- a/spec/workload/resilience/pod_io_stress_spec.cr
+++ b/spec/workload/resilience/pod_io_stress_spec.cr
@@ -26,7 +26,7 @@ describe "Resilience pod delete Chaos" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      result = ShellCmd.run_testsuite("uninstall_litmus")
+      result = ShellCmd.run_testsuite("setup:uninstall_litmus")
       result[:status].success?.should be_true
     end
   end

--- a/spec/workload/resilience/pod_memory_hog_spec.cr
+++ b/spec/workload/resilience/pod_memory_hog_spec.cr
@@ -26,7 +26,7 @@ describe "Resilience pod memory hog Chaos" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      result = ShellCmd.run_testsuite("uninstall_litmus")
+      result = ShellCmd.run_testsuite("setup:uninstall_litmus")
       result[:status].success?.should be_true
     end
   end

--- a/spec/workload/resilience/pod_network_corruption_spec.cr
+++ b/spec/workload/resilience/pod_network_corruption_spec.cr
@@ -22,7 +22,7 @@ describe "Resilience Pod Network corruption Chaos" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      result = ShellCmd.run_testsuite("uninstall_litmus")
+      result = ShellCmd.run_testsuite("setup:uninstall_litmus")
       result[:status].success?.should be_true
     end
   end

--- a/spec/workload/resilience/pod_network_duplication_spec.cr
+++ b/spec/workload/resilience/pod_network_duplication_spec.cr
@@ -26,7 +26,7 @@ describe "Resilience Pod Network duplication Chaos" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      result = ShellCmd.run_testsuite("uninstall_litmus")
+      result = ShellCmd.run_testsuite("setup:uninstall_litmus")
       result[:status].success?.should be_true
     end
   end

--- a/spec/workload/resilience/pod_network_latency_spec.cr
+++ b/spec/workload/resilience/pod_network_latency_spec.cr
@@ -26,7 +26,7 @@ describe "Resilience Pod Network Latency Chaos" do
     ensure
       result = ShellCmd.cnf_uninstall()
       result[:status].success?.should be_true
-      result = ShellCmd.run_testsuite("uninstall_litmus")
+      result = ShellCmd.run_testsuite("setup:uninstall_litmus")
       result[:status].success?.should be_true
     end
   end

--- a/src/tasks/setup/litmus_setup.cr
+++ b/src/tasks/setup/litmus_setup.cr
@@ -1,142 +1,62 @@
 # coding: utf-8
 require "sam"
-require "file_utils"
-require "colorize"
-require "totem"
 require "../utils/utils.cr"
 
-desc "Install LitmusChaos"
-task "install_litmus" do |_, args|
-  #todo in resilience node_drain task
-  #todo get node name 
-  #todo download litmus file then modify it with add_node_selector
-  #todo apply modified litmus file
-  Log.info { "install litmus" }
-  begin 
-    KubectlClient::Apply.namespace(LitmusManager::LITMUS_NAMESPACE)
-  rescue ex: KubectlClient::ShellCMD::AlreadyExistsError
-    Log.warn { "Cannot create #{LitmusManager::LITMUS_NAMESPACE}. Namespace already exists." }
-  end
-  cmd = "kubectl label namespace #{LitmusManager::LITMUS_NAMESPACE} pod-security.kubernetes.io/enforce=privileged"
-  ShellCmd.run(cmd, "Label.namespace")
-  Log.info { "install litmus operator"}
-  KubectlClient::Apply.file(LitmusManager::LITMUS_OPERATOR, namespace: LitmusManager::LITMUS_NAMESPACE)
-end
+# (rafal-lal) TODO: couple of TODOs found here before refactoring: saving for now
+# todo in resilience node_drain task
+# todo get node name
+# todo download litmus file then modify it with add_node_selector
+# todo apply modified litmus file
 
-desc "Uninstall LitmusChaos"
-task "uninstall_litmus" do |_, args|
-  uninstall_chaosengine_cmd = "kubectl delete chaosengine --all --all-namespaces"
-  status = Process.run(
-      uninstall_chaosengine_cmd,
-      shell: true,
-      output: stdout = IO::Memory.new,
-      error: stderr = IO::Memory.new
-  )
-  KubectlClient::Delete.file("https://litmuschaos.github.io/litmus/litmus-operator-v#{LitmusManager::Version}.yaml", namespace: LitmusManager::LITMUS_NAMESPACE)
-  Log.info { stdout }
-  Log.info { stderr }
-end
+namespace "setup" do
+  desc "Install LitmusChaos"
+  task "install_litmus" do |_, args|
+    logger = SLOG.for("install_litmus")
+    logger.info { "Installing Litmus tool" }
+    failed_msg = "Task 'install_litmus' failed"
 
-module LitmusManager
-
-  Version = "3.6.0"
-  RBAC_VERSION = "2.6.0"
-  # Version = "1.13.8"
-  # Version = "3.0.0-beta12"
-  NODE_LABEL = "kubernetes.io/hostname"
-  #https://raw.githubusercontent.com/litmuschaos/chaos-operator/v2.14.x/deploy/operator.yaml
-  LITMUS_OPERATOR = "https://litmuschaos.github.io/litmus/litmus-operator-v#{LitmusManager::Version}.yaml"
-  # for node drain
-  DOWNLOADED_LITMUS_FILE = "litmus-operator-downloaded.yaml"
-  MODIFIED_LITMUS_FILE = "litmus-operator-modified.yaml"
-  LITMUS_NAMESPACE = "litmus"
-  LITMUS_K8S_DOMAIN = "litmuschaos.io"
-
-
-
-  def self.add_node_selector(node_name)
-    file = File.read(DOWNLOADED_LITMUS_FILE)
-    deploy_index = file.index("kind: Deployment") || 0 
-    spec_literal = "spec:"
-    template = "\n      nodeSelector:\n        kubernetes.io/hostname: #{node_name}"
-    spec1_index = file.index(spec_literal, deploy_index + 1)  || 0
-    spec2_index = file.index(spec_literal, spec1_index + 1) || 0
-    output_file = file.insert(spec2_index + spec_literal.size, template) unless spec2_index == 0
-    File.write(MODIFIED_LITMUS_FILE, output_file) unless output_file == nil
-  end
-
-  def self.get_target_node_to_cordon(deployment_label, deployment_value, namespace)
-    app_nodeName_cmd = "kubectl get pods -l #{deployment_label}=#{deployment_value} -n #{namespace} -o=jsonpath='{.items[0].spec.nodeName}'"
-    Log.info { "Getting the operator node name: #{app_nodeName_cmd}" }
-    status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
-    Log.debug { "status_code: #{status_code}" }
-    appNodeName_response.to_s
-  end
-
-  private def self.get_status_info(chaos_resource, test_name, output_format, namespace) : {Int32, String}
-    status_cmd = "kubectl get #{chaos_resource}.#{LITMUS_K8S_DOMAIN} #{test_name} -n #{namespace} -o '#{output_format}'"
-    Log.info { "Getting litmus status info: #{status_cmd}" }
-    status_code = Process.run("#{status_cmd}", shell: true, output: status_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
-    status_response = status_response.to_s
-    Log.info { "status_code: #{status_code}, response: #{status_response}" }
-    {status_code, status_response}
-  end
-
-  private def self.get_status_info_until(chaos_resource, test_name, output_format, timeout, namespace, &block)
-    repeat_with_timeout(timeout: timeout, errormsg: "Litmus response timed-out") do
-      status_code, status_response = get_status_info(chaos_resource, test_name, output_format, namespace)
-      status_code == 0 && yield status_response
-    end
-  end
-
-  ## wait_for_test will wait for the completion of litmus test
-  def self.wait_for_test(test_name, chaos_experiment_name, args, namespace : String = "default")
-    chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
-    Log.info { "wait_for_test: #{chaos_result_name}" }
-
-    get_status_info_until("chaosengine", test_name, "jsonpath={.status.engineStatus}", LITMUS_CHAOS_TEST_TIMEOUT, namespace) do |engineStatus|
-      ["completed", "stopped"].includes?(engineStatus)
+    begin
+      KubectlClient::Apply.namespace(LitmusManager::LITMUS_NAMESPACE)
+    rescue KubectlClient::ShellCMD::AlreadyExistsError
+    rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
+      logger.error { "Error while creating '#{LitmusManager::LITMUS_NAMESPACE}' namespace: #{ex.message}" }
+      stdout_failure(failed_msg)
+      next
     end
 
-    get_status_info_until("chaosresults", chaos_result_name, "jsonpath={.status.experimentStatus.verdict}", GENERIC_OPERATION_TIMEOUT, namespace) do |verdict|
-      verdict != "Awaited"
+    begin
+      KubectlClient::Utils.label("namespace", LitmusManager::LITMUS_NAMESPACE,
+        ["pod-security.kubernetes.io/enforce=privileged"])
+      KubectlClient::Apply.file(LitmusManager::LITMUS_OPERATOR, namespace: LitmusManager::LITMUS_NAMESPACE)
+    rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
+      logger.error { "Error while installing Litmus tool: #{ex.message}" }
+      stdout_failure(failed_msg)
+      next
     end
+
+    logger.info { "Litmus tool has been installed" }
   end
 
-  ## check_chaos_verdict will check the verdict of chaosexperiment
-  def self.check_chaos_verdict(chaos_result_name, chaos_experiment_name, args, namespace : String = "default") : Bool
-    _, verdict = get_status_info("chaosresult", chaos_result_name, "jsonpath={.status.experimentStatus.verdict}", namespace)
+  desc "Uninstall LitmusChaos"
+  task "uninstall_litmus" do |_, args|
+    logger = SLOG.for("uninstall_litmus")
+    logger.info { "Uninstalling Litmus tool" }
 
-    if verdict == "Pass"
-      return true
-    else
-      Log.for("LitmusManager.check_chaos_verdict#details").debug do
-        status_code, verdict_details_response = get_status_info("chaosresult", chaos_result_name, "json", namespace)
-        "#{verdict_details_response}"
-      end
-
-      Log.for("LitmusManager.check_chaos_verdict").info {"#{chaos_experiment_name} chaos test failed: #{chaos_result_name}, verdict: #{verdict}"}
-      return false
+    begin
+      KubectlClient::Delete.resource("chaosengine", extra_opts: "--all --all-namespaces")
+    rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
+      # Cluster may not have the chaosengine CRD at all (litmus not installed) - not a failure.
+      logger.warn { "Could not delete chaosengine resources: #{ex.message}" }
     end
-  end
 
-  def self.chaos_manifests_path
-    Log.info {"chaos_manifests_path"}
-    chaos_manifests = "#{tools_path}/chaos-experiments"
-    if !Dir.exists?(chaos_manifests)
-      FileUtils.mkdir_p(chaos_manifests)
+    begin
+      KubectlClient::Delete.file(LitmusManager::LITMUS_OPERATOR, namespace: LitmusManager::LITMUS_NAMESPACE)
+    rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
+      logger.error { "Error while deleting Litmus operator: #{ex.message}" }
+      stdout_failure("Task 'uninstall_litmus' failed")
+      next
     end
-    chaos_manifests
-  end
 
-  def self.download_template(url, filename)
-    Log.info {"download_template url, filename: #{url}, #{filename}"}
-    cmp = chaos_manifests_path()
-    filepath = "#{cmp}/#{filename}"
-    Log.info {"filepath: #{filepath}"}
-
-    download_file(url, filepath)
-
-    filepath
+    logger.info { "Litmus tool has been uninstalled" }
   end
 end

--- a/src/tasks/utils/litmus_manager.cr
+++ b/src/tasks/utils/litmus_manager.cr
@@ -1,0 +1,103 @@
+module LitmusManager
+
+  Version = "3.6.0"
+  RBAC_VERSION = "2.6.0"
+  # Version = "1.13.8"
+  # Version = "3.0.0-beta12"
+  NODE_LABEL = "kubernetes.io/hostname"
+  #https://raw.githubusercontent.com/litmuschaos/chaos-operator/v2.14.x/deploy/operator.yaml
+  LITMUS_OPERATOR = "https://litmuschaos.github.io/litmus/litmus-operator-v#{LitmusManager::Version}.yaml"
+  # for node drain
+  DOWNLOADED_LITMUS_FILE = "litmus-operator-downloaded.yaml"
+  MODIFIED_LITMUS_FILE = "litmus-operator-modified.yaml"
+  LITMUS_NAMESPACE = "litmus"
+  LITMUS_K8S_DOMAIN = "litmuschaos.io"
+
+
+
+  def self.add_node_selector(node_name)
+    file = File.read(DOWNLOADED_LITMUS_FILE)
+    deploy_index = file.index("kind: Deployment") || 0 
+    spec_literal = "spec:"
+    template = "\n      nodeSelector:\n        kubernetes.io/hostname: #{node_name}"
+    spec1_index = file.index(spec_literal, deploy_index + 1)  || 0
+    spec2_index = file.index(spec_literal, spec1_index + 1) || 0
+    output_file = file.insert(spec2_index + spec_literal.size, template) unless spec2_index == 0
+    File.write(MODIFIED_LITMUS_FILE, output_file) unless output_file == nil
+  end
+
+  def self.get_target_node_to_cordon(deployment_label, deployment_value, namespace)
+    app_nodeName_cmd = "kubectl get pods -l #{deployment_label}=#{deployment_value} -n #{namespace} -o=jsonpath='{.items[0].spec.nodeName}'"
+    Log.info { "Getting the operator node name: #{app_nodeName_cmd}" }
+    status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
+    Log.debug { "status_code: #{status_code}" }
+    appNodeName_response.to_s
+  end
+
+  private def self.get_status_info(chaos_resource, test_name, output_format, namespace) : {Int32, String}
+    status_cmd = "kubectl get #{chaos_resource}.#{LITMUS_K8S_DOMAIN} #{test_name} -n #{namespace} -o '#{output_format}'"
+    Log.info { "Getting litmus status info: #{status_cmd}" }
+    status_code = Process.run("#{status_cmd}", shell: true, output: status_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
+    status_response = status_response.to_s
+    Log.info { "status_code: #{status_code}, response: #{status_response}" }
+    {status_code, status_response}
+  end
+
+  private def self.get_status_info_until(chaos_resource, test_name, output_format, timeout, namespace, &block)
+    repeat_with_timeout(timeout: timeout, errormsg: "Litmus response timed-out") do
+      status_code, status_response = get_status_info(chaos_resource, test_name, output_format, namespace)
+      status_code == 0 && yield status_response
+    end
+  end
+
+  ## wait_for_test will wait for the completion of litmus test
+  def self.wait_for_test(test_name, chaos_experiment_name, args, namespace : String = "default")
+    chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
+    Log.info { "wait_for_test: #{chaos_result_name}" }
+
+    get_status_info_until("chaosengine", test_name, "jsonpath={.status.engineStatus}", LITMUS_CHAOS_TEST_TIMEOUT, namespace) do |engineStatus|
+      ["completed", "stopped"].includes?(engineStatus)
+    end
+
+    get_status_info_until("chaosresults", chaos_result_name, "jsonpath={.status.experimentStatus.verdict}", GENERIC_OPERATION_TIMEOUT, namespace) do |verdict|
+      verdict != "Awaited"
+    end
+  end
+
+  ## check_chaos_verdict will check the verdict of chaosexperiment
+  def self.check_chaos_verdict(chaos_result_name, chaos_experiment_name, args, namespace : String = "default") : Bool
+    _, verdict = get_status_info("chaosresult", chaos_result_name, "jsonpath={.status.experimentStatus.verdict}", namespace)
+
+    if verdict == "Pass"
+      return true
+    else
+      Log.for("LitmusManager.check_chaos_verdict#details").debug do
+        status_code, verdict_details_response = get_status_info("chaosresult", chaos_result_name, "json", namespace)
+        "#{verdict_details_response}"
+      end
+
+      Log.for("LitmusManager.check_chaos_verdict").info {"#{chaos_experiment_name} chaos test failed: #{chaos_result_name}, verdict: #{verdict}"}
+      return false
+    end
+  end
+
+  def self.chaos_manifests_path
+    Log.info {"chaos_manifests_path"}
+    chaos_manifests = "#{tools_path}/chaos-experiments"
+    if !Dir.exists?(chaos_manifests)
+      FileUtils.mkdir_p(chaos_manifests)
+    end
+    chaos_manifests
+  end
+
+  def self.download_template(url, filename)
+    Log.info {"download_template url, filename: #{url}, #{filename}"}
+    cmp = chaos_manifests_path()
+    filepath = "#{cmp}/#{filename}"
+    Log.info {"filepath: #{filepath}"}
+
+    download_file(url, filepath)
+
+    filepath
+  end
+end

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -74,7 +74,7 @@ task "readiness" do |t, args|
 end
 
 desc "Does the CNF crash when network latency occurs"
-task "pod_network_latency", ["install_litmus"] do |t, args|
+task "pod_network_latency", ["setup:install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     #todo if args has list of labels to perform test on, go into pod specific mode
     #TODO tests should fail if cnf not installed
@@ -174,7 +174,7 @@ task "pod_network_latency", ["install_litmus"] do |t, args|
 end
 
 desc "Does the CNF crash when network corruption occurs"
-task "pod_network_corruption", ["install_litmus"] do |t, args|
+task "pod_network_corruption", ["setup:install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     #TODO tests should fail if cnf not installed
     task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
@@ -230,7 +230,7 @@ task "pod_network_corruption", ["install_litmus"] do |t, args|
 end
 
 desc "Does the CNF crash when network duplication occurs"
-task "pod_network_duplication", ["install_litmus"] do |t, args|
+task "pod_network_duplication", ["setup:install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     #TODO tests should fail if cnf not installed
     task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
@@ -288,7 +288,7 @@ task "pod_network_duplication", ["install_litmus"] do |t, args|
 end
 
 desc "Does the CNF crash when disk fill occurs"
-task "disk_fill", ["install_litmus"] do |t, args|
+task "disk_fill", ["setup:install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       app_namespace = resource[:namespace]
@@ -346,7 +346,7 @@ task "disk_fill", ["install_litmus"] do |t, args|
 end
 
 desc "Does the CNF crash when pod-delete occurs"
-task "pod_delete", ["install_litmus"] do |t, args|
+task "pod_delete", ["setup:install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     #todo clear all annotations
     task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
@@ -448,7 +448,7 @@ task "pod_delete", ["install_litmus"] do |t, args|
 end
 
 desc "Does the CNF crash when pod-memory-hog occurs"
-task "pod_memory_hog", ["install_litmus"] do |t, args|
+task "pod_memory_hog", ["setup:install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       app_namespace = resource[:namespace]
@@ -506,7 +506,7 @@ task "pod_memory_hog", ["install_litmus"] do |t, args|
 end
 
 desc "Does the CNF crash when pod-io-stress occurs"
-task "pod_io_stress", ["install_litmus"] do |t, args|
+task "pod_io_stress", ["setup:install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       app_namespace = resource[:namespace]
@@ -574,7 +574,7 @@ end
 
 
 desc "Does the CNF crash when pod-dns-error occurs"
-task "pod_dns_error", ["install_litmus"] do |t, args|
+task "pod_dns_error", ["setup:install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     runtimes = KubectlClient::Get.container_runtimes
     Log.info { "pod_dns_error runtimes: #{runtimes}" }

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -216,7 +216,7 @@ module WorkloadResource
 end
 
 desc "Does the CNF crash when node-drain occurs"
-task "node_drain", ["install_litmus"] do |t, args|
+task "node_drain", ["setup:install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     skipped = false
     task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|


### PR DESCRIPTION
## Description

Revival of #2255 by @rafal-lal, cherry-picked onto current main (the rest of that branch's refactor series already landed as rebased commits).

- Moves the `LitmusManager` module into `src/tasks/utils/litmus_manager.cr` and rewrites `install_litmus`/`uninstall_litmus` in the `setup` namespace with structured logging (`SLOG`) and explicit error handling, matching the already-merged kind/kubescape/helm setup task refactors.
- Uses `KubectlClient::Utils.label` and `KubectlClient::Delete.resource` instead of raw `kubectl` shellouts.

Changes on top of the original branch:

- The moved `LitmusManager` code carries main's current module body (`exit_code`, `download_file` fixes from 90415f3a and friends) instead of the April-2025 copy.
- Task references are updated to the namespaced names (`["setup:install_litmus"]` in `reliability.cr`/`state.cr`, `setup:uninstall_litmus` in the resilience specs). Sam resolves parent-namespace references downward but not bare names into namespaces, so without this every chaos task's dependency would fail to resolve.
- A failed `chaosengine` deletion during uninstall logs a warning instead of failing the task, so `uninstall_all` stays quiet on clusters where litmus was never installed (the missing-CRD error maps to `UnspecifiedError`, not `NotFoundError`).

Note: this renames the user-facing tasks to `setup:install_litmus`/`setup:uninstall_litmus`, consistent with the other tool setup tasks.

## Issues:

Refs #2255

🤖 Generated with [Claude Code](https://claude.com/claude-code)