### PR TITLE
Give every task group a declared success criterion

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -136,6 +136,8 @@ All counts/scores are scoped to the tests that actually ran.
 | `essential_passed` / `essential_max_passed` | Passed vs. maximum-passable among `essential`-tagged tests. |
 | `points` | Total points scored. |
 | `maximum_points` | Maximum points achievable by the tests that ran. |
+| `criteria` | Success-criterion verdict per task group that ran (see below). Absent when no such group ran. |
+
 ##### Test scoring
 
 A test declares everything the suite knows about it at its own definition:
@@ -164,6 +166,61 @@ There is no `points.yml`. The suite used to write one into the working directory
 and read it straight back, so it needed a writable directory to read data it was
 compiled with, and edits to the file were silently reverted on the next run.
 
+##### Group success criteria
+
+Every task group — the suites (`all`, `workload`, `platform`, `cert`) and the
+categories (`security`, `configuration`, ..., and the `platform:` ones) —
+declares a success criterion in `Points::GROUP_CRITERIA`. These are group-level
+policy — what the suite certifies, and what it demands of each category — so
+they live together in one table:
+
+```crystal
+suite_task "cert", [...],
+  scope: "essential",     # whose tests count
+  min_passed: 15,         # how many of them must pass
+  max_failed: CNFManager::NO_FAILURE_LIMIT   # the threshold accounts for failures
+```
+
+A group passes when **every** threshold it declares holds:
+
+| threshold | default | meaning |
+|-----------|---------|---------|
+| `min_passed` | `0` | at least this many tests in scope passed |
+| `min_ratio` | none | at least this share of the tests that **exist** in scope passed |
+| `max_failed` | `0` | at most this many failed; `NO_FAILURE_LIMIT` for no limit |
+
+`min_ratio` counts against how many tests are declared in scope rather than how
+many a run reached, because excluding tests shrinks the latter — and `cert`
+takes an `exclude` argument, so a ratio over it could be met by running less.
+
+With the defaults — no floor, no ratio, no failures tolerated — a group passes
+when nothing in it failed, which is what these groups have always demanded.
+Only `cert` declares anything else.
+
+Each evaluated group is recorded under `summary.criteria` in evaluation order:
+
+```yaml
+summary:
+  criteria:
+    - group: security
+      scope: security
+      min_passed: 0
+      max_failed: 0
+      passed_count: 17
+      max_passed: 19
+      failed_count: 2
+      passed: false
+```
+
+A group's dependencies run before its body, so the **last** entry is the
+outermost group, and its verdict is what `exit_code` reflects.
+
+The same verdict is printed to stdout in a stable, greppable form:
+
+```
+Security: FAILED (2 of 19 tests failed)
+Certification: PASSED (17 of 19 essential tests passed, threshold 15)
+```
 
 ##### `items[]` fields
 

--- a/docs/cnf-testsuite-results.schema.json
+++ b/docs/cnf-testsuite-results.schema.json
@@ -4,7 +4,15 @@
   "title": "CNTi Test Suite results file",
   "description": "Schema for the results/cnf-testsuite-results-<timestamp>.yml file produced by a completed CNTi Test Suite run. Matches schema_version 1. The file is YAML; this schema validates it as JSON (YAML is a JSON superset).",
   "type": "object",
