### PR TITLE
Classify every exit: 64 for a wrong command line, never 0 for a refusal

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -5,6 +5,7 @@
 - [Overview](USAGE.md#overview)
 - [Syntax and Usage](USAGE.md#syntax-for-running-any-of-the-tests)
 - [Common Examples](USAGE.md#common-example-commands)
+- [Exit Codes](USAGE.md#exit-codes)
 - [Logging Options](USAGE.md#logging-options)
 
 ### Overview
@@ -120,7 +121,7 @@ items:
 | `schema_version` | Integer version of this results-file schema; bumped on breaking changes. |
 | `status` | Overall run verdict, derived from `exit_code`: `passed` (0), `failed` (1), `error` (2). |
 | `command` | The command line that produced this file. |
-| `exit_code` | Process exit code, answering "did this run meet its objective?". `2` at least one test errored (raised) - the suite itself broke, which always wins. Otherwise, for a run with a pass criterion (`cert`): `0` the criterion was met, `1` it was not. For a run without one (`all`, `workload`, `platform`): `0` no test failed (passed/skipped/na), `1` at least one test failed. Additionally, the process exits with `64` (usage error) on unknown or malformed command-line arguments, before any test runs. |
+| `exit_code` | Process exit code, answering "did this run meet its objective?". `2` at least one test errored (raised) - the suite itself broke, which always wins. Otherwise, for a run with a pass criterion (`cert`): `0` the criterion was met, `1` it was not. For a run without one (`all`, `workload`, `platform`): `0` no test failed (passed/skipped/na), `1` at least one test failed. Additionally, the process exits with `64` (usage error) on unknown or malformed command-line arguments, before any test runs. See [Exit codes](#exit-codes) for the full table. |
 | `summary` | Aggregate numbers for the whole run (see below). |
 | `items` | One entry per test that ran (see below). |
 
@@ -197,6 +198,21 @@ diagnostics and go to **stderr** (or to the `LOG_PATH` file when set). This mean
 `LOG_LEVEL=debug`. When capturing the streams separately, their relative ordering is not
 guaranteed — merge them with `2>&1` if strict interleaving matters. Cursor-control progress
 rewrites and colors are only emitted when stdout is a terminal.
+
+---
+
+### Exit codes
+
+The exit code answers one question: did the invocation do what was asked?
+
+| Code | Meaning | When |
+|------|---------|------|
+| `0` | Yes | A test run met its objective — for a run with a pass criterion (`cert`) the criterion was met, for any other run no test failed. A setup, install or uninstall command completed. |
+| `1` | No | At least one test failed, or the criterion was not met. Or a command could not do its job: a precondition was missing (no kubeconfig, no CNF installed, a CNF already installed, a tool failed to install) or an operation failed. A message says which. |
+| `2` | The suite itself broke | A test raised an unexpected exception, or the process crashed outside a test. Always wins over `1`. |
+| `64` | Usage error | The command line was wrong: an unknown task, flag or argument; a malformed value; a required argument missing; an argument naming a file that does not exist. Detected before the requested operation starts. (sysexits `EX_USAGE`.) |
+
+A script that only needs pass/fail can test for `0`. A script that wants to tell "the CNF failed" (`1`) apart from "the suite or the invocation is broken" (`2`, `64`) can branch on the code.
 
 ---
 

--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -178,7 +178,7 @@ describe "Installation" do
     begin
       result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-minimal-cnf/cnf-testsuite.yml")
+      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-minimal-cnf/cnf-testsuite.yml", expect_failure: true)
       (/A CNF is already installed. Installation of multiple CNFs is not allowed./ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()

--- a/spec/utils/cli_args_spec.cr
+++ b/spec/utils/cli_args_spec.cr
@@ -27,6 +27,46 @@ describe "CLI argument validation" do
     result[:output].should contain("separate them with")
   end
 
+  it "exits 64 when a task's own arguments are missing or name no file", tags: ["points"] do
+    result = ShellCmd.run_testsuite("update_config")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("Usage: update_config")
+
+    result = ShellCmd.run_testsuite("update_config input_config=/nonexistent.yml output_config=/tmp/ignored.yml")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("does not exist")
+
+    result = ShellCmd.run_testsuite("validate_config")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("Usage: validate_config")
+
+    result = ShellCmd.run_testsuite("validate_config cnf-config=/nonexistent/cnf-testsuite.yml")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("CNF configuration file not found")
+
+    result = ShellCmd.run_testsuite("cnf_install cnf-config=/nonexistent/cnf-testsuite.yml")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("CNF configuration file not found")
+  end
+
+  it "exits 1, never 0, when a command refuses to do what was asked", tags: ["points"] do
+    output_config = File.tempname("already-latest", ".yml")
+    begin
+      result = ShellCmd.run_testsuite("update_config input_config=spec/fixtures/cnf-testsuite-v2-example.yml output_config=#{output_config}")
+      result[:status].exit_code.should eq(1)
+      result[:output].should contain("already the latest version")
+      File.exists?(output_config).should be_false
+    ensure
+      File.delete?(output_config)
+    end
+  end
+
+  it "exits 2 when the suite itself breaks outside a test", tags: ["points"] do
+    result = ShellCmd.run_testsuite("_raise_outside_task_runner")
+    result[:status].exit_code.should eq(2)
+    result[:output].should contain("unhandled")
+  end
+
   it "preserves '=' characters inside named argument values", tags: ["points"] do
     Sam::Args.new(["cnf-config=a=b"]).named["cnf-config"].should eq("a=b")
   end

--- a/spec/utils/cli_help_spec.cr
+++ b/spec/utils/cli_help_spec.cr
@@ -83,7 +83,7 @@ describe "CLI help" do
 
     # ... and on the invocation path, not just via `help`.
     result = ShellCmd.run_testsuite("livenes")
-    result[:status].exit_code.should eq(1)
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
     result[:output].should contain("Did you mean 'liveness'?")
 
     # Nothing close enough gets no misleading suggestion.

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -154,8 +154,10 @@ rescue e : Sam::NotFound
     stdout_failure "Did you mean '#{suggestion}'?"
   end
   stdout_info "Run `#{CLIHelp::BIN_NAME} help tasks` to list every task."
-  exit 1
+  exit USAGE_EXIT_CODE
 rescue e
+  # An exception nothing caught: the suite itself broke, the same verdict as
+  # a test that errored.
   puts e.backtrace.join("\n"), e
-  exit 1
+  exit CNFManager::Task::CRITICAL_FAILURE_CODE
 end

--- a/src/tasks/cert/cert_utils.cr
+++ b/src/tasks/cert/cert_utils.cr
@@ -6,8 +6,7 @@ def get_excluded_tasks(args)
     if exclude.is_a? String
       exclude = exclude.includes?(",") ? exclude.split(",") : exclude.split(" ")
     else
-      puts "Exclude argument should contain string value Ex.: (exclude=\"increase_decrease_capacity single_process_type\")"
-      exit 1
+      usage_error! "Exclude argument should contain string value Ex.: (exclude=\"increase_decrease_capacity single_process_type\")"
     end
   else
     exclude = [] of String
@@ -16,8 +15,7 @@ def get_excluded_tasks(args)
     cert_tests = CNFManager::Points.tasks_by_tag_intersection(["cert"])
     exclude.each do |task|
       unless cert_tests.includes? task
-        puts "Excluded task \"#{task}\" is not a cert test, check syntax"
-        exit 1
+        usage_error! "Excluded task \"#{task}\" is not a cert test, check syntax"
       end
     end
   end

--- a/src/tasks/setup/cnf_setup.cr
+++ b/src/tasks/setup/cnf_setup.cr
@@ -6,10 +6,14 @@ task "cnf_install", ["setup:install_local_helm", "setup:create_namespace"] do |_
   logger = SLOG.for("cnf_install")
   logger.info { "Installing CNF to cluster" }
 
+  # A wrong command line is a usage error; find out before ClusterTools is
+  # deployed, not after.
+  CNFInstall.parse_install_cli_args(args)
+
   if CNFManager.cnf_installed?
-    stdout_warning "A CNF is already installed. Installation of multiple CNFs is not allowed."
-    stdout_warning "To install a new CNF, uninstall the existing one by running: cnf_uninstall"
-    exit 0
+    stdout_failure "A CNF is already installed. Installation of multiple CNFs is not allowed."
+    stdout_failure "To install a new CNF, uninstall the existing one by running: cnf_uninstall"
+    exit 1
   end
 
   if ClusterTools.install
@@ -43,11 +47,11 @@ end
 desc "Check a cnf-testsuite.yml for errors without installing anything"
 task "validate_config" do |_, args|
   if args.named["cnf-config"]?
-    config = CNFInstall::Config.parse_cnf_config_from_file(args.named["cnf-config"].to_s)
+    config_path = CNFInstall.ensure_cnf_config_path_file(args.named["cnf-config"].to_s)
+    config = CNFInstall::Config.parse_cnf_config_from_file(config_path)
     stdout_success "Successfully validated CNF config"
     SLOG.for("validate_config").debug { "Config: #{config.inspect}" }
   else
-    stdout_failure "cnf-config parameter needed"
-    exit 1
+    usage_error! "Usage: validate_config cnf-config=PATH"
   end
 end

--- a/src/tasks/update_config.cr
+++ b/src/tasks/update_config.cr
@@ -8,8 +8,7 @@ desc "Updates an old configuration file to the latest version and saves it to th
 task "update_config" do |_, args|
   # Ensure both arguments are provided
   if !((args.named.keys.includes? "input_config") && (args.named.keys.includes? "output_config"))
-    stdout_warning "Usage: update_config input_config=OLD_CONFIG_PATH output_config=NEW_CONFIG_PATH"
-    exit(0)
+    usage_error! "Usage: update_config input_config=OLD_CONFIG_PATH output_config=NEW_CONFIG_PATH"
   end
 
   input_config = args.named["input_config"].as(String)
@@ -17,8 +16,7 @@ task "update_config" do |_, args|
 
   # Check if the input config file exists
   unless File.exists?(input_config)
-    stdout_failure "The input config file '#{input_config}' does not exist."
-    exit(1)
+    usage_error! "The input config file '#{input_config}' does not exist."
   end
 
   begin
@@ -26,8 +24,8 @@ task "update_config" do |_, args|
 
     # Verify that config is not the latest version
     if CNFInstall::Config.config_version_is_latest?(raw_input_config)
-      stdout_warning "Input config is the latest version."
-      exit(0)
+      stdout_failure "Input config is already the latest version; nothing was written to '#{output_config}'."
+      exit(1)
     end
 
     # Initialize the ConfigUpdater

--- a/src/tasks/utils/cli_args_validation.cr
+++ b/src/tasks/utils/cli_args_validation.cr
@@ -3,6 +3,14 @@ require "sam"
 # Exit code for CLI usage errors (sysexits EX_USAGE).
 USAGE_EXIT_CODE = 64
 
+# Report a usage error and exit with USAGE_EXIT_CODE. For mistakes that are
+# visible from the command line alone -- a missing or unknown argument, a
+# malformed value, a path that names no file -- before anything has run.
+def usage_error!(message : String) : NoReturn
+  stdout_failure message
+  exit USAGE_EXIT_CODE
+end
+
 # Every key=value argument some task actually reads.
 KNOWN_CLI_NAMED_ARGS = [
   "cnf-config", "cnf-path", "timeout", "input_config", "output_config",

--- a/src/tasks/utils/cli_help.cr
+++ b/src/tasks/utils/cli_help.cr
@@ -191,8 +191,8 @@ module CLIHelp
       #{Sam::TASK_SEPARATOR}         run several tasks in one invocation, e.g. `#{BIN_NAME} liveness #{Sam::TASK_SEPARATOR} readiness`
 
     EXIT CODES
-      0   the run met its objective          2   a test errored (the suite broke)
-      1   it did not                         64  usage error, before any test ran
+      0   the run met its objective          2   the suite broke: a test errored, or a crash
+      1   it did not, or a command failed    64  usage error: the command line was wrong
 
     MORE
       #{BIN_NAME} help tasks     list every task, grouped by category

--- a/src/tasks/utils/cnf_installation/install_common.cr
+++ b/src/tasks/utils/cnf_installation/install_common.cr
@@ -18,8 +18,7 @@ module CNFInstall
     parsed_args = parse_install_cli_args(cli_args)
     cnf_config_path = parsed_args[:config_path]
     if cnf_config_path.empty?
-      stdout_failure "cnf-config or cnf-path parameter with valid CNF configuration should be provided."
-      exit(1)
+      usage_error! "cnf-config or cnf-path parameter with valid CNF configuration should be provided."
     end
     config = Config.parse_cnf_config_from_file(cnf_config_path)
     ensure_cnf_dir_structure()
@@ -67,14 +66,17 @@ module CNFInstall
   end
 
   def self.ensure_cnf_config_path_file(path)
-    if CNFManager.path_has_yml?(path)
+    if path.empty?
+      usage_error! "cnf-config=PATH is required: a cnf-testsuite.yml or the directory holding one."
+    elsif CNFManager.path_has_yml?(path)
       yml = path
     elsif File.directory?(path)
       yml = File.join(path, CONFIG_FILE)
     else
-      stdout_failure "Invalid CNF configuration file: #{path}."
-      exit(1)
+      usage_error! "Invalid CNF configuration file: #{path}."
     end
+    usage_error! "CNF configuration file not found: #{yml}." unless File.file?(yml)
+    yml
   end
 
   def self.ensure_cnf_dir_structure

--- a/src/tasks/utils/cnf_manager/task.cr
+++ b/src/tasks/utils/cnf_manager/task.cr
@@ -16,7 +16,7 @@ module CNFManager
       @@logger.for("ensure_cnf_installed!").info { "Is CNF installed: #{cnf_installed}" }
 
       unless cnf_installed
-        stdout_warning("You must install a CNF first.")
+        stdout_failure("You must install a CNF first.")
         exit FAILURE_CODE
       end
     end

--- a/src/tasks/workload/mock_task.cr
+++ b/src/tasks/workload/mock_task.cr
@@ -14,3 +14,9 @@ task "_divide_by_zero" do |_, args|
     "divided by zero" 
   end
 end
+
+# Raises outside task_runner, so nothing catches it before the entrypoint's
+# last-resort rescue. Exercises the "the suite itself broke" exit code.
+task "_raise_outside_task_runner" do |_, args|
+  raise "unhandled"
+end


### PR DESCRIPTION
Follow-up to #2424 (exit code of a test run) and #2423 (exit 64 for CLI validation): the `exit` calls *outside* the test path — ~40 sites across setup, install and utility tasks — were never classified. Two "nothing to do" paths exited **0**, task-level usage mistakes exited 1 like any failure, and an unknown task exited 1 while `help <unknown>` exited 64.

## The classification

| Code | Means | What changed |
|---|---|---|
| `64` | the command line was wrong | unknown task name; malformed `exclude=`; `cnf_install`/`validate_config` with no config path or a path naming no file; `update_config` with missing args or a missing input file — all were 1 |
| `1` | the command could not, or would not, do what was asked | `cnf_install` refusing because a CNF is already installed, and `update_config` declining because the input is already the latest version — **both were 0**. Every other site (tool installs, kubeconfig, no CNF installed, install failures, parse errors, results-dir permission) already exited 1 with a message; unchanged |
| `2` | the suite itself broke | the entrypoint's last-resort rescue for an exception nothing caught — was 1 |

The rule for 64: the mistake is visible from the invocation alone. A file that fails to *parse* is bad input, not a bad command line, and stays 1.

A `usage_error!(message)` helper sits next to #2423's `USAGE_EXIT_CODE` and carries the convention into task code.

## Two things that fell out of drawing the line

- **`cnf_install` parses its arguments before deploying ClusterTools.** Previously a wrong command line was reported *after* "ClusterTools installed / CNF installation start."
- **A config path naming no file slipped past the CLI check** — `path_has_yml?` only looks at the extension — and surfaced later as "No config found" with exit 1. The check now verifies the file exists. `validate_config` resolves its path through the same helper, so it behaves like `cnf_install` (and accepts a directory as a side effect).

## Judgment call worth a look

`update_config` on an already-current config used to warn and exit 0 without writing the output file. It now exits 1 with "already the latest version; nothing was written to '<output>'". The alternative — write the file unchanged and exit 0 — is friendlier to `update_config … && use output`, but changes the task's semantics rather than its exit code. Happy to switch if you prefer that reading.

## Docs

USAGE.md gets an **Exit codes** section (+ TOC entry, + pointer from the `exit_code` field row); the help page's EXIT CODES block is aligned.

## Verification

New specs (tag `points`): 64 for missing/nonexistent arguments across `update_config`, `validate_config`, `cnf_install`; 1 for the already-latest refusal **and the output file must not exist**; 2 via a new `_raise_outside_task_runner` mock that raises where `task_runner` cannot catch it. Updated: unknown-task example (`cli_help_spec`) 1→64; already-installed example (`setup_spec:177`) now `expect_failure: true`.

- `crystal spec --tag points` — 38 examples, 0 failures
- `crystal spec --tag validate_config` — 3/3
- `crystal spec spec/setup_spec.cr:177` — 1/1 (against a live kind cluster)

Remaining `exit 1` sites in `src/tasks` are all classified and message-bearing (the acceptance check in #2433).

Closes #2433

