### PR TITLE
Fix flaky fluentd/fluentbit detection in routed_logs

### DIFF
--- a/src/tasks/utils/fluent_manager.cr
+++ b/src/tasks/utils/fluent_manager.cr
@@ -16,6 +16,13 @@ module FluentManager
       @chart = chart
     end
 
+    # Digest pinned in image_name ("repo:tag@sha256:..."). The helm values files
+    # pin the same digest, so a collector installed by the testsuite always runs
+    # exactly this image. Empty when the flavor pins no digest.
+    def image_digest : String
+      image_name.partition("@")[2]
+    end
+
     def install
       Log.info { "Installing #{flavor_name} daemonset using #{values_file}" }
       Helm.helm_repo_add(flavor_name, repo_url)
@@ -75,13 +82,16 @@ module FluentManager
 
   def self.find_active_match_pods : Array(JSON::Any)?
     all_flavors.each do |flavor|
-      # Look for images of all flavors stored on node.
-      matching_image = ClusterTools.local_match_by_image_name_with_retries(flavor.image_name)
-      # When image name found on any of the nodes, check if any
-      # pod with this image is currently running on the cluster.
-      matching_pods = KubectlClient::Get.pods_by_digest(matching_image[:digest]) if matching_image[:found]
+      # Match running pods by the digest pinned in the flavor definition, read
+      # from pod container statuses. Detection used to resolve that digest via
+      # node .status.images first, which the kubelet refreshes asynchronously:
+      # a freshly installed collector could stay invisible there for over 30s,
+      # longer than the retry budget, making routed_logs detection flaky.
+      digest = flavor.image_digest
+      next if digest.empty?
+      matching_pods = KubectlClient::Get.pods_by_digest(digest)
 
-      return matching_pods if !matching_pods.nil? && matching_pods.first?
+      return matching_pods if matching_pods.first?
     end
     nil
   end


### PR DESCRIPTION
## Description

`routed_logs` resolved the log collector's image digest by matching flavor image names against node `.status.images`, then looked up pods by that digest. The kubelet refreshes the node image list asynchronously, so a freshly installed collector could stay invisible there for over 30 seconds — longer than the retry budget — making the `observability_routed_logs` spec shard flaky. The fluentbit example installs the collector immediately before running the test, so it sat right in that window.

## Approach

The digest itself was never the problem. The helm values files pin the same digest the flavor definitions carry:

| flavor | values file | flavor constant |
|---|---|---|
| fluentd | `sha256:4bad7545…` | `sha256:4bad7545…` |
| fluentd-bitnami | `sha256:6771c744…` | `sha256:6771c744…` |
| fluent-bit | `sha256:7d727245…` | `sha256:7d727245…` |

Helm installs **by digest**, so a collector installed by the testsuite always runs exactly that image. Only the lookup path was unreliable.

So this drops the node scan and matches pods directly by the pinned digest through their container statuses, which are populated as soon as the pod runs. That is precisely what the old code did once node status caught up — `local_match_by_image_name` returned the *pinned* digest, and matched node imageIDs by substring — so **detection semantics are unchanged; only the lag is gone.**

Matching on the digest also makes detection independent of the registry host: the fluent-bit flavor names `fluent/fluent-bit` while its chart pulls from `cr.fluentbit.io/fluent/fluent-bit`. And the no-collector skip path gets faster — one pod list per flavor instead of a node-status retry loop.

## Changes

- `FluentBase#image_digest` parses the digest pinned in `image_name`; flavors pinning no digest are skipped.
- `find_active_match_pods` calls `KubectlClient::Get.pods_by_digest` with it directly.

One file, +16/-6. `ClusterTools.local_match_by_image_name_with_retries` stays — jaeger and mysql still use it.

## Follow-ups (not in scope here)

- The pinned digest is duplicated across the helm values file, the flavor constant, and `spec/fixtures/fluentd-values-bad.yml`, with nothing guarding drift. Worth single-sourcing.
- `pod_tailed?` hardcodes `namespace: TESTSUITE_NAMESPACE` while pod matching searches all namespaces, and `logs()` raises on error. A third-party collector outside `cnf-testsuite` would therefore error the test rather than be read. Digest pinning keeps this latent today, but it blocks any genuine third-party collector detection.

## Verification

- `crystal build --no-codegen src/cnf-testsuite.cr` passes.
- Digest parsing checked against all three flavor strings plus an unpinned one, and confirmed the digest substring still matches an imageID from a different registry host.
- Rebased onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)