### PR TITLE
Stop node_drain cordoning one node while draining another

### DIFF
--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -479,7 +479,7 @@ All state: `./cnf-testsuite state`
 
 #### Overview
 
-A node is drained and workload resources rescheduled to another node, passing with a liveness and readiness check. This will skip when the cluster only has a single node.
+A node is drained and workload resources rescheduled to another node, passing with a liveness and readiness check. This will skip when the cluster has fewer than two schedulable nodes, when the workload has no scheduled pod, or when no schedulable node is left to move the chaos operator onto.
 Expectation: All workload resources are successfully rescheduled onto other available node(s).
 
 #### Rationale

--- a/src/tasks/utils/litmus_manager.cr
+++ b/src/tasks/utils/litmus_manager.cr
@@ -26,12 +26,37 @@ module LitmusManager
     File.write(MODIFIED_LITMUS_FILE, output_file) unless output_file == nil
   end
 
-  def self.get_target_node_to_cordon(deployment_label, deployment_value, namespace)
-    app_nodeName_cmd = "kubectl get pods -l #{deployment_label}=#{deployment_value} -n #{namespace} -o=jsonpath='{.items[0].spec.nodeName}'"
-    Log.info { "Getting the operator node name: #{app_nodeName_cmd}" }
-    status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
-    Log.debug { "status_code: #{status_code}" }
-    appNodeName_response.to_s
+  # Node the workload identified by `deployment_label=deployment_value` sits on,
+  # or nil when it has no pod scheduled anywhere.
+  def self.get_workload_node_name(deployment_label, deployment_value, namespace) : String?
+    scheduled_pod_node_name(namespace, "#{deployment_label}=#{deployment_value}")
+  end
+
+  # Node the Litmus operator sits on, or nil when it is not scheduled anywhere.
+  def self.get_litmus_node_name : String?
+    scheduled_pod_node_name(LITMUS_NAMESPACE, "app.kubernetes.io/name=litmus")
+  end
+
+  # Node of the pod matching `selector`, or nil when none is scheduled.
+  #
+  # Terminating pods are excluded. They are still listed by `kubectl get pods` and
+  # their phase is still Running, so only the deletion timestamp distinguishes
+  # them -- and the node one of them names is a node its workload is already
+  # leaving, which sends the caller to the wrong node moments later.
+  #
+  # A pod that is scheduled but still starting does count: it is already bound to
+  # its node. A Running pod is preferred when the selector matches several.
+  private def self.scheduled_pod_node_name(namespace : String, selector : String) : String?
+    logger = Log.for("scheduled_pod_node_name")
+    pods = KubectlClient::Get.resource("pods", namespace: namespace, selector: selector)
+    items = pods.dig?("items").try(&.as_a) || [] of JSON::Any
+    scheduled_pods = items.select do |pod|
+      pod.dig?("metadata", "deletionTimestamp").nil? && pod.dig?("spec", "nodeName")
+    end
+    pod = scheduled_pods.find { |p| p.dig?("status", "phase").try(&.as_s) == "Running" } || scheduled_pods.first?
+    node_name = pod.try(&.dig?("spec", "nodeName")).try(&.as_s)
+    logger.info { "Selector '#{selector}' in #{namespace} namespace matched #{items.size} pod(s), #{scheduled_pods.size} of them scheduled and not terminating; node: #{node_name || "none"}" }
+    node_name
   end
 
   private def self.get_status_info(chaos_resource, test_name, output_format, namespace) : {Int32, String}

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -217,7 +217,7 @@ end
 desc "Does the CNF crash when node-drain occurs"
 task "node_drain", ["setup:install_litmus"] do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
-    skipped = false
+    skip_reason : String? = nil
     task_response = CNFManager.workload_resource_test(args, config) do |resource, _, _|
       test_passed = true
       app_namespace = resource[:namespace]
