### PR TITLE
Replace the SAM task dump with structured CLI help

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -262,8 +262,35 @@ cnf-config=<path_to_your_config_file>/cnf-testsuite.yml
 
 #### Get available options and to see all available tests from command line:
 
+`help` prints a usage page: the typical workflow, the options, the `key=value`
+arguments, the flags, and the `~exclusion` / `@` syntax. `-h` and a bare
+invocation print the same page.
+
 ```
 ./cnf-testsuite help
+./cnf-testsuite -h
+```
+
+To list every task, grouped by category:
+
+```
+./cnf-testsuite help tasks
+```
+
+To see what a single task does, what it runs first, and which suites it belongs
+to:
+
+```
+./cnf-testsuite help liveness
+```
+
+An unknown task name is answered with the closest match, e.g. `./cnf-testsuite
+livenes` suggests `liveness`.
+
+#### Print the version:
+
+```
+./cnf-testsuite --version
 ```
 
 #### Clean up the CNTI Test Suite, the K8s cluster, and upstream projects:

--- a/spec/cnf_testsuite_all/cnf_testsuite_spec.cr
+++ b/spec/cnf_testsuite_all/cnf_testsuite_spec.cr
@@ -10,7 +10,7 @@ describe CnfTestSuite do
 
   it "a task should fail with an exit code of 2 when there is an exception", tags: ["security"] do
     begin
-      result = ShellCmd.run_testsuite("divide_by_zero strict")
+      result = ShellCmd.run_testsuite("_divide_by_zero strict")
       (result[:status].exit_code == 2).should be_true
     end
   end

--- a/spec/utils/cli_help_spec.cr
+++ b/spec/utils/cli_help_spec.cr
@@ -1,0 +1,93 @@
+require "./../spec_helper"
+require "../../src/tasks/utils/cli_args_validation"
+
+# Parses `help tasks` output into {task path => description}. A row is
+# "  <path>" padded to the description column; a path too long for that column
+# pushes its description onto the following indented line(s).
+private def parse_task_rows(output : String) : Hash(String, String)
+  rows = {} of String => String
+  last_path = ""
+  output.each_line do |line|
+    next if line.strip.empty?
+    if line.starts_with?("  ") && !line.starts_with?("   ")
+      # "  name<padding>description" or "  name" alone
+      rest = line[2..].rstrip
+      path, _, description = rest.partition(" ")
+      rows[path] = description.strip
+      last_path = path
+    elsif line.starts_with?("   ") && !last_path.empty?
+      rows[last_path] = "#{rows[last_path]} #{line.strip}".strip
+    end
+  end
+  rows
+end
+
+describe "CLI help" do
+  it "prints usage without a terminal and exits 0", tags: ["points"] do
+    # SAM's help shelled out to `tput cols` and crashed with "Invalid Int32" when
+    # TERM was unset, which is the normal case in containers and CI.
+    result = ShellCmd.run_testsuite("help", "env -u TERM")
+    result[:status].exit_code.should eq(0)
+    result[:output].should contain("USAGE")
+    result[:output].should_not contain("Invalid Int32")
+  end
+
+  it "'-h' prints the same single help page and exits 0", tags: ["points"] do
+    help = ShellCmd.run_testsuite("help")
+    flag = ShellCmd.run_testsuite("-h")
+    flag[:status].exit_code.should eq(0)
+    flag[:output].should eq(help[:output])
+    # -h used to print the option banner and then fall through to the task table.
+    flag[:output].scan(/^USAGE$/m).size.should eq(1)
+  end
+
+  it "'--version' prints the version and exits 0", tags: ["points"] do
+    result = ShellCmd.run_testsuite("--version")
+    result[:status].exit_code.should eq(0)
+    result[:output].should contain("CNF TestSuite version:")
+  end
+
+  it "'help tasks' groups tasks and describes every one it lists", tags: ["points"] do
+    result = ShellCmd.run_testsuite("help tasks")
+    result[:status].exit_code.should eq(0)
+
+    result[:output].should contain("GETTING STARTED")
+    result[:output].should contain("TEST SUITES")
+    result[:output].should contain("PLATFORM TESTS")
+
+    rows = parse_task_rows(result[:output])
+    rows.should_not be_empty
+    rows.each { |path, description| description.should_not eq("") }
+
+    # Internal tasks are hidden by the leading-underscore convention.
+    rows.keys.any?(&.starts_with?("_")).should be_false
+    rows.keys.any?(&.includes?(":_")).should be_false
+    rows.keys.should_not contain("generate:makefile")
+
+    # Real tasks are still listed.
+    rows.keys.should contain("liveness")
+    rows.keys.should contain("cnf_install")
+  end
+
+  it "'help <task>' describes a single task", tags: ["points"] do
+    result = ShellCmd.run_testsuite("help liveness")
+    result[:status].exit_code.should eq(0)
+    result[:output].should contain("cnf-testsuite liveness")
+    result[:output].should contain("liveness probe")
+  end
+
+  it "suggests the closest task for an unknown name", tags: ["points"] do
+    result = ShellCmd.run_testsuite("help livenes")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("Did you mean 'liveness'?")
+
+    # ... and on the invocation path, not just via `help`.
+    result = ShellCmd.run_testsuite("livenes")
+    result[:status].exit_code.should eq(1)
+    result[:output].should contain("Did you mean 'liveness'?")
+
+    # Nothing close enough gets no misleading suggestion.
+    result = ShellCmd.run_testsuite("zzzzzzzz")
+    result[:output].should_not contain("Did you mean")
+  end
+end

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -6,7 +6,7 @@ require "./tasks/utils/utils.cr"
 require "./cnf_testsuite.cr"
 
 
