### PR TITLE
Skip Docker Hub login steps when secrets are unavailable

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -329,17 +329,7 @@ jobs:
         shards install  
         echo "RUNNER: $RUNNER_NAME"
     - name: Run Crystal Spec
-      env:
-        DOCKERHUB_EMAIL: ${{ secrets.DOCKERHUB_EMAIL }}
-        IMAGE_REPO: ${{ secrets.IMAGE_REPO }}
       run: |
-        EMAIL_ARRAY=($DOCKERHUB_EMAIL)
-        IMAGE_ARRAY=($IMAGE_REPO)
-        RANDOMIZER=$(( 0 + $RANDOM % 3 ))
-        export PROTECTED_DOCKERHUB_USERNAME=$DOCKERHUB_USERNAME
-        export PROTECTED_DOCKERHUB_PASSWORD=$DOCKERHUB_PASSWORD
-        export PROTECTED_DOCKERHUB_EMAIL=${EMAIL_ARRAY[$RANDOMIZER]}
-        export PROTECTED_IMAGE_REPO=${IMAGE_ARRAY[$RANDOMIZER]}
         source cluster.env
         export KUBECONFIG=$(pwd)/$CLUSTER.conf
         until [[ $(kubectl get pods -l app=local-path-provisioner --namespace=local-path-storage -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') == "True" ]]; do

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -91,20 +91,25 @@ jobs:
     name: Crystal Specs
     needs: [tests]
     runs-on: [v1.0.0]
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.tests.outputs.matrix)}}
     steps:
     - name: Login to Docker Hub
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
     - name: Sign in to Docker Hub with Helm
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       run: |
         helm registry login \
-          --username ${{ secrets.DOCKERHUB_USERNAME }} \
-          --password ${{ secrets.DOCKERHUB_PASSWORD }} \
+          --username ${{ env.DOCKERHUB_USERNAME }} \
+          --password ${{ env.DOCKERHUB_PASSWORD }} \
           registry-1.docker.io
     - name: Cleanup Tmp DIR
       run: |
@@ -325,9 +330,6 @@ jobs:
         echo "RUNNER: $RUNNER_NAME"
     - name: Run Crystal Spec
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
         DOCKERHUB_EMAIL: ${{ secrets.DOCKERHUB_EMAIL }}
         IMAGE_REPO: ${{ secrets.IMAGE_REPO }}
       run: |
@@ -368,6 +370,9 @@ jobs:
     name: Chaos & Oran Tests
     needs: [tests]
     runs-on: ubuntu-24.04
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     strategy:
       fail-fast: false
       # Derived from CHAOS_TAGS in the `tests` job so the chaos matrix and the
@@ -375,15 +380,17 @@ jobs:
       matrix: ${{ fromJson(needs.tests.outputs.chaos_matrix) }}
     steps:
     - name: Login to Docker Hub
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
     - name: Sign in to Docker Hub with Helm
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       run: |
         helm registry login \
-          --username ${{ secrets.DOCKERHUB_USERNAME }} \
-          --password ${{ secrets.DOCKERHUB_PASSWORD }} \
+          --username ${{ env.DOCKERHUB_USERNAME }} \
+          --password ${{ env.DOCKERHUB_PASSWORD }} \
           registry-1.docker.io
     - name: Checkout code
       uses: actions/checkout@v4
@@ -447,17 +454,22 @@ jobs:
   test_binary_configuration_lifecycle:
     name: Test Binary Without Source(config_lifecycle)
     runs-on: [v1.0.0]
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
     - name: Login to Docker Hub
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
     - name: Sign in to Docker Hub with Helm
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       run: |
         helm registry login \
-          --username ${{ secrets.DOCKERHUB_USERNAME }} \
-          --password ${{ secrets.DOCKERHUB_PASSWORD }} \
+          --username ${{ env.DOCKERHUB_USERNAME }} \
+          --password ${{ env.DOCKERHUB_PASSWORD }} \
           registry-1.docker.io
     - name: Cleanup Tmp DIR
       run: |
