### PR TITLE
ci: stop free5GC runs colliding on a fixed kind cluster name

### DIFF
--- a/.github/workflows/nightly_free5gc.yml
+++ b/.github/workflows/nightly_free5gc.yml
@@ -3,12 +3,23 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
-  push:
-    branches:
-      - main
+
+# The validation owns a whole kind cluster on a shared self-hosted runner, so
+# runs must not overlap. Queue them instead of cancelling: a nightly run that
+# is already exercising free5GC is worth finishing.
+concurrency:
+  group: free5gc-validation
+  cancel-in-progress: false
+
 jobs:
   free5gc-validation:
     runs-on: [v1.0.0]
+    env:
+      # Unique per run. A fixed name ("free5gc-dev") collided whenever a second
+      # run started before the first had cleaned up, and a leaked cluster then
+      # blocked every later run: "node(s) already exist for a cluster with the
+      # name free5gc-dev".
+      KIND_CLUSTER_NAME: free5gc-${{ github.run_id }}
     steps:
       - name: Checkout Code & Submodules
         uses: actions/checkout@v4
@@ -66,7 +77,7 @@ jobs:
             - containerPath: /var/lib/kubelet/config.json
               hostPath: $HOME/.docker/config.json
           EOF
-          kind create cluster --name free5gc-dev --config kind_setup.yaml --wait 5m
+          kind create cluster --name "$KIND_CLUSTER_NAME" --config kind_setup.yaml --wait 5m
       - name: Build CNF Testsuite
         run: |
           shards install
@@ -75,6 +86,8 @@ jobs:
         run: |
           LOG_LEVEL=INFO crystal spec spec/free5gc_cert_spec.cr -v
       - name: Delete Kind Cluster
+        if: always()
         continue-on-error: true
+        timeout-minutes: 10
         run: |
-          until kind delete cluster --name free5gc-dev  --verbosity 1; do sleep 1; done
+          until kind delete cluster --name "$KIND_CLUSTER_NAME" --verbosity 1; do sleep 1; done


### PR DESCRIPTION
## Problem

The free5GC validation creates its cluster under the fixed name `free5gc-dev`, so a second run starting before the first finished fails outright ([run](https://github.com/lfn-cnti/testsuite/actions/runs/32388971760)):

```
ERROR: failed to create cluster: node(s) already exist for a cluster with the name "free5gc-dev"
```

Three things combined to make this **self-perpetuating**.

**It ran on every push to main**, not just nightly. Merging three PRs this afternoon started three full validations, two of which were still running when the third tried to create the cluster:

| time | trigger | state |
|---|---|---|
| 14:46 | #2442 merge | still running |
| 15:17 | #2427 merge | still running |
| 15:55 | #2443 merge | **failed — name taken** |

**Nothing serialized them.** No `concurrency` group, so runs raced for the one name.

**Cleanup could not recover it.** `continue-on-error: true` only stops that step's *own* failure from failing the job — it does **not** run the step after an earlier step failed. The step list from the failing run:

```
failure  Setup Kind Cluster with Sysctl Patch
skipped  Build CNF Testsuite
skipped  Run Free5GC Spec Test
skipped  Delete Kind Cluster      <-- never ran
```

So any failure leaked the cluster, and the leaked cluster made the *next* run fail at creation, which skipped cleanup again. Once wedged it stayed wedged until someone deleted the cluster by hand. That is why the 00:38 scheduled run and several pushes on 8/19 also failed.

## Changes

1. **Nightly and on-demand only** — dropped the `push: branches: [main]` trigger. A full free5GC validation per merge is what put three runs on one runner.
2. **`concurrency: { group: free5gc-validation, cancel-in-progress: false }`** — runs queue instead of racing. Not cancelling, since a run already exercising free5GC is worth finishing.
3. **Cluster name unique per run** — `free5gc-${{ github.run_id }}`, matching what the spec workflows already do with `uuidgen`.
4. **`if: always()` on cleanup**, plus `timeout-minutes: 10` — it now runs on every path, including after a failed creation, and its `until … do sleep 1; done` retry loop is unbounded so it needs a bound.

The unique name also means a leaked cluster can no longer *block* a later run; the only remaining cost is the stale cluster's own resources.

## Verification

- YAML re-validated after the edit.
- No other reference to `free5gc-dev` anywhere in the repo (only the explanatory comments), so nothing else depends on the old name.
- Generated name form (`free5gc-32388971760`) checked against kind's allowed character set.

Cluster creation still writes the default kubeconfig rather than an isolated `--kubeconfig` file as `actions.yml` does. That is safe here — the spec workflows isolate theirs, and this workflow's runs are now serialized — but adopting the same isolation would be a reasonable follow-up.

## Needs a manual step

The currently leaked `free5gc-dev` cluster still exists on the runner and will not be cleaned up by this change (the workflow no longer uses that name). Someone with runner access should run:

```
kind delete cluster --name free5gc-dev
```

Related: #2445 ("Related" section) notes the same leaked cluster, and #2442 fixed the same fixed-shared-name class of bug for the spec registry containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)