-desc "The CNF Test Suite program enables interoperability of CNFs from multiple vendors running on top of Kubernetes supplied by different vendors. The goal is to provide an open source test suite to enable both open and closed source CNFs to demonstrate conformance and implementation of best practices."
+desc "Run every workload and platform test"
 task "all", ["workload", "platform"] do  |_, args|
   Log.debug { "all" }
 
@@ -37,7 +37,7 @@ task "all", ["workload", "platform"] do  |_, args|
   stdout_info "Test results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
 end
 
-desc "The CNF Test Suite program enables interoperability of CNFs from multiple vendors running on top of Kubernetes supplied by different vendors. The goal is to provide an open source test suite to enable both open and closed source CNFs to demonstrate conformance and implementation of best practices."
+desc "Run every workload test against the installed CNF"
 task "workload", ["ensure_cnf_installed", "setup:configuration_file_setup", "compatibility","state", "security", "configuration", "observability", "microservice", "resilience"] do  |_, args|
   Log.debug { "workload" }
 
@@ -71,11 +71,13 @@ task "ensure_cnf_installed" do |_, args|
   CNFManager::Task.ensure_cnf_installed!
 end
 
+desc "Print the CNF Test Suite version"
 task "version" do |_, args|
   Log.info { "VERSION: #{ReleaseManager::VERSION}" }
   puts "CNF TestSuite version: #{ReleaseManager::VERSION}".colorize(:green)
 end
 
+desc "Maintainers: create or update the GitHub release for the current version"
 task "upsert_release" do |_, args|
   Log.info { "upserting release on: #{ReleaseManager::VERSION}" }
 
@@ -89,6 +91,7 @@ task "upsert_release" do |_, args|
   end
 end
 
+desc "Emit one log line at every level; useful for checking log configuration"
 task "test" do
   Log.debug { "debug test" }
   Log.info { "info test" }
@@ -109,16 +112,27 @@ bin_name = "cnf-testsuite"
 completion_template = <<-TEMPLATE
 # to remove
 # complete -r #{bin_name}
-complete -W "#{Sam.root_namespace.all_tasks.map(&.name).join(" ")}" #{bin_name}
+complete -W "#{CLIHelp.visible_tasks.map(&.path).join(" ")}" #{bin_name}
 TEMPLATE
 
 puts completion_template
 end
 
 begin
