### PR TITLE
Remove smitholi67 from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @martin-mat @collivier @rich-l @smitholi67
+* @martin-mat @collivier @rich-l


### PR DESCRIPTION
## Description

Removes @smitholi67 from the automatic reviewer list in `.github/CODEOWNERS` — they are not involved in CNTi activities anymore. The remaining code owners are unchanged; takes effect for PRs opened after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)