@@ -229,124 +229,128 @@ task "node_drain", ["setup:install_litmus"] do |t, args|
         result.add_impacted_resource(resource["kind"], resource["name"], resource["namespace"], reason: "no resource label found for #{t.name} test")
         test_passed = false
       else
-        schedulable_nodes_count=KubectlClient::Get.schedulable_nodes_list
-        cordon_deployment_label = "#{spec_labels.as_h.first_key}"
-        cordon_deployment_value = "#{spec_labels.as_h.first_value}"
+        schedulable_nodes = KubectlClient::Get.schedulable_nodes_list
+        deployment_label = "#{spec_labels.as_h.first_key}"
+        deployment_label_value = "#{spec_labels.as_h.first_value}"
 
         # Declare this outside the block so that the name of the node can be used to uncordon later.
         cordon_target_node_name = nil
 
-        if schedulable_nodes_count.size > 1
-          # Identify cordon node target.
-          cordon_target_node_name = LitmusManager.get_target_node_to_cordon(cordon_deployment_label, cordon_deployment_value, namespace: app_namespace)
-          Log.info { "Found node to cordon #{cordon_target_node_name} using label #{cordon_deployment_label}='#{cordon_deployment_value}' in #{app_namespace} namespace." }
+        begin
+          # Resolve the workload's node once, up front, and use that single answer for
+          # both the cordon and the chaos experiment. Asking a second time after
+          # cordoning let the two answers disagree: pods terminating from an earlier
+          # test are still listed by kubectl, so the first answer could name a node the
+          # workload had already left, and the run would cordon one node while draining
+          # another.
+          app_node_name = LitmusManager.get_workload_node_name(deployment_label, deployment_label_value, namespace: app_namespace)
 
-          # Cordon the node.
-          cordon_result = KubectlClient::Utils.cordon("#{cordon_target_node_name}")
-
-          # If cordoning fails, skip the test.
-          if cordon_result[:status].success?
-            Log.info { "Cordoned node #{cordon_target_node_name} successfully." }
+          if schedulable_nodes.size <= 1
+            skip_reason = "node_drain chaos test requires the cluster to have atleast two schedulable nodes"
+          elsif app_node_name.nil?
+            skip_reason = "node_drain chaos test found no scheduled pod for #{deployment_label}=#{deployment_label_value} in the #{app_namespace} namespace"
           else
-            Log.info { "Unable to cordon node #{cordon_target_node_name}." }
-            skipped = true
-          end
-        else
-          Log.info { "Skipping test. Scheduleable node count is not > 1." }
-          skipped = true
-        end
+            Log.info { "Found node to cordon #{app_node_name} using label #{deployment_label}='#{deployment_label_value}' in #{app_namespace} namespace." }
 
