### PR TITLE
Replace unanchored ARGV regex checks with an invoked-task helper

### DIFF
--- a/spec/utils/cli_args_spec.cr
+++ b/spec/utils/cli_args_spec.cr
@@ -1,5 +1,6 @@
 require "./../spec_helper"
 require "../../src/tasks/utils/sam_args_patch"
+require "../../src/tasks/utils/cli_args_validation"
 
 describe "CLI argument validation" do
   it "rejects unknown flags and named arguments with a usage error", tags: ["points"] do
@@ -28,5 +29,27 @@ describe "CLI argument validation" do
 
   it "preserves '=' characters inside named argument values", tags: ["points"] do
     Sam::Args.new(["cnf-config=a=b"]).named["cnf-config"].should eq("a=b")
+  end
+
+  it "invoked_task? matches only tokens in task positions", tags: ["points"] do
+    original = ARGV.dup
+    begin
+      ARGV.clear
+      ARGV.concat(["state", "cnf-config=x", "strict", "@", "security"])
+      invoked_task?("state").should be_true
+      invoked_task?("security").should be_true      # after the '@' separator
+      invoked_task?("strict").should be_false       # flag, not a task position
+      invoked_task?("cnf-config=x").should be_false
+
+      # The old unanchored regexes matched substrings anywhere on the command
+      # line - /ran/ matched an invocation of rolling_version_change.
+      ARGV.clear
+      ARGV.concat(["rolling_version_change"])
+      invoked_task?("ran").should be_false
+      invoked_task?("rolling_version_change").should be_true
+    ensure
+      ARGV.clear
+      ARGV.concat(original)
+    end
   end
 end

--- a/src/tasks/cert/cert_compatibility.cr
+++ b/src/tasks/cert/cert_compatibility.cr
@@ -19,8 +19,7 @@ task "cert_compatibility" do |t, args|
   
   cert_stdout_score(tags, "Compatibility, Installability, and Upgradeability", exclude_warning: !exclude.empty?)
 
-  case "#{ARGV.join(" ")}" 
-  when /cert_compatibility/
+  if invoked_task?("cert_compatibility")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 

--- a/src/tasks/cert/cert_configuration.cr
+++ b/src/tasks/cert/cert_configuration.cr
@@ -20,8 +20,7 @@ task "cert_configuration" do |t, args|
   invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   cert_stdout_score(tags, "configuration", exclude_warning: !exclude.empty?)
-  case "#{ARGV.join(" ")}" 
-  when /cert_configuration/
+  if invoked_task?("cert_configuration")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/cert/cert_microservice.cr
+++ b/src/tasks/cert/cert_microservice.cr
@@ -21,8 +21,7 @@ task "cert_microservice" do |t, args|
   invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   cert_stdout_score(tags, "microservice", exclude_warning: !exclude.empty?)
-  case "#{ARGV.join(" ")}" 
-  when /cert_microservice/
+  if invoked_task?("cert_microservice")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/cert/cert_observability.cr
+++ b/src/tasks/cert/cert_observability.cr
@@ -18,8 +18,7 @@ task "cert_observability" do |t, args|
   invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   cert_stdout_score(tags, "Observability and Diagnostics", exclude_warning: !exclude.empty?)
-  case "#{ARGV.join(" ")}" 
-  when /cert_observability/
+  if invoked_task?("cert_observability")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/cert/cert_resilience.cr
+++ b/src/tasks/cert/cert_resilience.cr
@@ -20,8 +20,7 @@ desc "The CNF test suite checks to see if the CNFs are resilient to failures."
   Log.trace { "resilience args.raw: #{args.raw}" }
   Log.trace { "resilience args.named: #{args.named}" }
   cert_stdout_score(tags, "Reliability, Resilience, and Availability", exclude_warning: !exclude.empty?)
-  case "#{ARGV.join(" ")}" 
-  when /cert_resilience/
+  if invoked_task?("cert_resilience")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/cert/cert_security.cr
+++ b/src/tasks/cert/cert_security.cr
@@ -18,8 +18,7 @@ task "cert_security" do |t, args|
   invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   cert_stdout_score(tags, "security", exclude_warning: !exclude.empty?)
-  case "#{ARGV.join(" ")}" 
-  when /cert_security/
+  if invoked_task?("cert_security")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/cert/cert_state.cr
+++ b/src/tasks/cert/cert_state.cr
@@ -19,8 +19,7 @@ task "cert_state" do |t, args|
   invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
 
   cert_stdout_score(tags, "state", exclude_warning: !exclude.empty?)
-  case "#{ARGV.join(" ")}" 
-  when /cert_state/
+  if invoked_task?("cert_state")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/utils/cli_args_validation.cr
+++ b/src/tasks/utils/cli_args_validation.cr
@@ -66,3 +66,22 @@ def validate_cli_args!(argv : Array(String))
     exit USAGE_EXIT_CODE
   end
 end
+
+# True when `name` was one of the tasks invoked on the command line: the first
+# token, or any token following the '@' task separator. Replaces the old
+# unanchored `case ARGV.join(" ") when /name/` checks, where e.g. /ran/ matched
+# any invocation containing "ran" (rolling_version_change, a fixture path, ...).
+def invoked_task?(name : String) : Bool
+  expect_task = true
+  ARGV.each do |token|
+    if token == Sam::TASK_SEPARATOR
+      expect_task = true
+      next
+    end
+    if expect_task
+      return true if token == name
+      expect_task = false
+    end
+  end
+  false
+end