-  # A bare invocation shows help. Run the help task in-process instead of
-  # re-executing the binary in a subshell and echoing its captured output.
-  argv = ARGV.empty? ? ["help"] : ARGV.clone
+  # -h/--version are recorded by the OptionParser in logging.cr at require time;
+  # act on them here, where every task is registered and help can list them all.
+  if CLIInvocation.version_requested?
+    puts "CNF TestSuite version: #{ReleaseManager::VERSION}"
+    exit 0
+  end
+
+  # A bare invocation shows help, as does -h.
+  if CLIInvocation.help_requested? || ARGV.empty?
+    puts CLIHelp.main_page
+    exit 0
+  end
+
+  argv = ARGV.clone
   validate_cli_args!(argv)
   # See issue #426 for exit code requirement
   Sam.process_tasks(argv)
@@ -135,7 +149,11 @@ begin
     end
   end
 rescue e : Sam::NotFound
-  puts e.message
+  stdout_failure e.message.to_s
+  if suggestion = CLIHelp.suggestion_for(e.task_path)
+    stdout_failure "Did you mean '#{suggestion}'?"
+  end
+  stdout_info "Run `#{CLIHelp::BIN_NAME} help tasks` to list every task."
   exit 1
 rescue e
   puts e.backtrace.join("\n"), e

--- a/src/tasks/cert/cert_compatibility.cr
+++ b/src/tasks/cert/cert_compatibility.cr
@@ -25,6 +25,6 @@ task "cert_compatibility" do |t, args|
 
 end
 
-task "cert_compatibility_title" do |_, args|
+task "_cert_compatibility_title" do |_, args|
   
 end

--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -1,5 +1,5 @@
 # coding: utf-8
-desc "Platform Tests"
+desc "Run every test against the Kubernetes platform itself, rather than the CNF"
 task "platform", ["setup:install_local_helm", "k8s_conformance", "platform:observability", "platform:resilience", "platform:hardware_and_scheduling", "platform:security"]  do |_, args|
   Log.debug { "platform" }
 

--- a/src/tasks/setup/cnf_setup.cr
+++ b/src/tasks/setup/cnf_setup.cr
@@ -1,6 +1,7 @@
 require "sam"
 require "../utils/utils.cr"
 
+desc "Install the CNF under test from a cnf-testsuite.yml config"
 task "cnf_install", ["setup:install_local_helm", "setup:create_namespace"] do |_, args|
   logger = SLOG.for("cnf_install")
   logger.info { "Installing CNF to cluster" }
@@ -24,6 +25,7 @@ task "cnf_install", ["setup:install_local_helm", "setup:create_namespace"] do |_
   stdout_success "CNF installation complete."
 end
 
+desc "Uninstall the CNF under test and remove its installed files"
 task "cnf_uninstall" do |_, args|
   logger = SLOG.for("cnf_uninstall")
   logger.info { "Uninstalling CNF from cluster" }
@@ -38,6 +40,7 @@ task "cnf_uninstall" do |_, args|
   end
 end
 
+desc "Check a cnf-testsuite.yml for errors without installing anything"
 task "validate_config" do |_, args|
   if args.named["cnf-config"]?
     config = CNFInstall::Config.parse_cnf_config_from_file(args.named["cnf-config"].to_s)

--- a/src/tasks/setup/prereqs.cr
+++ b/src/tasks/setup/prereqs.cr
@@ -5,6 +5,7 @@ require "totem"
 require "../../modules/helm"
 
 namespace "setup" do
+  desc "Verify the tools and cluster access the test suite needs"
   task "prereqs" do |_, args|
     kubectl_ok = KubectlClient.installation_found?
     helm_ok = Helm.installation_found?