-  "required": ["name", "testsuite_version", "schema_version", "status", "exit_code", "summary", "items"],
+  "required": [
+    "name",
+    "testsuite_version",
+    "schema_version",
+    "status",
+    "exit_code",
+    "summary",
+    "items"
+  ],
   "additionalProperties": false,
   "properties": {
     "name": {
@@ -23,7 +31,12 @@
     },
     "status": {
       "description": "Overall run verdict, derived from exit_code (0 -> passed, 1 -> failed, 2 -> error). May be null before any test has run.",
-      "enum": ["passed", "failed", "error", null]
+      "enum": [
+        "passed",
+        "failed",
+        "error",
+        null
+      ]
     },
     "command": {
       "description": "The command line that produced this file.",
@@ -32,13 +45,21 @@
     "exit_code": {
       "description": "Process exit code: 0 = passed, 1 = failed (a required test failed), 2 = error (a test raised).",
       "type": "integer",
-      "enum": [0, 1, 2]
+      "enum": [
+        0,
+        1,
+        2
+      ]
     },
-    "summary": { "$ref": "#/$defs/summary" },
+    "summary": {
+      "$ref": "#/$defs/summary"
+    },
     "items": {
       "description": "One entry per test that ran.",
       "type": "array",
-      "items": { "$ref": "#/$defs/item" }
+      "items": {
+        "$ref": "#/$defs/item"
+      }
     }
   },
   "$defs": {
@@ -46,81 +67,246 @@
       "description": "Aggregate numbers for the run, scoped to the tests that actually ran.",
       "type": "object",
       "required": [
-        "total", "passed", "failed", "skipped", "na", "error",
-        "max_passed", "essential_passed", "essential_max_passed",
-        "points", "maximum_points"
+        "total",
+        "passed",
+        "failed",
+        "skipped",
+        "na",
+        "error",
+        "max_passed",
+        "essential_passed",
+        "essential_max_passed",
+        "points",
+        "maximum_points"
       ],
       "additionalProperties": false,
       "properties": {
-        "total": { "description": "Number of tests executed.", "type": "integer", "minimum": 0 },
-        "passed": { "type": "integer", "minimum": 0 },
-        "failed": { "type": "integer", "minimum": 0 },
-        "skipped": { "type": "integer", "minimum": 0 },
-        "na": { "type": "integer", "minimum": 0 },
-        "error": { "type": "integer", "minimum": 0 },
+        "total": {
+          "description": "Number of tests executed.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "passed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skipped": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "na": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "error": {
+          "type": "integer",
+          "minimum": 0
+        },
         "max_passed": {
           "description": "Maximum number of tests that could have passed (denominator for 'X of Y tests passed').",
           "type": "integer",
           "minimum": 0
         },
-        "essential_passed": { "type": "integer", "minimum": 0 },
-        "essential_max_passed": { "type": "integer", "minimum": 0 },
-        "points": { "description": "Total points scored.", "type": "integer" },
-        "maximum_points": { "description": "Maximum points achievable by the tests that ran.", "type": "integer" }
+        "essential_passed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "essential_max_passed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "points": {
+          "description": "Total points scored.",
+          "type": "integer"
+        },
+        "maximum_points": {
+          "description": "Maximum points achievable by the tests that ran.",
+          "type": "integer"
+        },
+        "criteria": {
+          "description": "Success criterion verdicts, one per task group that ran, in evaluation order. A group's dependencies run before its body, so the last entry is the outermost group and its verdict decides exit_code. Absent when no group with a declared criterion ran.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "group",
+              "scope",
+              "min_passed",
+              "passed_count",
+              "max_passed",
+              "failed_count",
+              "passed",
+              "min_ratio",
+              "declared_count",
+              "max_failed"
+            ],
+            "properties": {
+              "group": {
+                "description": "Task group the criterion belongs to.",
+                "type": "string"
+              },
+              "scope": {
+                "description": "points.yml tag whose tests count toward the criterion; defaults to the group name.",
+                "type": "string"
+              },
+              "min_passed": {
+                "description": "Minimum number of tests in scope that must pass.",
+                "type": "integer",
+                "minimum": 0
+              },
+              "passed_count": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "max_passed": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "failed_count": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "passed": {
+                "description": "True when the group met its criterion.",
+                "type": "boolean"
+              },
+              "min_ratio": {
+                "description": "Minimum share of the tests in scope that must pass, as a fraction of how many exist rather than how many ran. Null when the group sets no ratio.",
+                "type": [
+                  "number",
+                  "null"
+                ],
+                "minimum": 0,
+                "maximum": 1
+              },
+              "declared_count": {
+                "description": "How many tests in scope are declared, the denominator min_ratio is taken against.",
+                "type": "integer",
+                "minimum": 0
+              },
+              "max_failed": {
+                "description": "How many tests in scope may fail; null for no limit, meaning the group's other thresholds already account for failures.",
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "minimum": 0
+              }
+            }
+          }
+        }
       }
     },
     "item": {
       "description": "Result of a single test.",
       "type": "object",
-      "required": ["name", "status", "type", "points", "start_time", "end_time", "task_runtime"],
+      "required": [
+        "name",
+        "status",
+        "type",
+        "points",
+        "start_time",
+        "end_time",
+        "task_runtime"
+      ],
       "additionalProperties": false,
       "properties": {
-        "name": { "description": "Test name, e.g. privileged_containers.", "type": "string" },
+        "name": {
+          "description": "Test name, e.g. privileged_containers.",
+          "type": "string"
+        },
         "status": {
           "description": "Outcome of this test.",
-          "enum": ["passed", "failed", "skipped", "na", "error"]
+          "enum": [
+            "passed",
+            "failed",
+            "skipped",
+            "na",
+            "error"
+          ]
         },
         "message": {
           "description": "One-line verdict for the test.",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "type": {
           "description": "The test's declared type (essential, normal, bonus).",
           "type": "string"
         },
-        "points": { "description": "Points awarded for this test.", "type": "integer" },
-        "start_time": { "description": "RFC 3339 timestamp.", "type": "string" },
-        "end_time": { "description": "RFC 3339 timestamp.", "type": "string" },
-        "task_runtime": { "description": "Test duration in seconds.", "type": "number" },
+        "points": {
+          "description": "Points awarded for this test.",
+          "type": "integer"
+        },
+        "start_time": {
+          "description": "RFC 3339 timestamp.",
+          "type": "string"
+        },
+        "end_time": {
+          "description": "RFC 3339 timestamp.",
+          "type": "string"
+        },
+        "task_runtime": {
+          "description": "Test duration in seconds.",
+          "type": "number"
+        },
         "details": {
           "description": "Free-form reason/evidence strings. Present only when non-empty.",
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "remediation": {
           "description": "Guidance on how to fix the failure. Present only when non-empty.",
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "impacted_resources": {
           "description": "Structured list of offending resources. Present only when non-empty.",
           "type": "array",
-          "items": { "$ref": "#/$defs/impacted_resource" }
+          "items": {
+            "$ref": "#/$defs/impacted_resource"
+          }
         }
       }
     },
     "impacted_resource": {
       "description": "A resource that caused or participated in a test's result. Only fields that are known are recorded.",
       "type": "object",
-      "required": ["kind", "name"],
+      "required": [
+        "kind",
+        "name"
+      ],
       "additionalProperties": false,
       "properties": {
-        "kind": { "type": "string" },
-        "name": { "type": "string" },
-        "namespace": { "type": "string" },
-        "container": { "type": "string" },
-        "pod": { "type": "string" },
-        "reason": { "type": "string" }
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "container": {
+          "type": "string"
+        },
+        "pod": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        }
       }
     }
   }

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -120,34 +120,69 @@ describe "SampleUtils" do
     end
   end
 
-  it "'write_summary!' should derive the exit code from the run's pass criterion", tags: ["points"] do
+  it "'evaluate_group!' should record a verdict per group and drive the exit code", tags: ["points"] do
     results_backup = File.read(CNFManager::Points::Results.file)
     begin
-      failed_result = CNFManager::TestCaseResult.new(
-        "fake_pass_criterion_test", CNFManager::ResultStatus::Failed, "fake failure",
+      # liveness is tagged [resilience, ..., essential], so it counts toward both
+      # the resilience group and cert's essential scope.
+      failed = CNFManager::TestCaseResult.new(
+        "liveness", CNFManager::ResultStatus::Failed, "fake failure",
         [] of String, Time.utc, Time.utc)
-      CNFManager::Points.upsert_task(failed_result)
-      # Without a criterion, a failed test alone means the run missed its objective.
+      CNFManager::Points.upsert_task(failed)
+
+      # A group whose criterion allows no failures fails on that one failure.
+      result = CNFManager::Points.evaluate_group!("resilience").not_nil!
+      result.passed.should be_false
+      result.failed_count.should eq(1)
+      CNFManager::Points.write_summary!
+
+      yaml = YAML.parse(File.read(CNFManager::Points::Results.file))
+      yaml["exit_code"].as_i.should eq(1)
+      yaml["status"].as_s.should eq("failed")
+
+      # The verdict is recorded in the summary for every evaluated group.
+      criteria = yaml["summary"]["criteria"].as_a
+      entry = criteria.find { |c| c["group"].as_s == "resilience" }.not_nil!
+      entry["passed"].as_bool.should be_false
+      entry["scope"].as_s.should eq("resilience")
+      entry["failed_count"].as_i.should eq(1)
+
+      # cert sets no failure limit, so its threshold alone decides, and the scope it
+      # counts is essential rather than its own name.
+      cert = CNFManager::Points.evaluate_group!("cert").not_nil!
+      cert.max_failed.should be_nil
+      cert.scope.should eq("essential")
+      cert.min_passed.should eq(ESSENTIAL_PASSED_THRESHOLD)
+      cert.passed.should be_false # nothing passed, so the threshold is not met
+
+      # The outermost group evaluated decides the run: SAM runs dependencies
+      # before a parent's body, so the last verdict recorded is the parent's.
+      CNFManager::Points.write_summary!
       YAML.parse(File.read(CNFManager::Points::Results.file))["exit_code"].as_i.should eq(1)
 
-      # With a criterion (cert), the group is judged by that criterion alone:
-      # the same failed test no longer forces exit 1 once the threshold is met.
-      CNFManager::Points.pass_threshold = 0
+      # Once the failure is gone the same group passes and the code returns to 0.
+      CNFManager::Points.clean_results_yml
+      CNFManager::Points.clear_group_results
+      CNFManager::Points.evaluate_group!("resilience").not_nil!.passed.should be_true
       CNFManager::Points.write_summary!
       yaml = YAML.parse(File.read(CNFManager::Points::Results.file))
       yaml["exit_code"].as_i.should eq(0)
       yaml["status"].as_s.should eq("passed")
-
-      # An unmet criterion exits 1 even when no individual test failed.
-      CNFManager::Points.pass_threshold = Int32::MAX
-      CNFManager::Points.write_summary!
-      yaml = YAML.parse(File.read(CNFManager::Points::Results.file))
-      yaml["exit_code"].as_i.should eq(1)
-      yaml["status"].as_s.should eq("failed")
     ensure
-      CNFManager::Points.pass_threshold = nil
+      CNFManager::Points.clear_group_results
       File.write(CNFManager::Points::Results.file, results_backup)
     end
+  end
+
+  it "'group_criteria' should be declared for every reported group", tags: ["points"] do
+    %w[all workload platform cert compatibility state security configuration
+       observability microservice resilience].each do |group|
+      CNFManager::Points.group_criteria(group).should_not be_nil
+    end
+    # Criteria entries are configuration, not tests, so they must not leak into
+    # the test-name list that scoring denominators are built from.
+    CNFManager::Points.all_task_test_names.should_not contain("workload")
+    CNFManager::Points.all_task_test_names.should_not contain("cert")
   end
 
   it  "'task_points' should return the amount of points for a passing test", tags: ["points"] do

--- a/spec/utils/test_metadata_spec.cr
+++ b/spec/utils/test_metadata_spec.cr
@@ -7,6 +7,66 @@ require "../../src/tasks/**"
 # existing, and cannot omit its type. What remains are the few invariants that
 # span a test's declaration and something outside it.
 describe "test metadata" do
+  it "declares a criterion for every group it reports on", tags: ["points"] do
+    %w[all workload platform cert compatibility state security configuration
+       observability microservice resilience].each do |group|
+      CNFManager::Points.group_criteria(group).should_not be_nil
+    end
+  end
+
+  it "measures a ratio criterion against the tests that exist, not those that ran", tags: ["points"] do
+    # max_passed counts only the tests a run reached, and cert takes an
+    # `exclude` argument, so a ratio over it could be met by running fewer
+    # tests. The denominator is therefore how many tests carry the scope tag.
+    results_backup = File.read(CNFManager::Points::Results.file)
+    begin
+      CNFManager::Points.clean_results_yml
+      CNFManager::Points.clear_group_results
+
+      declared = CNFManager::Points.tasks_by_tag("resilience").size
+      declared.should be > 2
+
+      # One test passes out of a category of `declared`, so any ratio above
+      # 1/declared must fail no matter how few of the others ran.
+      CNFManager::Points.upsert_task(CNFManager::TestCaseResult.new(
+        "liveness", CNFManager::ResultStatus::Passed, "probe",
+        [] of String, Time.utc, Time.utc))
+
+      CNFManager::GroupRegistry.register("ratio_probe", false,
+        CNFManager::GroupCriterion.new(scope: "resilience", min_ratio: 0.9))
+      result = CNFManager::Points.evaluate_group!("ratio_probe").not_nil!
+      result.declared_count.should eq(declared)
+      result.passed_count.should eq(1)
+      result.passed.should be_false
+
+      # A ratio the single pass does clear.
+      CNFManager::GroupRegistry.register("ratio_probe", false,
+        CNFManager::GroupCriterion.new(scope: "resilience", min_ratio: 1.0 / declared))
+      CNFManager::Points.evaluate_group!("ratio_probe").not_nil!.passed.should be_true
+    ensure
+      CNFManager::GroupRegistry.unregister("ratio_probe")
+      CNFManager::Points.clear_group_results
+      File.write(CNFManager::Points::Results.file, results_backup)
+    end
+  end
+
+  it "scopes every group's criterion to tests that exist", tags: ["points"] do
+    # A criterion counts the tests carrying its scope tag, and scope defaults to
+    # the group's own name. A group whose name is not a tag therefore counts
+    # nothing, finds no failures, and passes unconditionally - silently, with no
+    # error to notice. `all` was exactly that: no test carries an "all" tag, so
+    # a run with failing tests still exited 0, which is what #2424 exists to
+    # prevent. It now scopes to every test instead.
+    CNFManager::GroupRegistry.all.each do |path, group|
+      scope = group.criterion.scope || path
+      next if scope == CNFManager::EVERY_TEST
+
+      CNFManager::Points.tasks_by_tag(scope).empty?.should be_false,
+        "'#{path}' scopes its criterion to '#{scope}', which matches no tests, " \
+        "so it can only ever pass"
+    end
+  end
+
   it "registers a task for every declared test", tags: ["points"] do
     paths = Sam.root_namespace.all_tasks.map(&.name)
     orphans = CNFManager::TestRegistry.names.reject { |name| paths.includes?(name) }
@@ -25,7 +85,7 @@ describe "test metadata" do
     deliberate_orphans = ["clusterapi_enabled"]
 
     counts = Hash(String, Int32).new(0)
-    CNFManager::TestRegistry::CATEGORY_AGGREGATES.each do |path|
+    CNFManager::GroupRegistry.category_paths.each do |path|
       aggregate = Sam.root_namespace.all_tasks.find { |task| task.path == path }
       aggregate.should_not be_nil, "no aggregate task for category '#{path}'"
       deps = aggregate.not_nil!.dependency_names

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -6,66 +6,6 @@ require "./tasks/utils/utils.cr"
 require "./cnf_testsuite.cr"
 
 
-desc "Run every workload and platform test"
-task "all", ["workload", "platform"] do  |_, args|
-  Log.debug { "all" }
-
-  total = CNFManager::Points.total_points([] of String)
-  max_points = CNFManager::Points.total_max_points([] of String)
-  total_passed = CNFManager::Points.total_passed([] of String)
-  max_passed = CNFManager::Points.total_max_passed([] of String)
-
-  final_msg = "Final score: #{total} of #{max_points} points (#{total_passed} of #{max_passed} tests passed)"
-  if total > 0
-    stdout_success final_msg
-  else
-    stdout_failure final_msg
-  end
-
-  if CNFManager::Points.failed_required_tasks.size > 0
-    stdout_failure "Test Suite failed!"
-    stdout_failure "Failed required tasks: #{CNFManager::Points.failed_required_tasks.inspect}"
-    yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
-      YAML.parse(file)
-    end
-
-    if (yaml["exit_code"]) != 2
-      update_yml("#{CNFManager::Points::Results.file}", "exit_code", "1")
-    end
-  end
-  CNFManager::Points.write_summary!
-  stdout_info "Test results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-end
-
-desc "Run every workload test against the installed CNF"
-task "workload", ["compatibility","state", "security", "configuration", "observability", "microservice", "resilience"] do  |_, args|
-  Log.debug { "workload" }
-
-  total = CNFManager::Points.total_points("workload")
-  max_points = CNFManager::Points.total_max_points("workload")
-  total_passed = CNFManager::Points.total_passed("workload")
-  max_passed = CNFManager::Points.total_max_passed("workload")
-  final_msg = "Final workload score: #{total} of #{max_points} points (#{total_passed} of #{max_passed} tests passed)"
-  if total > 0
-    stdout_success final_msg
-  else
-    stdout_failure final_msg
-  end
-
-  if CNFManager::Points.failed_required_tasks.size > 0
-    stdout_failure "Test Suite failed!"
-    stdout_failure "Failed required tasks: #{CNFManager::Points.failed_required_tasks.inspect}"
-    yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
-      YAML.parse(file)
-    end
-    if (yaml["exit_code"]) != 2
-      update_yml("#{CNFManager::Points::Results.file}", "exit_code", "1")
-    end
-  end
-  CNFManager::Points.write_summary!
-  stdout_info "Test results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-end
-
 desc "Makes sure a cnf is in the cnf directory"
 task "ensure_cnf_installed" do |_, args|
   CNFManager::Task.ensure_cnf_installed!

--- a/src/tasks/cert/cert.cr
+++ b/src/tasks/cert/cert.cr
@@ -5,14 +5,13 @@ require "colorize"
 require "totem"
 require "../utils/utils.cr"
 
-desc "The CNF Test Suite program certifies a CNF based on passing some percentage of essential tests."
-task "cert", ["version", "cert_compatibility", "cert_state", "cert_security", "cert_configuration", "cert_observability", "cert_microservice", "cert_resilience"] do  |_, args|
+desc "Run the certification tests; exits 0 when the CNF is certified"
+suite_task "cert", ["version", "cert_compatibility", "cert_state", "cert_security", "cert_configuration", "cert_observability", "cert_microservice", "cert_resilience"],
+  scope: "essential",
+  min_passed: ESSENTIAL_PASSED_THRESHOLD,
+  max_failed: CNFManager::NO_FAILURE_LIMIT,
+  summary: false do  |_, args|
   Log.debug { "cert" }
-
-  # `cert` is judged by its certification criterion rather than by individual
-  # test failures, so the run exits 0 exactly when the CNF is certified.
-  # See Points.write_summary! for the derivation.
-  CNFManager::Points.pass_threshold = ESSENTIAL_PASSED_THRESHOLD
 
   stdout_success "RESULTS SUMMARY"
   total = CNFManager::Points.total_points("cert")
@@ -28,9 +27,6 @@ task "cert", ["version", "cert_compatibility", "cert_state", "cert_security", "c
     stdout_success "  - #{essential_total_passed} of #{essential_max_passed} essential tests passed"
   else
     stdout_failure "  - #{essential_total_passed} of #{essential_max_passed} essential tests passed"
-    stdout_failure "Certification failed! Passing threshold is #{ESSENTIAL_PASSED_THRESHOLD} essential tests"
   end
 
-  CNFManager::Points.write_summary!
-  stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
 end

--- a/src/tasks/platform/hardware_and_scheduling.cr
+++ b/src/tasks/platform/hardware_and_scheduling.cr
@@ -5,12 +5,7 @@ require "../utils/utils.cr"
 
 namespace "platform" do
   desc "The CNF container should access all hardware and schedule to specific worker nodes by using a device plugin."
-  task "hardware_and_scheduling", ["oci_compliant"] do |t, args|
-    Log.debug { "hardware_and_scheduling" }
-    Log.trace { "hardware_and_scheduling args.raw: #{args.raw}" }
-    Log.trace { "hardware_and_scheduling args.named: #{args.named}" }
-    stdout_score("platform:hardware_and_scheduling")
-  end
+  category_task "hardware_and_scheduling", ["oci_compliant"]
 
   desc "Does the Platform use a runtime that is oci compliant"
   scored_task "oci_compliant",

--- a/src/tasks/platform/observability.cr
+++ b/src/tasks/platform/observability.cr
@@ -7,12 +7,7 @@ require "../../modules/k8s_kernel_introspection"
 
 namespace "platform" do
   desc "The CNF test suite checks to see if the Platform has Observability support."
-  task "observability", ["kube_state_metrics", "node_exporter", "prometheus_adapter", "metrics_server"] do |t, args|
-    Log.debug { "observability" }
-    Log.trace { "observability args.raw: #{args.raw}" }
-    Log.trace { "observability args.named: #{args.named}" }
-    stdout_score("platform:observability")
-  end
+  category_task "observability", ["kube_state_metrics", "node_exporter", "prometheus_adapter", "metrics_server"]
 
   desc "Does the Platform have Kube State Metrics installed"
   scored_task "kube_state_metrics",

--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -1,27 +1,6 @@
 # coding: utf-8
 desc "Run every test against the Kubernetes platform itself, rather than the CNF"
-task "platform", ["setup:install_local_helm", "platform:k8s_conformance", "platform:observability", "platform:resilience", "platform:hardware_and_scheduling", "platform:security"]  do |_, args|
-  Log.debug { "platform" }
-
-  total = CNFManager::Points.total_points("platform")
-  max_points = CNFManager::Points.total_max_points("platform")
-  total_passed = CNFManager::Points.total_passed("platform")
-  max_passed = CNFManager::Points.total_max_passed("platform")
-  final_msg = "Final platform score: #{total} of #{max_points} points (#{total_passed} of #{max_passed} tests passed)"
-  if total > 0
-    stdout_success final_msg
-  else
-    stdout_failure final_msg
-  end
-
-  if CNFManager::Points.failed_required_tasks.size > 0
-    stdout_failure "Test Suite failed!"
-    stdout_failure "Failed required tasks: #{CNFManager::Points.failed_required_tasks.inspect}"
-    update_yml("#{CNFManager::Points::Results.file}", "exit_code", "1")
-  end
-  CNFManager::Points.write_summary!
-  stdout_info "Test results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-end
+suite_task "platform", ["setup:install_local_helm", "platform:k8s_conformance", "platform:observability", "platform:resilience", "platform:hardware_and_scheduling", "platform:security"]
 
 # These two moved into the platform namespace; the old names keep working.
 alias_task "k8s_conformance", "platform:k8s_conformance"

--- a/src/tasks/platform/resilience.cr
+++ b/src/tasks/platform/resilience.cr
@@ -5,12 +5,7 @@ require "../utils/utils.cr"
 
 namespace "platform" do
   desc "The CNF test suite checks to see if the CNFs are resilient to failures."
-  task "resilience", ["worker_reboot_recovery"] do |t, args|
-    Log.debug { "resilience" }
-    Log.trace { "resilience args.raw: #{args.raw}" }
-    Log.trace { "resilience args.named: #{args.named}" }
-    stdout_score("platform:resilience")
-  end
+  category_task "resilience", ["worker_reboot_recovery"]
 
   desc "Does the Platform recover the node and reschedule pods when a worker node fails"
   scored_task "worker_reboot_recovery" do |t, args|

--- a/src/tasks/platform/security.cr
+++ b/src/tasks/platform/security.cr
@@ -6,10 +6,7 @@ require "yaml"
 
 namespace "platform" do
   desc "The CNF test suite checks to see if the platform is hardened."
-  task "security", ["control_plane_hardening", "cluster_admin", "helm_tiller", "verify_configmaps_encryption", "verify_secrets_encryption"] do |t, args|
-    Log.debug { "security" }
-    stdout_score("platform:security")
-  end
+  category_task "security", ["control_plane_hardening", "cluster_admin", "helm_tiller", "verify_configmaps_encryption", "verify_secrets_encryption"]
 
   desc "Is the platform control plane hardened"
   scored_task "control_plane_hardening",

--- a/src/tasks/suites.cr
+++ b/src/tasks/suites.cr
@@ -1,0 +1,14 @@
+require "sam"
+require "colorize"
+require "./utils/utils.cr"
+
+# `all` has no tag of its own - no test carries one - so its criterion and its
+# score cover every test that ran rather than a tag's worth.
+desc "Run every workload and platform test"
+suite_task "all", ["workload", "platform"],
+  title: "",
+  scope: CNFManager::EVERY_TEST
+
+desc "Run every workload test against the installed CNF"
+suite_task "workload", ["compatibility", "state", "security", "configuration",
+                        "observability", "microservice", "resilience"]

--- a/src/tasks/utils/cnf_manager/points.cr
+++ b/src/tasks/utils/cnf_manager/points.cr
@@ -178,17 +178,96 @@ module CNFManager
       end
     end
 
-    # Pass criteria for the running task group, when it has one. `cert` sets the
-    # essential-test threshold it certifies against; runs without a criterion
-    # (all/workload/platform) leave this nil and fall back to "no test failed".
-    @@pass_threshold : Int32? = nil
+    # The evaluated success criterion of one task group.
+    record GroupResult,
+      group : String,
+      scope : String,
+      min_passed : Int32,
+      min_ratio : Float64?,
+      declared_count : Int32,
+      max_failed : Int32?,
+      passed_count : Int32,
+      max_passed : Int32,
+      failed_count : Int32,
+      passed : Bool
 
-    def self.pass_threshold : Int32?
-      @@pass_threshold
+    # Groups evaluated so far, in evaluation order. SAM runs a task's
+    # dependencies before its body, so a group is always recorded after the
+    # groups nested inside it: the last entry is the outermost group, and its
+    # verdict is the run's.
+    @@group_results = [] of GroupResult
+
+    def self.group_results : Array(GroupResult)
+      @@group_results
     end
 
-    def self.pass_threshold=(threshold : Int32?)
-      @@pass_threshold = threshold
+    def self.clear_group_results
+      @@group_results.clear
+    end
+
+    def self.group_criteria(group : String) : CNFManager::GroupCriterion?
+      CNFManager::GroupRegistry.criterion_for(group)
+    end
+
+    # Evaluates `group` against its criterion and records the verdict. Called by
+    # each group's task once its members have run.
+    def self.evaluate_group!(group : String) : GroupResult?
+      criteria = group_criteria(group)
+      return nil if criteria.nil?
+
+      scope = criteria.scope || group
+      min_passed = criteria.min_passed
+      max_failed = criteria.max_failed
+
+      if scope == CNFManager::EVERY_TEST
+        passed_count = total_passed([] of String)
+        max_passed = total_max_passed([] of String)
+        failed_count = failed_count_for(nil)
+      else
+        passed_count = total_passed(scope)
+        max_passed = total_max_passed(scope)
+        failed_count = failed_count_for(scope)
+      end
+
+      # The ratio is taken against the tests that exist in scope, not the ones
+      # this run reached: max_passed shrinks when tests are excluded, and cert
+      # takes an `exclude` argument, so a ratio over it could be satisfied by
+      # running fewer tests.
+      declared_count = scope == CNFManager::EVERY_TEST ? all_task_test_names.size : tasks_by_tag(scope).size
+      ratio = criteria.min_ratio
+
+      passed = passed_count >= min_passed
+      if ratio
+        # An empty scope would make the ratio vacuously true - the same trap as
+        # a criterion scoped to a tag no test carries - so fail instead.
+        passed = passed && declared_count > 0 && (passed_count.to_f / declared_count) >= ratio
+      end
+      passed = passed && failed_count <= max_failed if max_failed
+
+      result = GroupResult.new(group: group, scope: scope, min_passed: min_passed,
+                               min_ratio: ratio, declared_count: declared_count,
+                               max_failed: max_failed, passed_count: passed_count,
+                               max_passed: max_passed, failed_count: failed_count,
+                               passed: passed)
+      @@group_results.reject! { |existing| existing.group == group }
+      @@group_results << result
+      result
+    end
+
+    # Number of recorded items that failed. With a scope, only the tests carrying
+    # that tag count; with nil, every recorded item does.
+    def self.failed_count_for(scope : String?) : Int32
+      scoped = scope ? tasks_by_tag(scope) : nil
+      return 0 if scoped && scoped.empty?
+
+      yaml = File.open("#{Results.file}") { |file| YAML.parse(file) }
+      items = yaml["items"]?.try(&.as_a?) || [] of YAML::Any
+      items.count do |item|
+        name = item["name"]?.try(&.as_s?)
+        next false unless name
+        next false if scoped && !scoped.includes?(name)
+        item["status"]?.try(&.as_s?) == "failed"
+      end
     end
 
     def self.create_final_results_yml_name
@@ -508,8 +587,8 @@ module CNFManager
       exit_code =
         if error > 0
           2
-        elsif threshold = @@pass_threshold
-          essential_passed >= threshold ? 0 : 1
+        elsif outermost = @@group_results.last?
+          outermost.passed ? 0 : 1
         else
           failed > 0 ? 1 : 0
         end
@@ -518,10 +597,27 @@ module CNFManager
       # 0 -> passed, 2 -> error (critical), anything else (1) -> failed.
       run_status = exit_code == 0 ? "passed" : (exit_code == 2 ? "error" : "failed")
 
+      summary_yaml = YAML.parse(summary.to_yaml)
+      unless @@group_results.empty?
+        criteria = @@group_results.map do |result|
+          {group:          result.group,
+           scope:          result.scope,
+           min_passed:     result.min_passed,
+           min_ratio:      result.min_ratio,
+           declared_count: result.declared_count,
+           max_failed:     result.max_failed,
+           passed_count:   result.passed_count,
+           max_passed:     result.max_passed,
+           failed_count:   result.failed_count,
+           passed:         result.passed}
+        end
+        summary_yaml.as_h[YAML::Any.new("criteria")] = YAML.parse(criteria.to_yaml)
+      end
+
       merged = results.as_h
       merged[YAML::Any.new("exit_code")] = YAML::Any.new(exit_code.to_i64)
       merged[YAML::Any.new("status")] = YAML::Any.new(run_status)
-      merged[YAML::Any.new("summary")] = YAML.parse(summary.to_yaml)
+      merged[YAML::Any.new("summary")] = summary_yaml
       File.open("#{Results.file}", "w") { |f| YAML.dump(merged, f) }
     end
 

--- a/src/tasks/utils/group_task.cr
+++ b/src/tasks/utils/group_task.cr
@@ -1,0 +1,202 @@
+require "sam"
+
+module CNFManager
+  # The criterion a task group passes by.
+  #
+  #   scope           tag whose tests count; defaults to the group's own name
+  #   min_passed      minimum number of those tests that must pass
+  #   min_ratio       minimum share of the tests in scope that must pass, as a
+  #                   fraction of how many *exist* rather than how many ran. The
+  #                   run's own max_passed would shrink when tests are excluded -
+  #                   and cert takes an `exclude` argument - so a ratio over it
+  #                   could be met by running less. Counting against the declared
+  #                   set means a skipped test counts against you, which for a
+  #                   certification bar is the honest reading: not verified is
+  #                   not passed.
+  #   max_failed      how many tests in scope may fail; nil for no limit, which
+  #                   is how a group says its other thresholds already account
+  #                   for failures rather than treating them as a separate mode
+  #
+  # All three are thresholds and all are cumulative: every one must hold.
+  #
+  # The defaults - no floor, no failures tolerated - mean "nothing in this group
+  # failed", which is what these groups have always demanded. Only a group with
+  # a real policy decision says anything, and today that is only cert.
+  #
+  # EVERY_TEST is for a group whose members are not identified by a tag of their
+  # own. `all` is the case: no test carries an "all" tag, so scoping its
+  # criterion to its own name counted nothing at all and made it pass whatever
+  # happened underneath it.
+  record GroupCriterion,
+    scope : String? = nil,
+    min_passed : Int32 = 0,
+    min_ratio : Float64? = nil,
+    max_failed : Int32? = 0
+
+  # Scope covering every test that ran, rather than those carrying one tag.
+  EVERY_TEST = ""
+
+  # max_failed value meaning "no limit". Spelled out rather than left as a bare
+  # nil, because nil is also what an unset min_ratio looks like: `max_failed:
+  # nil` could be misread as "unset, so the default applies", which is the
+  # opposite of what it means.
+  NO_FAILURE_LIMIT = nil
+
+  # Every task group, registered as its task is defined. A category runs tests
+  # and gives them their category; a suite runs other groups.
+  module GroupRegistry
+    record Group,
+      path : String,
+      category : Bool,
+      criterion : GroupCriterion
+
+    @@groups = {} of String => Group
+
+    def self.register(path : String, category : Bool, criterion : GroupCriterion)
+      @@groups[path] = Group.new(path: path, category: category, criterion: criterion)
+    end
+
+    def self.all : Hash(String, Group)
+      @@groups
+    end
+
+    # Only specs use this, to evaluate a criterion without leaving a group
+    # behind that the guards would then check.
+    def self.unregister(path : String)
+      @@groups.delete(path)
+    end
+
+    def self.[]?(path : String) : Group?
+      @@groups[path]?
+    end
+
+    def self.criterion_for(path : String) : GroupCriterion?
+      @@groups[path]?.try(&.criterion)
+    end
+
+    # The groups that give a test its category. Derived from what registered,
+    # so adding a category is one declaration rather than a declaration plus an
+    # entry in a list that can silently disagree with it.
+    def self.category_paths : Array(String)
+      @@groups.select { |_, group| group.category }.keys
+    end
+  end
+end
+
+# Declares a task group: the task, the criterion it passes by, and the verdict
+# it reports. Mixed into both the top level and Sam::Namespace so that `task`
+# registers in the right place, and so a group inside a namespace knows its own
+# full path.
+module GroupTaskDSL
+  def group_path_prefix : String
+    ""
+  end
+
+  # A group of tests. Its name is also the tag its members carry, and running it
+  # is what gives those members their category. `title` is the heading the score
+  # is reported under when it differs from the group's own name.
+  def category_task(
+    name : String,
+    deps : Array(String) = [] of String,
+    title : String? = nil,
+    scope : String? = nil,
+    min_passed : Int32 = 0,
+    min_ratio : Float64? = nil,
+    max_failed : Int32? = 0
+  )
+    register_group(name, true, deps, title, true, scope, min_passed, min_ratio, max_failed) { }
+  end
+
+  def category_task(
+    name : String,
+    deps : Array(String) = [] of String,
+    title : String? = nil,
+    scope : String? = nil,
+    min_passed : Int32 = 0,
+    min_ratio : Float64? = nil,
+    max_failed : Int32? = 0,
+    &block : Sam::Task, Sam::Args -> Void
+  )
+    register_group(name, true, deps, title, true, scope, min_passed, min_ratio, max_failed, &block)
+  end
+
+  # A group of other groups: all, workload, platform, cert. `summary` is false
+  # for a group that reports its score itself, which only cert does.
+  def suite_task(
+    name : String,
+    deps : Array(String) = [] of String,
+    title : String? = nil,
+    summary : Bool = true,
+    scope : String? = nil,
+    min_passed : Int32 = 0,
+    min_ratio : Float64? = nil,
+    max_failed : Int32? = 0
+  )
+    register_group(name, false, deps, title, summary, scope, min_passed, min_ratio, max_failed) { }
+  end
+
+  def suite_task(
+    name : String,
+    deps : Array(String) = [] of String,
+    title : String? = nil,
+    summary : Bool = true,
+    scope : String? = nil,
+    min_passed : Int32 = 0,
+    min_ratio : Float64? = nil,
+    max_failed : Int32? = 0,
+    &block : Sam::Task, Sam::Args -> Void
+  )
+    register_group(name, false, deps, title, summary, scope, min_passed, min_ratio, max_failed, &block)
+  end
+
+  private def register_group(
+    name : String,
+    category : Bool,
+    deps : Array(String),
+    title : String?,
+    summary : Bool,
+    scope : String?,
+    min_passed : Int32,
+    min_ratio : Float64?,
+    max_failed : Int32?,
+    &block : Sam::Task, Sam::Args -> Void
+  )
+    path = "#{group_path_prefix}#{name}"
+    criterion = CNFManager::GroupCriterion.new(scope: scope, min_passed: min_passed,
+                                               min_ratio: min_ratio,
+                                               max_failed: max_failed)
+    CNFManager::GroupRegistry.register(path, category, criterion)
+
+    task(name, deps) do |t, args|
+      Log.for(path).debug { "#{path} args: #{args.raw}" }
+      block.call(t, args)
+
+      # Reporting used to be copied into every group's body. The verdict in
+      # particular was keyed by the group's *display* name there, so the three
+      # groups whose display name differs from their own - compatibility,
+      # resilience, observability - looked up a criterion that did not exist and
+      # silently reported nothing.
+      if summary
+        if category
+          stdout_score(path, title || path)
+        else
+          stdout_suite_score(path, title || path, criterion)
+        end
+      end
+      stdout_group_verdict(path)
+      stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green) if invoked_task?(name)
+    end
+  end
+end
+
+class Sam::Namespace
+  include GroupTaskDSL
+
+  # Defined after the include so it wins: a group inside `namespace "platform"`
+  # is platform:<name>, which is the path its criterion and members are keyed by.
+  def group_path_prefix : String
+    path
+  end
+end
+
+include GroupTaskDSL

--- a/src/tasks/utils/test_metadata.cr
+++ b/src/tasks/utils/test_metadata.cr
@@ -59,16 +59,6 @@ module CNFManager
 
   # Every test, registered as its task is defined.
   module TestRegistry
-    # The aggregates that define a category. A test's category is whichever of
-    # these runs it, so membership is stated once - in the aggregate's own
-    # dependency list - rather than on the test as well.
-    CATEGORY_AGGREGATES = %w[
-      compatibility state security configuration observability microservice
-      resilience 5g ran
-      platform:security platform:observability platform:resilience
-      platform:hardware_and_scheduling
-    ]
-
     @@tests = {} of String => TestMetadata
     @@category_of : Hash(String, String)? = nil
 
@@ -89,12 +79,14 @@ module CNFManager
       @@tests.keys
     end
 
-    # test name => the category aggregate that runs it. Built from the task
-    # graph, so a test cannot claim a category that never runs it.
+    # test name => the category group that runs it. Both halves are derived:
+    # which groups are categories comes from their own declaration, and which
+    # tests they run comes from the task graph. A test cannot claim a category
+    # that never runs it, and a category cannot be forgotten from a list.
     def self.category_of : Hash(String, String)
       @@category_of ||= begin
         mapping = {} of String => String
-        CATEGORY_AGGREGATES.each do |path|
+        CNFManager::GroupRegistry.category_paths.each do |path|
           aggregate = Sam.root_namespace.all_tasks.find { |task| task.path == path }
           next unless aggregate
           aggregate.dependency_names.each do |dep|

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -344,6 +344,60 @@ STRING
   else
     stdout_failure test_log_msg
   end
+
+end
+
+# Prints the success-criterion verdict for a group, when it declares one.
+# Kept in a stable "<Group>: PASSED|FAILED (reason)" shape so CI can grep it.
+# The "Final <name> score" line the top-level suites report. A suite whose
+# criterion covers every test scores over the whole run rather than one tag.
+def stdout_suite_score(path : String, title : String, criterion : CNFManager::GroupCriterion)
+  scope = criterion.scope == CNFManager::EVERY_TEST ? [] of String : [path]
+  total = CNFManager::Points.total_points(scope)
+  max_points = CNFManager::Points.total_max_points(scope)
+  total_passed = CNFManager::Points.total_passed(scope)
+  max_passed = CNFManager::Points.total_max_passed(scope)
+  CNFManager::Points.write_summary!
+
+  msg = "Final #{title} score: #{total} of #{max_points} points " \
+        "(#{total_passed} of #{max_passed} tests passed)"
+  total > 0 ? stdout_success(msg) : stdout_failure(msg)
+end
+
+def stdout_group_verdict(group : String)
+  result = CNFManager::Points.evaluate_group!(group)
+  return unless result
+  CNFManager::Points.write_summary!
+
+  pretty = group.split(/:|_/).map(&.capitalize).join(" ")
+  # Name whichever threshold is binding, so a verdict says why rather than just
+  # what.
+  ratio_shortfall = result.min_ratio && result.declared_count > 0 &&
+                    (result.passed_count.to_f / result.declared_count) < result.min_ratio.not_nil!
+  reason =
+    if (limit = result.max_failed) && result.failed_count > limit
+      "#{result.failed_count} of #{result.passed_count + result.failed_count} tests failed"
+    elsif ratio_shortfall
+      "#{result.passed_count} of #{result.declared_count} #{result.scope} tests passed, " \
+      "threshold #{(result.min_ratio.not_nil! * 100).round(1)}%"
+    elsif result.passed_count < result.min_passed
+      "#{result.passed_count} of #{result.declared_count} #{result.scope} tests passed, " \
+      "threshold #{result.min_passed}"
+    elsif result.min_passed > 0
+      "#{result.passed_count} of #{result.declared_count} #{result.scope} tests passed, " \
+      "threshold #{result.min_passed}"
+    elsif result.min_ratio
+      "#{result.passed_count} of #{result.declared_count} #{result.scope} tests passed, " \
+      "threshold #{(result.min_ratio.not_nil! * 100).round(1)}%"
+    else
+      "no tests failed"
+    end
+
+  if result.passed
+    stdout_success "#{pretty}: PASSED (#{reason})"
+  else
+    stdout_failure "#{pretty}: FAILED (#{reason})"
+  end
 end
 
 # this method extracts a string value from a config section if it exists

--- a/src/tasks/workload/5g_validator.cr
+++ b/src/tasks/workload/5g_validator.cr
@@ -6,12 +6,7 @@ require "totem"
 require "../utils/utils.cr"
 
 desc "The CNF test suite checks to see if 5g CNFs follow cloud native principles"
-task "5g", ["smf_upf_core_validator", "smf_upf_heartbeat", "suci_enabled"] do |_, args|
-  stdout_score("5g")
-  if invoked_task?("5g")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
-end
+category_task "5g", ["smf_upf_core_validator", "smf_upf_heartbeat", "suci_enabled"]
 
 desc "Test if a 5G core is valid"
 scored_task "smf_upf_core_validator" do |t, args|

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -8,13 +8,8 @@ require "../utils/utils.cr"
 
 
 desc "The CNF test suite checks to see if CNFs support horizontal scaling (across multiple machines) and vertical scaling (between sizes of machines) by using the native K8s kubectl"
-task "compatibility", ["helm_chart_valid", "helm_chart_published", "helm_deploy", "cni_compatible", "increase_decrease_capacity", "rollback", "deprecated_k8s_features"].concat(ROLLING_VERSION_CHANGE_TEST_NAMES) do |_, args|
-  stdout_score("compatibility", "Compatibility, Installability, and Upgradeability")
-  if invoked_task?("compatibility")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
-
-end
+category_task "compatibility", ["helm_chart_valid", "helm_chart_published", "helm_deploy", "cni_compatible", "increase_decrease_capacity", "rollback", "deprecated_k8s_features"].concat(ROLLING_VERSION_CHANGE_TEST_NAMES),
+  title: "Compatibility, Installability, and Upgradeability"
 ROLLING_VERSION_CHANGE_TEST_NAMES.each do |tn|
   pretty_test_name = tn.split(/:|_/).join(" ")
   pretty_test_name_capitalized = tn.split(/:|_/).map(&.capitalize).join(" ")

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -10,7 +10,7 @@ rolling_version_change_test_names = ["rolling_update", "rolling_downgrade", "rol
 
 desc "Configuration should be managed in a declarative manner, using ConfigMaps, Operators, or other declarative interfaces."
 
-task "configuration", [
+category_task "configuration", [
     "nodeport_not_used",
     "hostport_not_used",
     "hardcoded_ip_addresses_in_k8s_runtime_configuration",
@@ -22,12 +22,7 @@ task "configuration", [
     "default_namespace",
     "operator_installed",
     "versioned_tag"
-  ] do |_, args|
-  stdout_score("configuration", "configuration")
-  if invoked_task?("configuration")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
-end
+  ]
 
 desc "Check if the CNF is running containers with labels configured?"
 scored_task "require_labels",

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -12,12 +12,7 @@ require "../../modules/k8s_kernel_introspection"
 require "../utils/utils.cr"
 
 desc "The CNF test suite checks to see if CNFs follows microservice principles"
-task "microservice", ["reasonable_image_size", "reasonable_startup_time", "single_process_type", "service_discovery", "shared_database", "specialized_init_system", "sig_term_handled", "zombie_handled"] do |_, args|
-  stdout_score("microservice")
-  if invoked_task?("microservice")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
-end
+category_task "microservice", ["reasonable_image_size", "reasonable_startup_time", "single_process_type", "service_discovery", "shared_database", "specialized_init_system", "sig_term_handled", "zombie_handled"]
 
 REASONABLE_STARTUP_BUFFER = 10.0
 STRACE_WAIT_BUFFER = 3

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -8,12 +8,8 @@ require "../../modules/k8s_kernel_introspection"
 require "../utils/utils.cr"
 
 desc "In order to maintain, debug, and have insight into a protected environment, its infrastructure elements must have the property of being observable. This means these elements must externalize their internal states in some way that lends itself to metrics, tracing, and logging."
-task "observability", ["log_output", "prometheus_traffic", "open_metrics", "routed_logs", "tracing"] do |_, args|
-  stdout_score("observability", "Observability and Diagnostics")
-  if invoked_task?("observability")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
-end
+category_task "observability", ["log_output", "prometheus_traffic", "open_metrics", "routed_logs", "tracing"],
+  title: "Observability and Diagnostics"
 
 desc "Check if the CNF outputs logs to stdout or stderr"
 scored_task "log_output",

--- a/src/tasks/workload/ran.cr
+++ b/src/tasks/workload/ran.cr
@@ -6,12 +6,7 @@ require "totem"
 require "../utils/utils.cr"
 
 desc "The CNF test suite checks to see if RAN CNFs follow cloud native principles"
-task "ran", ["oran_e2_connection"] do |_, args|
-  stdout_score("ran")
-  if invoked_task?("ran")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
-end
+category_task "ran", ["oran_e2_connection"]
 desc "Test if RAN uses the ORAN e2 interface"
 scored_task "oran_e2_connection" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -5,7 +5,7 @@ require "colorize"
 require "../utils/utils.cr"
 
 desc "The CNF test suite checks to see if the CNFs are resilient to failures."
- task "resilience", [
+category_task "resilience", [
    "pod_network_latency",
    "pod_network_corruption",
    "disk_fill",
@@ -16,15 +16,8 @@ desc "The CNF test suite checks to see if the CNFs are resilient to failures."
    "pod_network_duplication",
    "liveness",
    "readiness"
-  ] do |t, args|
-  Log.debug { "resilience" }
-  Log.trace { "resilience args.raw: #{args.raw}" }
-  Log.trace { "resilience args.named: #{args.named}" }
-  stdout_score("resilience", "Reliability, Resilience, and Availability")
-  if invoked_task?("resilience")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
-end
+  ],
+  title: "Reliability, Resilience, and Availability"
 
 def run_probe_task(t, args, probe_type : String)
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -6,7 +6,7 @@ require "totem"
 require "../utils/utils.cr"
 
 desc "CNF containers should be isolated from one another and the host.  The CNF Test suite uses tools like Sysdig Inspect and gVisor"
-task "security", [
+category_task "security", [
     "symlink_file_system",
     "privilege_escalation",
     "insecure_capabilities",
@@ -26,12 +26,7 @@ task "security", [
     "host_network",
     "service_account_mapping",
     "application_credentials"
-  ] do |_, args|
-  stdout_score("security")
-  if invoked_task?("security")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
-end
+  ]
 
 desc "Check if pods in the CNF use sysctls with restricted values"
 scored_task "sysctls",

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -7,12 +7,7 @@ require "../utils/utils.cr"
 require "../../modules/kubectl_client"
 
 desc "The CNF test suite checks if state is stored in a custom resource definition or a separate database (e.g. etcd) rather than requiring local storage.  It also checks to see if state is resilient to node failure"
-task "state", ["no_local_volume_configuration", "elastic_volumes", "database_persistence", "node_drain"] do |_, args|
-  stdout_score("state")
-  if invoked_task?("state")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
-end
+category_task "state", ["no_local_volume_configuration", "elastic_volumes", "database_persistence", "node_drain"]
 
 ELASTIC_PROVISIONING_DRIVERS_REGEX = /kubernetes.io\/aws-ebs|kubernetes.io\/azure-file|kubernetes.io\/azure-disk|kubernetes.io\/cinder|kubernetes.io\/gce-pd|kubernetes.io\/glusterfs|kubernetes.io\/quobyte|kubernetes.io\/rbd|kubernetes.io\/vsphere-volume|kubernetes.io\/portworx-volume|kubernetes.io\/scaleio|kubernetes.io\/storageos|rook-ceph.rbd.csi.ceph.com/
 


### PR DESCRIPTION
## Core of the change

`cert` was the only group that knew whether it had passed. Every other group printed a score and left the reader to interpret it — nothing about pass or fail was machine-readable per group. **A group now declares its own pass criterion and reports its own verdict.**

```crystal
category_task "state", ["no_local_volume_configuration", "elastic_volumes",
                        "database_persistence", "node_drain"]

suite_task "cert", [...],
  scope: "essential",     # whose tests count
  min_passed: 15,         # how many must pass
  max_failed: CNFManager::NO_FAILURE_LIMIT   # the threshold accounts for failures
```

## Architecture

**A criterion is a set of cumulative thresholds** — every one declared must hold:

| threshold | default | meaning |
|---|---|---|
| `min_passed` | `0` | at least this many tests in scope passed |
| `min_ratio` | none | at least this share of the tests that **exist** in scope passed |
| `max_failed` | `0` | at most this many failed; `NO_FAILURE_LIMIT` for no limit |

Defaults mean *"nothing in this group failed"*, which is what every group has always demanded. Only `cert` declares otherwise.

Note `max_failed` is the one threshold that defaults to a *constraint* rather than to "unset". If it defaulted to no-limit, a group declaring nothing would have no criteria at all and pass unconditionally — the `all` bug below, generalised to every group.

`min_ratio` counts against how many tests are **declared** in scope, not how many a run reached: `max_passed` shrinks when tests are excluded, and `cert` takes an `exclude` argument, so a ratio over it could be met by running less.

**Declaring at the group, not centrally, is what makes the verdict reliable.** `category_task`/`suite_task` register the group and emit its verdict, so a group cannot exist without one. The same declaration says whether a group is a *category* or a *suite* — which is where a test's category comes from, replacing the hand-maintained list #2448 introduced.

## Two bugs this fixes

- **Three groups reported nothing.** The verdict used to be emitted from `stdout_score` keyed by the group's *display* name, so `compatibility`, `resilience` and `observability` looked up a criterion that did not exist and silently said nothing.
- **`all` always passed.** No test carries an `all` tag, so scoping its criterion to its own name counted zero tests, found zero failures, and passed unconditionally — and `all` is the outermost group of an `all` run, so **a run with failing tests exited 0**, exactly what #2424 exists to prevent. A criterion can now be scoped to every test that ran, and `all` is declared that way. A spec guards it: a criterion whose scope matches no tests fails CI.

## Both surfaces

stdout, in a stable greppable shape, naming whichever threshold is binding:

```
Security: FAILED (2 of 19 tests failed)
Certification: PASSED (17 of 19 essential tests passed, threshold 15)
```

and `summary.criteria` in the results file, one entry per group in evaluation order. Dependencies run before a parent's body, so the **last entry is the outermost group** and `exit_code` follows its verdict — keeping #2424's contract while making the objective explicit per group.

## Also

- Every group's body was the same three lines of reporting copied 17 times; the DSL does it now, so most groups are pure declarations. `suites.cr` went from 38 lines to two.
- `all` and `workload` move out of `src/cnf-testsuite.cr` into `src/tasks/suites.cr` — they are suites like `platform` and `cert`, and defining two of the four in the entry point meant they registered only when the binary ran.
- `cert`'s description no longer claims "some percentage of essential tests"; the criterion is a fixed count.

## Verification

- `crystal spec --tag points` — 39 examples, 0 failures.
- The scope guard verified by reverting `all` to its broken scope: it fails with the group, the scope, and why.
- A real run's `summary.criteria` validates against the updated JSON schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