-        unless skipped
-          test_passed = true
-          deployment_label="#{spec_labels.as_h.first_key}"
-          deployment_label_value="#{spec_labels.as_h.first_value}"
-          app_nodeName_cmd = "kubectl get pods -l #{deployment_label}=#{deployment_label_value} -n #{resource["namespace"]} -o=jsonpath='{.items[0].spec.nodeName}'"
-          Log.for("node_drain").debug { "Getting the app node name #{app_nodeName_cmd}" }
-          status_code = Process.run("#{app_nodeName_cmd}", shell: true, output: appNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
-          Log.for("node_drain").debug { "status_code: #{status_code}" }
-          app_nodeName = appNodeName_response.to_s
+            # Record the cordon target before cordoning, so the ensure block below
+            # releases the node even if the cordon only partly took effect.
+            cordon_target_node_name = app_node_name
+            cordon_result = KubectlClient::Utils.cordon(app_node_name)
 
-          litmus_nodeName_cmd = "kubectl get pods -n litmus -l app.kubernetes.io/name=litmus -o=jsonpath='{.items[0].spec.nodeName}'"
-          Log.for("node_drain").debug { "Getting the app node name #{litmus_nodeName_cmd}" }
-          status_code = Process.run("#{litmus_nodeName_cmd}", shell: true, output: litmusNodeName_response = IO::Memory.new, error: stderr = IO::Memory.new).exit_code
-          Log.for("node_drain").debug { "status_code: #{status_code}" }
-          litmus_nodeName = litmusNodeName_response.to_s
-          Log.info { "Workload Node Name: #{app_nodeName}" }
-          Log.info { "Litmus Node Name: #{litmus_nodeName}" }
-          if litmus_nodeName == app_nodeName
-            Log.info { "Litmus and the workload are scheduled to the same node. Re-scheduling Litmus" }
-            nodes = KubectlClient::Get.schedulable_nodes_list
-            node_names = nodes.map { |item|
-              Log.info { "items labels: #{item.dig?("metadata", "labels")}" }
-              node_name = item.dig?("metadata", "labels", "kubernetes.io/hostname")
-              Log.debug { "NodeName: #{node_name}" }
-              node_name
-            }
-            Log.info { "All Schedulable Nodes: #{nodes}" }
-            Log.info { "Schedulable Node Names: #{node_names}" }
-            litmus_nodes = node_names - ["#{litmus_nodeName}"]
-            Log.info { "Schedulable Litmus Nodes: #{litmus_nodes}" }
-
-            download_file("#{LitmusManager::LITMUS_OPERATOR}","#{LitmusManager::DOWNLOADED_LITMUS_FILE}")
-            Log.info {"Re-Schedule Litmus"}
-            LitmusManager.add_node_selector(litmus_nodes[0])
-            KubectlClient::Apply.file("#{LitmusManager::MODIFIED_LITMUS_FILE}")
-            KubectlClient::Wait.resource_wait_for_install(kind: "Deployment", resource_name: "chaos-operator-ce", wait_count: 180, namespace: "litmus")
+            # If cordoning fails, skip the test.
+            if cordon_result[:status].success?
+              Log.info { "Cordoned node #{app_node_name} successfully." }
+            else
+              skip_reason = "node_drain chaos test was unable to cordon node #{app_node_name}"
+            end
           end
 
-          experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/node-drain/fault.yaml"
-          rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/node-drain/rbac.yaml"
+          if skip_reason.nil? && app_node_name
+            litmus_node_name = LitmusManager.get_litmus_node_name
+            Log.info { "Workload Node Name: #{app_node_name}" }
+            Log.info { "Litmus Node Name: #{litmus_node_name}" }
 
-          experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
-          KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
-  
-          rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
-          rbac_yaml = File.read(rbac_path)
-          rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
-          File.write(rbac_path, rbac_yaml)
-          KubectlClient::Apply.file(rbac_path)
+            if litmus_node_name == app_node_name
+              # Litmus would be drained along with the workload, so it has to move
+              # first. The workload's node is cordoned by now and is therefore already
+              # absent from the schedulable list.
+              Log.info { "Litmus and the workload are scheduled to the same node. Re-scheduling Litmus" }
+              litmus_nodes = KubectlClient::Get.schedulable_nodes_list.compact_map do |item|
+                item.dig?("metadata", "labels", LitmusManager::NODE_LABEL).try(&.as_s)
+              end.reject { |node_name| node_name == app_node_name }
+              Log.info { "Schedulable Litmus Nodes: #{litmus_nodes}" }
 
-          KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
+              litmus_target_node = litmus_nodes.first?
+              if litmus_target_node.nil?
+                # Nowhere to move Litmus to. Draining this node would take the chaos
+                # operator down with the workload, so there is no test to run.
+                skip_reason = "node_drain chaos test requires a schedulable node that does not run Litmus, but #{app_node_name} is the only one left"
+              else
+                download_file("#{LitmusManager::LITMUS_OPERATOR}", "#{LitmusManager::DOWNLOADED_LITMUS_FILE}")
+                Log.info { "Re-Schedule Litmus" }
+                LitmusManager.add_node_selector(litmus_target_node)
+                KubectlClient::Apply.file("#{LitmusManager::MODIFIED_LITMUS_FILE}")
+                KubectlClient::Wait.resource_wait_for_install(kind: "Deployment", resource_name: "chaos-operator-ce", wait_count: 180, namespace: "litmus")
+              end
+            end
+          end
 
-          chaos_experiment_name = "node-drain"
-          test_name = "#{resource["name"]}-#{Random::Secure.hex(4)}"
-          chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
+          if skip_reason.nil? && app_node_name
+            experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/node-drain/fault.yaml"
+            rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/node-drain/rbac.yaml"
 
-          template = ChaosTemplates::NodeDrain.new(
-            test_name,
-            "#{chaos_experiment_name}",
-            app_namespace,
-            "#{deployment_label}",
-            "#{deployment_label_value}",
-            app_nodeName
-          ).to_s
-          Log.for("node_drain").info { "Chaos test name: #{test_name}; Experiment name: #{chaos_experiment_name}; Label #{deployment_label}=#{deployment_label_value}; namespace: #{app_namespace}" }
-          chaos_template_path = File.join(CNF_TEMP_FILES_DIR, "#{chaos_experiment_name}-chaosengine.yml")
-          File.write(chaos_template_path, template)
-          KubectlClient::Apply.file(chaos_template_path)
-          LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
-          test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
-        end
+            experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
+            KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
 
-        # Uncordon the node.
-        if cordon_target_node_name
-          uncordon_result = KubectlClient::Utils.uncordon("#{cordon_target_node_name}")
+            rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
+            rbac_yaml = File.read(rbac_path)
+            rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
+            File.write(rbac_path, rbac_yaml)
+            KubectlClient::Apply.file(rbac_path)
 
-          # If uncordoning fails, log the error.
-          if uncordon_result[:status].success?
-            Log.info { "Uncordoned node #{cordon_target_node_name} successfully." }
-          else
-            Log.error { "Uncordoning node #{cordon_target_node_name} failed." }
-            skipped = true
+            KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
+
+            chaos_experiment_name = "node-drain"
+            test_name = "#{resource["name"]}-#{Random::Secure.hex(4)}"
+            chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
+
+            template = ChaosTemplates::NodeDrain.new(
+              test_name,
+              "#{chaos_experiment_name}",
+              app_namespace,
+              "#{deployment_label}",
+              "#{deployment_label_value}",
+              app_node_name
+            ).to_s
+            Log.for("node_drain").info { "Chaos test name: #{test_name}; Experiment name: #{chaos_experiment_name}; Label #{deployment_label}=#{deployment_label_value}; namespace: #{app_namespace}" }
+            chaos_template_path = File.join(CNF_TEMP_FILES_DIR, "#{chaos_experiment_name}-chaosengine.yml")
+            File.write(chaos_template_path, template)
+            KubectlClient::Apply.file(chaos_template_path)
+            LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
+            test_passed = LitmusManager.check_chaos_verdict(chaos_result_name, chaos_experiment_name, args, namespace: app_namespace)
+          end
+        ensure
+          # Uncordon the node whatever happened above. Without this, a test that raises
+          # leaves the cluster one schedulable node short for every test that follows.
+          if cordon_target_node_name
+            uncordon_result = KubectlClient::Utils.uncordon("#{cordon_target_node_name}")
+
+            # If uncordoning fails, log the error.
+            if uncordon_result[:status].success?
+              Log.info { "Uncordoned node #{cordon_target_node_name} successfully." }
+            else
+              Log.error { "Uncordoning node #{cordon_target_node_name} failed." }
+              skip_reason = "node_drain chaos test was unable to uncordon node #{cordon_target_node_name}"
+            end
           end
         end
       end
 
       test_passed
     end
-    if skipped
-      Log.for(t.name).warn{"The node_drain test needs minimum 2 schedulable nodes, current number of nodes: #{KubectlClient::Get.schedulable_nodes_list.size}"}
-      result.skipped("node_drain chaos test requires the cluster to have atleast two schedulable nodes")
+    if skip_reason
+      Log.for(t.name).warn { "#{skip_reason}. Current number of schedulable nodes: #{KubectlClient::Get.schedulable_nodes_list.size}" }
+      result.skipped(skip_reason)
     elsif task_response
       result.passed("node_drain chaos test passed")
     else


### PR DESCRIPTION
`node_drain` intermittently dies with `Index out of bounds` instead of producing a verdict, failing the `debian` job on unrelated PRs ([#2403](https://github.com/lfn-cnti/testsuite/pull/2403), [#2404](https://github.com/lfn-cnti/testsuite/pull/2404), both on bookworm within five minutes of each other; the same commit passed 28 minutes earlier).

```
💥 🏆ERROR: [node_drain] Unexpected error occurred
Index out of bounds
  src/tasks/workload/state.cr:292:45   ← LitmusManager.add_node_selector(litmus_nodes[0])
```

## The bug

The test resolved the workload's node **twice**, from two separate `kubectl get pods … {.items[0].spec.nodeName}` calls: once to choose the cordon target, and again *after* cordoning to aim the chaos experiment. Terminating pods are still listed by `kubectl get pods`, and `increase_decrease_capacity` runs immediately before `node_drain` — scaling coredns 1→3→1 and leaving pods on their way out. In the failing run only **0.6 s** separated the two tests.

When the two calls disagreed, the run cordoned a node the workload had already left. The workload's real node therefore stayed schedulable, and if Litmus shared it:

```crystal
litmus_nodes = node_names - ["#{litmus_nodeName}"]   # [B] - [B] => []
LitmusManager.add_node_selector(litmus_nodes[0])     # 💥
```

`schedulable_nodes_list` filters on `NoSchedule` taints and `kubectl cordon` adds one, so on the 3-node kind cluster (tainted control-plane + 2 workers) exactly one candidate survives the cordon. The crash proves that survivor was the workload's node — i.e. that the two lookups disagreed.

It costs the run twice over: exit code 2 for an errored test, **and** one essential test short of certification (14 of 18, threshold 15 — a passing run scores exactly 15, so `node_drain` is the entire margin).

## The change

**Resolve the node once**, before anything is cordoned, and use that single answer for both the cordon and the experiment. The lookup moved from a shell-out to `KubectlClient`, and skips pods carrying a `deletionTimestamp` — the *only* thing that distinguishes a terminating pod, whose phase is still `Running`. A pod that is scheduled but still starting counts, since it is already bound to its node.

**Guard the relocation target.** With nowhere to move Litmus, draining the node would take the chaos operator down with the workload, so the test skips instead of raising. `skipped` became `skip_reason` so each skip states its own cause; the existing two-node message is unchanged, since the spec matches on it.

**Uncordon in an `ensure`.** It sat in straight-line code after the chaos run, so any exception left the node cordoned for every test that followed.

## Verification

Against a 3-node kind cluster, all three paths:

| path | result |
|---|---|
| Litmus co-located with the workload → relocation runs | `PASSED` |
| Litmus elsewhere → direct path | `PASSED` |
| exception after cordoning (injected `raise`) | node returns `Ready` |

The last one reproduces the leak too: on `main` the same injected raise leaves the node `Ready,SchedulingDisabled`; with this change it comes back `Ready`.

`crystal spec spec/workload/resilience/node_drain_spec.cr` — 1 example, 0 failures. Doc lint (`mdl -s doc-lint/mdl-style.rb -u doc-lint/mdl-TTDS-rules.rb`) clean.

## Not addressed

The `main` failure in [run 32464652936](https://github.com/lfn-cnti/testsuite/actions/runs/32464652936) is a different problem — `Connection reset by peer` in `download_file`, i.e. #2445 (no retry on network fetches).