@@ -535,17 +547,22 @@ jobs:
   test_binary_microservice:
     name: Test Binary Without Source(microservice)
     runs-on: [v1.0.0]
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
     - name: Login to Docker Hub
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
     - name: Sign in to Docker Hub with Helm
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       run: |
         helm registry login \
-          --username ${{ secrets.DOCKERHUB_USERNAME }} \
-          --password ${{ secrets.DOCKERHUB_PASSWORD }} \
+          --username ${{ env.DOCKERHUB_USERNAME }} \
+          --password ${{ env.DOCKERHUB_PASSWORD }} \
           registry-1.docker.io
     - name: Cleanup Tmp DIR
       run: |
@@ -621,17 +638,22 @@ jobs:
   test_binary_all:
     name: Test Binary Without Source(all)
     runs-on: [v1.0.0]
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
     - name: Login to Docker Hub
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
     - name: Sign in to Docker Hub with Helm
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       run: |
         helm registry login \
-          --username ${{ secrets.DOCKERHUB_USERNAME }} \
-          --password ${{ secrets.DOCKERHUB_PASSWORD }} \
+          --username ${{ env.DOCKERHUB_USERNAME }} \
+          --password ${{ env.DOCKERHUB_PASSWORD }} \
           registry-1.docker.io
     - name: Cleanup Tmp DIR
       run: |

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -9,12 +9,16 @@ on:
 jobs:
   arm64:
     runs-on: ubuntu-24.04-arm
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_PASSWORD }}
       - uses: actions/checkout@v4
       - name: Install kind
         uses: ./.github/actions/install-kind
@@ -55,12 +59,16 @@ jobs:
           kind delete cluster --name arm64
   qemu-arm64:
     runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_PASSWORD }}
       - uses: actions/checkout@v4
       - name: Install kind
         uses: ./.github/actions/install-kind

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   debian:
     runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     strategy:
       matrix:
         release:
@@ -19,10 +22,11 @@ jobs:
           - sid
     steps:
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_PASSWORD }}
       - uses: actions/checkout@v4
       - name: Install kind
         uses: ./.github/actions/install-kind

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,16 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       CRYSTAL_IMAGE: "conformance/crystal:1.6.2-alpine"
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - name: Login to Docker Hub
+      if: ${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_PASSWORD != '' }}
       uses: docker/login-action@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
     - name: Checkout code
       uses: actions/checkout@v4
       with:
@@ -25,11 +29,6 @@ jobs:
         docker run --rm -v $PWD:/workspace -w /workspace $CRYSTAL_IMAGE shards install
         docker run --rm -v $PWD:/workspace -w /workspace $CRYSTAL_IMAGE crystal build src/cnf-testsuite.cr --release --static --link-flags '-lxml2 -llzma'
     - name: Publish Release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ env.GITHUB_TOKEN != '' }}
       run: |
-        if [ -z "${GITHUB_TOKEN+x}" ]; then
-          exit 0
-        else
-          ./cnf-testsuite upsert_release
-        fi
+        ./cnf-testsuite upsert_release

--- a/src/modules/cluster_tools/cluster_tools.cr
+++ b/src/modules/cluster_tools/cluster_tools.cr
@@ -225,9 +225,9 @@ module ClusterTools
   def self.official_content_digest_by_image_name(image_name)
     Log.info { "official_content_digest_by_image_name: #{image_name}"}
 
-    if ENV["DOCKERHUB_USERNAME"]? && ENV["DOCKERHUB_PASSWORD"]?
+    if (u = ENV["DOCKERHUB_USERNAME"]?) && !u.empty? && (p = ENV["DOCKERHUB_PASSWORD"]?) && !p.empty?
       Log.info { "Using USERNAME and PASSWORD for accessing the registry via skopeo" }
-      registry_creds = "--creds #{ENV["DOCKERHUB_USERNAME"]}:#{ENV["DOCKERHUB_PASSWORD"]}"
+      registry_creds = "--creds #{u}:#{p}"
     else
       Log.info { "Access the registry anonymously via skopeo" }
       registry_creds = ""


### PR DESCRIPTION
So forked-PR workflows can run without failing on missing credentials.