--- a/src/tasks/workload/5g_validator.cr
+++ b/src/tasks/workload/5g_validator.cr
@@ -8,8 +8,7 @@ require "../utils/utils.cr"
 desc "The CNF test suite checks to see if 5g CNFs follow cloud native principles"
 task "5g", ["smf_upf_core_validator", "suci_enabled"] do |_, args|
   stdout_score("5g")
-  case "#{ARGV.join(" ")}" 
-  when /5g/
+  if invoked_task?("5g")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -10,8 +10,7 @@ require "../utils/utils.cr"
 desc "The CNF test suite checks to see if CNFs support horizontal scaling (across multiple machines) and vertical scaling (between sizes of machines) by using the native K8s kubectl"
 task "compatibility", ["helm_chart_valid", "helm_chart_published", "helm_deploy", "cni_compatible", "increase_decrease_capacity", "rollback", "deprecated_k8s_features"].concat(ROLLING_VERSION_CHANGE_TEST_NAMES) do |_, args|
   stdout_score("compatibility", "Compatibility, Installability, and Upgradeability")
-  case "#{ARGV.join(" ")}" 
-  when /compatibility/
+  if invoked_task?("compatibility")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -24,8 +24,7 @@ task "configuration", [
     "versioned_tag"
   ] do |_, args|
   stdout_score("configuration", "configuration")
-  case "#{ARGV.join(" ")}" 
-  when /configuration/
+  if invoked_task?("configuration")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -14,8 +14,7 @@ require "../utils/utils.cr"
 desc "The CNF test suite checks to see if CNFs follows microservice principles"
 task "microservice", ["reasonable_image_size", "reasonable_startup_time", "single_process_type", "service_discovery", "shared_database", "specialized_init_system", "sig_term_handled"] do |_, args|
   stdout_score("microservice")
-  case "#{ARGV.join(" ")}" 
-  when /microservice/
+  if invoked_task?("microservice")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -10,8 +10,7 @@ require "../utils/utils.cr"
 desc "In order to maintain, debug, and have insight into a protected environment, its infrastructure elements must have the property of being observable. This means these elements must externalize their internal states in some way that lends itself to metrics, tracing, and logging."
 task "observability", ["log_output", "prometheus_traffic", "open_metrics", "routed_logs", "tracing"] do |_, args|
   stdout_score("observability", "Observability and Diagnostics")
-  case "#{ARGV.join(" ")}" 
-  when /observability/
+  if invoked_task?("observability")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/workload/ran.cr
+++ b/src/tasks/workload/ran.cr
@@ -8,8 +8,7 @@ require "../utils/utils.cr"
 desc "The CNF test suite checks to see if RAN CNFs follow cloud native principles"
 task "ran", ["oran_e2_connection"] do |_, args|
   stdout_score("ran")
-  case "#{ARGV.join(" ")}" 
-  when /ran/
+  if invoked_task?("ran")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -21,8 +21,7 @@ desc "The CNF test suite checks to see if the CNFs are resilient to failures."
   Log.trace { "resilience args.raw: #{args.raw}" }
   Log.trace { "resilience args.named: #{args.named}" }
   stdout_score("resilience", "Reliability, Resilience, and Availability")
-  case "#{ARGV.join(" ")}" 
-  when /reliability/
+  if invoked_task?("resilience")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -28,8 +28,7 @@ task "security", [
     "application_credentials"
   ] do |_, args|
   stdout_score("security")
-  case "#{ARGV.join(" ")}" 
-  when /security/
+  if invoked_task?("security")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -9,8 +9,7 @@ require "../../modules/kubectl_client"
 desc "The CNF test suite checks if state is stored in a custom resource definition or a separate database (e.g. etcd) rather than requiring local storage.  It also checks to see if state is resilient to node failure"
 task "state", ["no_local_volume_configuration", "elastic_volumes", "database_persistence", "node_drain"] do |_, args|
   stdout_score("state")
-  case "#{ARGV.join(" ")}" 
-  when /state/
+  if invoked_task?("state")
     stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
   end
 end


### PR DESCRIPTION
## Description

Implements #2434. 16 aggregate/category tasks decided whether to print the "Results have been saved to …" line via **unanchored regexes over the whole command line** (`case ARGV.join(" ") when /name/`). The match being an unanchored substring meant e.g. `/ran/` matched any invocation containing "ran" anywhere (`rolling_version_change`, a fixture path, …), and each of the 16 sites re-implemented the same pattern.

This adds `invoked_task?(name)` — true when `name` was an actual task token in the invocation (first token, or any token after the `@` separator; the same tokenization the #2423 CLI validator uses) — and replaces all 16 sites via a reviewed scripted transform.

**Bonus bug found by the transform**: `reliability.cr` matched `/reliability/`, but its task is named `resilience` — that results-path line was unreachable dead code. It now checks the real task name, so `./cnf-testsuite resilience` prints the line like every other category.

The one remaining `ARGV.join` in `src/` is the results file's documented `command:` field, which is intentional.

## Verification

- New in-process spec (`points` shard) pins the anchoring: task tokens match in first/after-`@` positions only; flags and `key=value` args don't; `invoked_task?("ran")` is false for a `rolling_version_change` invocation (the old regex's failure case).
- Built binary: `cert_state exclude=node_drain` still prints its results-path line (positive regression check).
- `points` shard passes locally: 18 examples, 0 failures.

## Issues

Fixes #2434

🤖 Generated with [Claude Code](https://claude.com/claude-code)