### PR TITLE
Send logs to stderr and keep stdout for results

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -161,6 +161,15 @@ Each `impacted_resources` entry has `kind` and `name`, plus optional `namespace`
 - **LOG_LEVEL** environment variable: sets minimal log level to display: error (default); info; debug.
 - **LOG_PATH** environment variable: if set - all logs would be appended to the file defined by that variable.
 
+#### Output streams
+
+Result lines, scores and summaries are the suite's output and go to **stdout**; log messages are
+diagnostics and go to **stderr** (or to the `LOG_PATH` file when set). This means
+`./cnf-testsuite <test> > results.txt 2> debug.log` cleanly separates the two even with
+`LOG_LEVEL=debug`. When capturing the streams separately, their relative ordering is not
+guaranteed — merge them with `2>&1` if strict interleaving matters. Cursor-control progress
+rewrites and colors are only emitted when stdout is a terminal.
+
 ---
 
 ### Common Example Commands

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -29,7 +29,6 @@ task "all", ["workload", "platform"] do  |_, args|
       YAML.parse(file)
     end
 
-    Log.debug { "results yaml: #{yaml}" }
     if (yaml["exit_code"]) != 2
       update_yml("#{CNFManager::Points::Results.file}", "exit_code", "1")
     end
@@ -59,7 +58,6 @@ task "workload", ["ensure_cnf_installed", "setup:configuration_file_setup", "com
     yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
       YAML.parse(file)
     end
-    Log.info { "results yaml: #{yaml}" }
     if (yaml["exit_code"]) != 2
       update_yml("#{CNFManager::Points::Results.file}", "exit_code", "1")
     end
@@ -117,18 +115,18 @@ TEMPLATE
 puts completion_template
 end
 
-# Sam.help
 begin
-  puts `#{PROGRAM_NAME} help` if ARGV.empty?
-  validate_cli_args!(ARGV)
+  # A bare invocation shows help. Run the help task in-process instead of
+  # re-executing the binary in a subshell and echoing its captured output.
+  argv = ARGV.empty? ? ["help"] : ARGV.clone
+  validate_cli_args!(argv)
   # See issue #426 for exit code requirement
-  Sam.process_tasks(ARGV.clone)
+  Sam.process_tasks(argv)
 
   if CNFManager::Points::Results.file_exists?
     yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
       YAML.parse(file)
     end
-    Log.info { "results yaml: #{yaml}" }
     case (yaml["exit_code"])
     when 1
       exit 1

--- a/src/tasks/utils/logging.cr
+++ b/src/tasks/utils/logging.cr
@@ -40,7 +40,9 @@ private def log_backend
   end
 
   if log_file.empty?
-    backend = Log::IOBackend.new(formatter: log_formatter)
+    # Logs are diagnostics, not output: they go to stderr so that stdout stays
+    # reserved for results and pipes/redirection stay clean (issue #2431).
+    backend = Log::IOBackend.new(STDERR, formatter: log_formatter)
   else
     log_io = File.open(log_file, "a")
     backend = Log::IOBackend.new(io: log_io, formatter: log_formatter)

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -283,15 +283,17 @@ def tools_path
 end
 
 def stdout_info(msg, same_line = false)
-  if same_line
+  if same_line && STDOUT.tty?
     msg = "#{"\e[1A\e[K"}#{msg}"
   end
   puts msg
 end
 
-# \e[1A\e[K is a sequence that allows to clear current line and place cursor at its beginning
+# \e[1A\e[K is a sequence that allows to clear current line and place cursor at
+# its beginning. Like color, it is only emitted on a TTY - in piped/captured
+# output the rewritten lines are simply printed one after another.
 def stdout_colored(msg, color, same_line = false)
-  if same_line
+  if same_line && STDOUT.tty?
     msg = "#{"\e[1A\e[K"}#{msg}"
   end
   puts msg.colorize(color)


### PR DESCRIPTION
## Description

Implements #2431 with the boundary rules recorded on the issue. Everything the suite emitted went to stdout — result lines, scores, and the log framework alike (`Log::IOBackend` default `STDOUT`; there was not a single `STDERR` write in `src/`). With `LOG_LEVEL=debug` — which CI uses everywhere — log lines interleave with result lines on one stream, and `./cnf-testsuite <test> > results.txt` captures a debug log instead of results.

Following the Unix convention (stdout = the program's output, stderr = diagnostics):

- **Log framework → stderr.** `LOG_PATH`/`LOGPATH` unchanged as the opt-in file destination. Result lines, scores and summaries stay on **stdout regardless of verdict** — a FAILED line is the suite successfully reporting its finding, not a diagnostic.
- **Cursor-control progress rewrites** (`\e[1A\e[K`, 8 install-progress sites) are now emitted **only on a TTY** — the same gate as color. Piped/captured output gets plain sequential lines instead of corrupted escapes.
- **Full results-YAML dumps removed** from the log stream (three sites in the entry point/aggregates) — the results file is the machine contract; the log only needs its path.
- **Bare invocation** runs the help task in-process instead of re-executing the binary in a subshell and echoing the captured output.

Deliberately *not* in scope (recorded on the issue): migrating operational-error messages ("KUBECONFIG is not set", …) from stdout to stderr — that lands with #2433, which classifies exactly those call sites.

## Verification

| Check | Result |
|---|---|
| `LOG_LEVEL=debug ./cnf-testsuite version 2>/dev/null` | only the version line (stdout clean) |
| `LOG_LEVEL=debug ./cnf-testsuite version 1>/dev/null` | only log lines (stderr carries diagnostics) |
| `./cnf-testsuite version \| cat -v` | no escape sequences when piped |
| bare `./cnf-testsuite` | help printed in-process, exit 0 |
| `crystal spec --tag points --tag logger --tag args` | 30 examples, 0 failures (the spec harness merges streams via `joined_output`, so output assertions are unaffected) |

Documented in USAGE.md, including the caveat that separately captured streams lose relative ordering (`2>&1` when strict interleaving matters).

## Issues

Fixes #2431

🤖 Generated with [Claude Code](https://claude.com/claude-code)