--- a/src/tasks/setup/setup.cr
+++ b/src/tasks/setup/setup.cr
@@ -8,6 +8,7 @@ task "setup", ["version", "setup:cnf_directory_setup", "setup:install_local_helm
 end
 
 namespace "setup" do
+  desc "Create the cnf-testsuite namespace used by the suite's helper tools"
   task "create_namespace" do |_, args|
     logger = SLOG.for("create_namespace")
     logger.info { "Creating namespace for CNTI testsuite" }
@@ -43,6 +44,7 @@ namespace "setup" do
     stdout_success "Successfully created directories for cnf-testsuite"
   end
 
+  desc "Materialize the suite's runtime configuration files in the working directory"
   task "configuration_file_setup" do |_, args|
     logger = SLOG.for("configuration_file_setup").info { "Creating configuration file" }
     CNFManager::Points.create_points_yml

--- a/src/tasks/utils/cli_args_validation.cr
+++ b/src/tasks/utils/cli_args_validation.cr
@@ -25,6 +25,7 @@ def validate_cli_args!(argv : Array(String))
   task_paths = Sam.root_namespace.all_tasks.map(&.path)
   errors = [] of String
   expect_task = true
+  current_task = ""
 
   argv.each do |token|
     if token == Sam::TASK_SEPARATOR
@@ -33,9 +34,13 @@ def validate_cli_args!(argv : Array(String))
     end
     if expect_task
       # Task names themselves are validated by SAM (Sam::NotFound).
+      current_task = token
       expect_task = false
       next
     end
+    # `help` takes a topic - "tasks" or a task name - rather than the flags and
+    # key=value arguments every other task takes.
+    next if current_task == "help"
 
     if token.empty?
       errors << "Empty argument given."
@@ -51,7 +56,7 @@ def validate_cli_args!(argv : Array(String))
         errors << "Invalid value for '#{key}=': '#{value}' is not a number."
       end
     elsif token.starts_with?("-")
-      errors << "Unknown option '#{token}'. Supported options: -l/--loglevel LEVEL, -h/--help."
+      errors << "Unknown option '#{token}'. Supported options: -l/--loglevel LEVEL, -h/--help, --version."
     elsif KNOWN_CLI_FLAGS.includes?(token)
       # valid bare flag
     elsif task_paths.includes?(token)

--- a/src/tasks/utils/cli_help.cr
+++ b/src/tasks/utils/cli_help.cr
@@ -1,0 +1,291 @@
+require "sam"
+require "levenshtein"
+
+# SAM keeps a task's dependency list private, and its NotFound exception drops
+# the path it could not resolve. Help groups tasks by the very aggregates the
+# suite runs, so the listing can never drift from what the tasks actually do,
+# and an unknown task can be matched against the real ones. Reopening is the
+# pattern already used for Sam::Args in sam_args_patch.cr.
+class Sam::Task
+  def dependency_names : Array(String)
+    @deps
+  end
+end
+
+class Sam::NotFound < Exception
+  getter task_path : String = ""
+
+  def initialize(task)
+    @task_path = task.to_s
+    @message = "Task #{task} was not found"
+  end
+end
+
+# Renders the CLI help. SAM's own help is a flat ShellTable dump of every
+# registered task that also shells out to `tput cols`, which crashes when TERM
+# is unset (containers, CI). This replaces it with a curated page plus a grouped
+# listing, and uses a fixed width so there is nothing to shell out to.
+module CLIHelp
+  BIN_NAME = "cnf-testsuite"
+
+  WIDTH       = 96
+  NAME_COLUMN = 34
+
+  # Namespaces that exist only to serve the task framework itself.
+  HIDDEN_NAMESPACES = ["generate"]
+
+  # Workload test categories, in the order `workload` runs them.
+  WORKLOAD_CATEGORIES = [
+    "compatibility", "state", "security", "configuration",
+    "observability", "microservice", "resilience",
+  ]
+
+  # A task whose final path segment starts with '_' is internal and never
+  # listed. A convention beats a hide-list that silently rots as tasks are added.
+  def self.hidden?(task : Sam::Task) : Bool
+    return true if task.name.starts_with?("_")
+    HIDDEN_NAMESPACES.any? { |namespace| task.path.starts_with?("#{namespace}:") }
+  end
+
+  def self.all_tasks : Array(Sam::Task)
+    Sam.root_namespace.all_tasks
+  end
+
+  def self.visible_tasks : Array(Sam::Task)
+    all_tasks.reject { |task| hidden?(task) }
+  end
+
+  def self.find_task(path : String) : Sam::Task?
+    all_tasks.find { |task| task.path == path }
+  end
+
+  # Closest visible task name to `name`, when one is near enough to be worth
+  # suggesting.
+  def self.suggestion_for(name : String) : String?
+    Levenshtein.find(name, visible_tasks.map(&.path), 3)
+  end
+
+  # Ordered groups of {title, tasks}. The test groups expand the suite's own
+  # aggregates rather than repeating their contents here. Whatever no group
+  # claims is listed under "Other", so a newly added task can never go missing.
+  def self.groups : Array(Tuple(String, Array(Sam::Task)))
+    claimed = Set(String).new
+    result = [] of Tuple(String, Array(Sam::Task))
+
+    add = ->(title : String, paths : Array(String)) do
+      tasks = [] of Sam::Task
+      paths.each do |path|
+        task = find_task(path)
+        next if task.nil? || hidden?(task) || claimed.includes?(task.path)
+        claimed << task.path
+        tasks << task
+      end
+      result << {title, tasks} unless tasks.empty?
+      nil
+    end
+
+    add.call("Getting started", [
+      "setup", "cnf_install", "cnf_uninstall", "validate_config",
+      "cnf_setup", "cnf_cleanup", "uninstall_all", "tools_uninstall",
+    ])
+    add.call("Test suites", ["all", "workload", "platform", "cert", "static"])
+
+    WORKLOAD_CATEGORIES.each do |category|
+      task = find_task(category)
+      next if task.nil?
+      add.call("Workload tests: #{category}", [category] + task.dependency_names)
+    end
+
+    platform_paths = [] of String
+    if platform = find_task("platform")
+      # `platform` also depends on a setup task; that belongs under setup.
+      platform_paths.concat(platform.dependency_names.reject(&.starts_with?("setup:")))
+    end
+    platform_paths.concat(visible_tasks.map(&.path).select(&.starts_with?("platform:")).sort)
+    add.call("Platform tests", platform_paths)
+
+    # 5G and RAN suites are aggregates in their own right rather than members of
+    # a workload category.
+    telco_paths = [] of String
+    ["5g", "ran"].each do |suite|
+      task = find_task(suite)
+      next if task.nil?
+      telco_paths << suite
+      telco_paths.concat(task.dependency_names)
+    end
+    telco_paths.concat(visible_tasks.map(&.path).select { |path|
+      path.starts_with?("smf_upf") || path.starts_with?("suci") || path.starts_with?("oran")
+    }.sort)
+    add.call("5G and RAN tests", telco_paths)
+
+    add.call("Certification", visible_tasks.map(&.path).select(&.starts_with?("cert")).sort)
+
+    # Tools the suite can install into the cluster on demand, outside the
+    # `setup:` namespace.
+    add.call("Tool management", visible_tasks.map(&.path).select { |path|
+      path.starts_with?("install_") || path.starts_with?("uninstall_")
+    }.sort)
+    add.call("Setup helpers", visible_tasks.map(&.path).select(&.starts_with?("setup:")).sort)
+    add.call("Utilities", [
+      "help", "completion", "version", "update_config", "delete_results",
+      "test", "upsert_release",
+    ])
+
+    rest = visible_tasks.reject { |task| claimed.includes?(task.path) }.sort_by(&.path)
+    result << {"Other", rest} unless rest.empty?
+    result
+  end
+
+  def self.main_page : String
+    named_args = KNOWN_CLI_NAMED_ARGS.join(", ")
+    flags = KNOWN_CLI_FLAGS.join(", ")
+
+    <<-HELP
+    The CNTi Test Suite validates a Cloud Native Function against cloud native
+    best practices by running tests against a live Kubernetes cluster.
+
+    USAGE
+      #{BIN_NAME} [options] <task> [arguments] [~exclusions] [#{Sam::TASK_SEPARATOR} <task> ...]
+
+    TYPICAL WORKFLOW
+      #{BIN_NAME} setup                                    install prerequisites (once)
+      #{BIN_NAME} cnf_install cnf-config=./cnf-testsuite.yml
+      #{BIN_NAME} cert                                     run the certification tests
+      #{BIN_NAME} cnf_uninstall
+
+    TEST SUITES
+      all         workload and platform tests
+      workload    tests against the installed CNF
+      platform    tests against the Kubernetes platform itself
+      cert        certification run; exits 0 when the CNF is certified
+
+    OPTIONS
+      -l, --loglevel LEVEL   trace, debug, info, notice, warn, error, fatal (default: error)
+      -h, --help             show this help and exit
+          --version          print the version and exit
+
+    ARGUMENTS (key=value, after the task name)
+      cnf-config=PATH   a cnf-testsuite.yml or the directory holding one (alias: cnf-path)
+      timeout=SECONDS   how long to wait for install and uninstall operations
+      All known arguments: #{named_args}
+
+    FLAGS
+      #{flags}
+
+    EXCLUSIONS AND MULTIPLE TASKS
+      ~<task>   skip a task within a suite, e.g. `#{BIN_NAME} all ~resilience`
+      #{Sam::TASK_SEPARATOR}         run several tasks in one invocation, e.g. `#{BIN_NAME} liveness #{Sam::TASK_SEPARATOR} readiness`
+
+    EXIT CODES
+      0   the run met its objective          2   a test errored (the suite broke)
+      1   it did not                         64  usage error, before any test ran
+
+    MORE
+      #{BIN_NAME} help tasks     list every task, grouped by category
+      #{BIN_NAME} help <task>    show what a single task does
+      Documentation: https://github.com/lfn-cnti/testsuite/blob/main/USAGE.md
+    HELP
+  end
+
+  def self.task_list : String
+    String.build do |io|
+      io << "Tasks. Run `" << BIN_NAME << " help <task>` for detail on one of them.\n"
+      groups.each do |title, tasks|
+        io << "\n" << title.upcase << "\n"
+        tasks.each { |task| io << row(task.path, task.description) }
+      end
+    end
+  end
+
+  def self.task_detail(path : String) : String?
+    task = find_task(path)
+    return nil if task.nil? || hidden?(task)
+
+    String.build do |io|
+      io << BIN_NAME << " " << task.path << "\n\n"
+      description = task.description
+      if description.empty?
+        io << "  (no description)\n"
+      else
+        wrap(description, WIDTH - 2).each { |line| io << "  " << line << "\n" }
+      end
+
+      deps = task.dependency_names.compact_map { |name| find_task(name) }.reject { |t| hidden?(t) }
+      parents = visible_tasks.select do |candidate|
+        candidate.path != task.path && candidate.dependency_names.includes?(task.path)
+      end
+      io << "\n" unless deps.empty? && parents.empty?
+      io << labelled_list("Runs first", deps.map(&.path)) unless deps.empty?
+      io << labelled_list("Part of", parents.map(&.path).sort) unless parents.empty?
+    end
+  end
+
+  # Fixed-width word wrap. Deliberately not terminal-aware: querying the
+  # terminal is what made SAM's help crash when TERM was unset.
+  private def self.wrap(text : String, width : Int32) : Array(String)
+    words = text.split(/\s+/).reject(&.empty?)
+    return [""] of String if words.empty?
+
+    lines = [] of String
+    current = ""
+    words.each do |word|
+      if current.empty?
+        current = word
+      elsif current.size + 1 + word.size <= width
+        current = "#{current} #{word}"
+      else
+        lines << current
+        current = word
+      end
+    end
+    lines << current unless current.empty?
+    lines
+  end
+
+  private def self.labelled_list(label : String, values : Array(String)) : String
+    prefix = "  #{label}: "
+    lines = wrap(values.join(", "), WIDTH - prefix.size)
+    String.build do |io|
+      io << prefix << lines.first << "\n"
+      lines[1..].each { |line| io << " " * prefix.size << line << "\n" }
+    end
+  end
+
+  private def self.row(name : String, description : String) : String
+    label = "  #{name}"
+    lines = wrap(description, WIDTH - NAME_COLUMN)
+    String.build do |io|
+      if label.size >= NAME_COLUMN
+        io << label << "\n"
+        lines.each { |line| io << " " * NAME_COLUMN << line << "\n" unless line.empty? }
+      else
+        io << label.ljust(NAME_COLUMN) << lines.first << "\n"
+        lines[1..].each { |line| io << " " * NAME_COLUMN << line << "\n" }
+      end
+    end
+  end
+end
+
+desc "Show usage; `help tasks` lists every task, `help <task>` describes one"
+task "help" do |_, args|
+  topic = args.raw.first?.try(&.to_s)
+
+  case topic
+  when nil
+    puts CLIHelp.main_page
+  when "tasks"
+    puts CLIHelp.task_list
+  else
+    detail = CLIHelp.task_detail(topic)
+    if detail
+      puts detail
+    else
+      stdout_failure "Unknown task '#{topic}'."
+      if suggestion = CLIHelp.suggestion_for(topic)
+        stdout_failure "Did you mean '#{suggestion}'?"
+      end
+      stdout_info "Run `#{CLIHelp::BIN_NAME} help tasks` to list every task."
+      exit USAGE_EXIT_CODE
+    end
+  end
+end

--- a/src/tasks/utils/cli_invocation.cr
+++ b/src/tasks/utils/cli_invocation.cr
@@ -1,0 +1,8 @@
+# Flags recognized by the top-level OptionParser in logging.cr. That parser runs
+# at require time, before every task is registered, so it only records what was
+# asked for - the entry point acts on it once the task tree is complete and can
+# therefore render a help page that lists everything.
+class CLIInvocation
+  class_property? help_requested : Bool = false
+  class_property? version_requested : Bool = false
+end

--- a/src/tasks/utils/logging.cr
+++ b/src/tasks/utils/logging.cr
@@ -1,4 +1,5 @@
 require "colorize"
+require "./cli_invocation"
 
 private class CLILogLevel
   class_property level : String = ""
@@ -11,11 +12,14 @@ Colorize.enabled = STDOUT.tty? && !ENV.has_key?("NO_COLOR")
 
 begin
   OptionParser.parse do |parser|
-    parser.banner = "Usage: cnf-testsuite [arguments]"
+    parser.banner = "Usage: cnf-testsuite [options] <task> [arguments]"
     parser.on("-l LEVEL", "--loglevel=LEVEL", "Specifies the logging level for cnf-testsuite suite") do |level|
       CLILogLevel.level = level
     end
-    parser.on("-h", "--help", "Show this help") { puts parser }
+    # These only record the request: this parser runs at require time, before
+    # the tasks exist, so the entry point is what acts on them.
+    parser.on("-h", "--help", "Show usage and exit") { CLIInvocation.help_requested = true }
+    parser.on("--version", "Print the version and exit") { CLIInvocation.version_requested = true }
   end
 rescue ex : OptionParser::InvalidOption
   puts ex

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -388,6 +388,7 @@ task "helm_deploy" do |t, args|
   end
 end
 
+desc "Checks if the CNF's helm chart is published in a helm repository"
 task "helm_chart_published", ["setup:install_local_helm"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     helm = Helm::Binary.get
@@ -439,6 +440,7 @@ task "helm_chart_published", ["setup:install_local_helm"] do |t, args|
   end
 end
 
+desc "Checks if the CNF's helm chart passes `helm lint`"
 task "helm_chart_valid", ["setup:install_local_helm"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     current_dir = FileUtils.pwd

--- a/src/tasks/workload/mock_task.cr
+++ b/src/tasks/workload/mock_task.cr
@@ -7,7 +7,7 @@ require "../utils/utils.cr"
 require "../../modules/kubectl_client"
 
 
-task "divide_by_zero" do |_, args|
+task "_divide_by_zero" do |_, args|
   CNFManager::Task.task_runner(args, check_cnf_installed: false) do |args, config, result|
     Log.info {"divide by zero"}
     raise "divide by zero" 


### PR DESCRIPTION
Closes #2429.

## Problem

`cnf-testsuite help` was SAM's flat `ShellTable` dump of all ~160 registered tasks:

```
$ env -u TERM ./cnf-testsuite help
… backtrace …
Invalid Int32: ""          # exit 1
```

`ShellTable` shells out to `tput cols` and calls `.to_i` on the empty result, so **help crashed whenever TERM was unset** — containers and CI, i.e. where people first meet the tool. Otherwise it printed 334 lines with no usage synopsis, no grouping, and nothing about flags, `key=value` arguments, `~exclusions` or the `@` separator. Internal tasks (`_tools_uninstall_start`, `divide_by_zero`, `generate:makefile`) sat alongside real ones, and `cnf_install`/`cnf_uninstall`/`validate_config` had blank descriptions. `-h` printed the option banner and then fell through to the same dump; `--version` did not exist.

## What it looks like now

```
$ cnf-testsuite help          # also -h, also a bare invocation — 43 lines
USAGE
  cnf-testsuite [options] <task> [arguments] [~exclusions] [@ <task> ...]

TYPICAL WORKFLOW
  cnf-testsuite setup                                    install prerequisites (once)
  cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
  …
EXIT CODES
  0   the run met its objective          2   a test errored (the suite broke)
  1   it did not                         64  usage error, before any test ran
```

```
$ cnf-testsuite help tasks
GETTING STARTED / TEST SUITES / WORKLOAD TESTS: <category> ×7 / PLATFORM TESTS /
5G AND RAN TESTS / CERTIFICATION / TOOL MANAGEMENT / SETUP HELPERS / UTILITIES / OTHER

$ cnf-testsuite help compatibility
  Runs first: helm_chart_valid, helm_chart_published, helm_deploy, cni_compatible, …
  Part of: workload

$ cnf-testsuite livenes
Task livenes was not found
Did you mean 'liveness'?
```

Rendering happens in-repo at a fixed width, so **there is nothing to shell out to and the TERM crash is gone by construction**.

## Design notes

- **Nothing can drift.** The argument and flag lists come from the `KNOWN_CLI_*` allowlists validation already uses, so help and validation cannot disagree. The test groups expand the suite's *own aggregates* rather than repeating their contents.
- **Nothing gets silently dropped.** Whatever no group claims is listed under "Other" — which is how I noticed that `zombie_handled` is defined in `microservice.cr` but is not in the `microservice` aggregate's deps, so it never runs as part of `workload`. Left alone here; worth a separate look.
- **Hidden by convention, not by list.** A leading underscore on the final path segment marks a task internal, so a hide-list can't rot as tasks are added. `divide_by_zero` and `cert_compatibility_title` are renamed accordingly.
- **`-h`/`--version` are recorded, then acted on.** The OptionParser in `logging.cr` runs at require time, before any task is registered; the entry point acts on the flags once the task tree is complete. Otherwise help would list only the tasks registered so far.
- `Sam::Task` and `Sam::NotFound` are reopened to expose a task's dependency list and the unresolved path — the pattern already used for `Sam::Args` in `sam_args_patch.cr`.

## Also

- Descriptions added for every task that lacked one; `all`/`workload` no longer share five lines of identical boilerplate.
- Shell completion now offers only visible tasks, and finally includes namespaced ones (`setup:install_litmus`). The full completion overhaul stays with #2430.
- `help` takes a topic rather than flags, so `validate_cli_args!` skips its arguments.

## Verification

Every acceptance criterion checked against the built binary:

| criterion | result |
|---|---|
| `help` with TERM unset | exit 0, 43 lines, no backtrace |
| `-h` prints one page, exits 0 | identical to `help`, single `USAGE` |
| `--version` | prints version, exit 0 |
| `help tasks` grouped, no internal tasks, all described | 11 groups, 155 tasks, none blank |
| `help <task>` | description + "Runs first" + "Part of" |
| unknown task suggestion | suggests, and stays silent when nothing is close |

Regression-checked: bare invocation, `version`, `-l debug`, usage errors still exit 64. `crystal spec --tag points` — 24 examples, 0 failures (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)