### PR TITLE
Keep results/latest.yml pointing at the newest results file, and let results-dir= move it

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -45,18 +45,25 @@ Failed/errored tests also print indented detail lines beneath the result:
 
 #### Results file
 
-Each run writes a **timestamped YAML file** to the `results/` directory of the current working
-directory (the path is also logged at startup):
+Each run writes a **timestamped YAML file** into the results directory — `results/` under the
+current working directory unless redirected (see below):
 
 ```
 results/cnf-testsuite-results-<YYYYMMDD-HHMMSS-mmm>.yml
 ```
 
-A new file is created per run. To grab the latest programmatically:
+A new file is created per run, and **`results/latest.yml` always points at the newest one** — a
+relative symlink, repointed whenever a results file is created (a copy, kept current, on
+filesystems without symlinks). Scripts should read `latest.yml` rather than sorting the
+directory. Every run also ends with one stable line naming both paths:
 
 ```
-ls -t results/cnf-testsuite-results-*.yml | head -1
+Results: results/cnf-testsuite-results-<timestamp>.yml (latest: results/latest.yml)
 ```
+
+To write somewhere else, pass `results-dir=PATH` on the command line or set the
+`CNF_TESTSUITE_RESULTS_DIR` environment variable; the argument wins over the variable. The
+timestamped file and `latest.yml` both go there, and `delete_results` honours the same setting.
 
 A machine-readable [JSON Schema](docs/cnf-testsuite-results.schema.json) describes the file
 (matching the current `schema_version`); use it to validate output or generate types.

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -67,9 +67,9 @@ end
 # Asserts that the most recent results file contains an item for the given task
 # with the expected status. Shared by the workload specs.
 def verify_task_result(task_name : String, expected_status : String)
-  latest_results = Dir.glob("results/cnf-testsuite-results-*.yml").max_by { |path| File.info(path).modification_time }
-  latest_results.should_not be_nil
-  yaml = YAML.parse(File.read(latest_results.not_nil!))
+  latest_results = CNFManager::Points::Results.latest
+  File.exists?(latest_results).should be_true
+  yaml = YAML.parse(File.read(latest_results))
   item = yaml["items"].as_a.find { |i| i["name"].as_s == task_name }
   item.should_not be_nil
   item.not_nil!["status"].as_s.should eq(expected_status)

--- a/spec/utils/results_spec.cr
+++ b/spec/utils/results_spec.cr
@@ -1,0 +1,46 @@
+require "../spec_helper"
+require "../../src/tasks/utils/cli_args_validation"
+
+describe "Results location" do
+  it "keeps results/latest.yml pointing at the newest results file", tags: ["points"] do
+    ShellCmd.run_testsuite("_divide_by_zero")
+    latest = CNFManager::Points::Results.latest
+    File.exists?(latest).should be_true
+    newest = Dir.glob("results/cnf-testsuite-results-*.yml").max_by { |path| File.info(path).modification_time }.not_nil!
+    File.symlink?(latest).should be_true
+    File.readlink(latest).should eq(File.basename(newest))
+    YAML.parse(File.read(latest))["items"].as_a.should_not be_empty
+  end
+
+  it "writes to results-dir=PATH, which wins over CNF_TESTSUITE_RESULTS_DIR", tags: ["points"] do
+    cli_dir = File.tempname("results-cli")
+    env_dir = File.tempname("results-env")
+    begin
+      default_count = Dir.glob("results/cnf-testsuite-results-*.yml").size
+
+      result = ShellCmd.run_testsuite("_divide_by_zero results-dir=#{cli_dir}", "CNF_TESTSUITE_RESULTS_DIR=#{env_dir}")
+      result[:output].should contain("Results: #{cli_dir}/")
+      Dir.glob(File.join(cli_dir, "cnf-testsuite-results-*.yml")).size.should eq(1)
+      File.exists?(File.join(cli_dir, "latest.yml")).should be_true
+      Dir.exists?(env_dir).should be_false
+      Dir.glob("results/cnf-testsuite-results-*.yml").size.should eq(default_count)
+
+      ShellCmd.run_testsuite("_divide_by_zero", "CNF_TESTSUITE_RESULTS_DIR=#{env_dir}")
+      env_files = Dir.glob(File.join(env_dir, "cnf-testsuite-results-*.yml"))
+      env_files.size.should eq(1)
+      File.readlink(File.join(env_dir, "latest.yml")).should eq(File.basename(env_files.first))
+
+      ShellCmd.run_testsuite("delete_results results-dir=#{cli_dir}")
+      Dir.glob(File.join(cli_dir, "*")).should be_empty
+    ensure
+      FileUtils.rm_rf(cli_dir)
+      FileUtils.rm_rf(env_dir)
+    end
+  end
+
+  it "rejects an empty results-dir= as a usage error", tags: ["points"] do
+    result = ShellCmd.run_testsuite("version results-dir=")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("results-dir=")
+  end
+end

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -202,9 +202,9 @@ describe "Microservice" do
     result = ShellCmd.run_testsuite("specialized_init_system")
     (/Containers do not use specialized init systems/ =~ result[:output]).should_not be_nil
 
-    latest_results = Dir.glob("results/cnf-testsuite-results-*.yml").max_by { |path| File.info(path).modification_time }
-    latest_results.should_not be_nil
-    yaml = YAML.parse(File.read(latest_results.not_nil!))
+    latest_results = CNFManager::Points::Results.latest
+    File.exists?(latest_results).should be_true
+    yaml = YAML.parse(File.read(latest_results))
     item = yaml["items"].as_a.find { |i| i["name"].as_s == "specialized_init_system" }
     item.should_not be_nil
     item.not_nil!["status"].as_s.should eq("failed")
@@ -227,9 +227,9 @@ describe "Microservice" do
       result = ShellCmd.run_testsuite("specialized_init_system")
       result[:status].exit_code.should eq(1)
 
-      latest_results = Dir.glob("results/cnf-testsuite-results-*.yml").max_by { |path| File.info(path).modification_time }
-      latest_results.should_not be_nil
-      yaml = YAML.parse(File.read(latest_results.not_nil!))
+      latest_results = CNFManager::Points::Results.latest
+      File.exists?(latest_results).should be_true
+      yaml = YAML.parse(File.read(latest_results))
       item = yaml["items"].as_a.find { |i| i["name"].as_s == "specialized_init_system" }
       item.should_not be_nil
       item.not_nil!["status"].as_s.should eq("failed")

--- a/spec/workload/resilience/pod_dns_error_spec.cr
+++ b/spec/workload/resilience/pod_dns_error_spec.cr
@@ -19,9 +19,9 @@ describe "Resilience pod dns error Chaos" do
       ((/( SKIPPED).*(pod_dns_error docker runtime not found)/)  =~ result[:output] || 
        (/(PASSED).*(pod_dns_error chaos test passed)/ =~ result[:output])).should_not be_nil
       
-      latest_results = Dir.glob("results/cnf-testsuite-results-*.yml").max_by { |path| File.info(path).modification_time }
-      latest_results.should_not be_nil
-      yaml = YAML.parse(File.read(latest_results.not_nil!))
+      latest_results = CNFManager::Points::Results.latest
+      File.exists?(latest_results).should be_true
+      yaml = YAML.parse(File.read(latest_results))
       item = yaml["items"].as_a.find { |i| i["name"].as_s == "pod_dns_error" }
       item.should_not be_nil
       (item.not_nil!["status"].as_s == "skipped" || item.not_nil!["status"].as_s == "passed").should be_true

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -138,6 +138,9 @@ begin
   Sam.process_tasks(argv)
 
   if CNFManager::Points::Results.file_exists?
+    # One stable line per run for scripts to grep; the pointer is the path
+    # that does not change between runs.
+    stdout_info "Results: #{CNFManager::Points::Results.file} (latest: #{CNFManager::Points::Results.latest})"
     yaml = File.open("#{CNFManager::Points::Results.file}") do |file|
       YAML.parse(file)
     end

--- a/src/tasks/cleanup.cr
+++ b/src/tasks/cleanup.cr
@@ -45,8 +45,9 @@ end
 
 desc "Deletes all results files from the results directory"
 task "delete_results" do |_, args|
-  files = Dir.glob("results/cnf-testsuite-results-*.yml")
+  files = Dir.glob(File.join(CNFManager::Points::Results.dir, "cnf-testsuite-results-*.yml"))
   files.each { |f| File.delete(f) }
+  File.delete?(CNFManager::Points::Results.latest)
   Log.info { "Deleted #{files.size} results file(s)" }
   stdout_success "Deleted #{files.size} results file(s)."
 end

--- a/src/tasks/utils/cli_args_validation.cr
+++ b/src/tasks/utils/cli_args_validation.cr
@@ -6,7 +6,7 @@ USAGE_EXIT_CODE = 64
 # Every key=value argument some task actually reads.
 KNOWN_CLI_NAMED_ARGS = [
   "cnf-config", "cnf-path", "timeout", "input_config", "output_config",
-  "exclude", "pod_labels", "baseline_count",
+  "exclude", "pod_labels", "baseline_count", "results-dir",
 ]
 # Named arguments whose value must be an integer.
 NUMERIC_CLI_NAMED_ARGS = ["timeout", "baseline_count"]
@@ -54,6 +54,8 @@ def validate_cli_args!(argv : Array(String))
         errors << "Unknown argument '#{key}='. Known arguments: #{KNOWN_CLI_NAMED_ARGS.join(", ")}."
       elsif NUMERIC_CLI_NAMED_ARGS.includes?(key) && value.to_i?.nil?
         errors << "Invalid value for '#{key}=': '#{value}' is not a number."
+      elsif key == "results-dir" && value.blank?
+        errors << "Invalid value for 'results-dir=': a directory path is required."
       end
     elsif token.starts_with?("-")
       errors << "Unknown option '#{token}'. Supported options: -l/--loglevel LEVEL, -h/--help, --version."

--- a/src/tasks/utils/cli_help.cr
+++ b/src/tasks/utils/cli_help.cr
@@ -181,6 +181,7 @@ module CLIHelp
     ARGUMENTS (key=value, after the task name)
       cnf-config=PATH   a cnf-testsuite.yml or the directory holding one (alias: cnf-path)
       timeout=SECONDS   how long to wait for install and uninstall operations
+      results-dir=PATH  where results files go (default: ./results, or $CNF_TESTSUITE_RESULTS_DIR)
       All known arguments: #{named_args}
 
     FLAGS

--- a/src/tasks/utils/cnf_manager/points.cr
+++ b/src/tasks/utils/cnf_manager/points.cr
@@ -148,8 +148,32 @@ module CNFManager
 
     class Results
       @@file : String = ""
+      @@dir : String? = nil
 
       @@logger : ::Log = Log.for("Points").for("Results")
+
+      DEFAULT_DIR     = "results"
+      RESULTS_DIR_ARG = "results-dir"
+      RESULTS_DIR_ENV = "CNF_TESTSUITE_RESULTS_DIR"
+      LATEST_NAME     = "latest.yml"
+
+      # Directory results are written to: `results-dir=PATH` on the command line,
+      # else CNF_TESTSUITE_RESULTS_DIR, else ./results. Resolved once per process
+      # and creates nothing -- delete_results reads it too.
+      def self.dir : String
+        @@dir ||= begin
+          arg = ARGV.find(&.starts_with?("#{RESULTS_DIR_ARG}="))
+          value = arg ? arg.split("=", 2)[1] : ENV[RESULTS_DIR_ENV]?
+          value.presence || DEFAULT_DIR
+        end
+      end
+
+      # Stable path to the newest results file, so scripts need not sort the
+      # directory: a relative symlink repointed whenever a results file is
+      # created (a copy, kept current, where symlinks are unsupported).
+      def self.latest : String
+        File.join(dir, LATEST_NAME)
+      end
 
       def self.file
         # (Re)create the file when it does not exist - including when something
@@ -169,6 +193,28 @@ module CNFManager
 
       private def self.create_file
         File.open(@@file, "w") { |f| YAML.dump(CNFManager::Points.template_results_yml, f) }
+        point_latest_at(@@file)
+      end
+
+      # Repoint `latest` at `path` without a window where it is missing: link
+      # under a temporary name, then rename over the old pointer. The target is
+      # relative, so a results directory stays self-contained when moved.
+      private def self.point_latest_at(path : String)
+        tmp = "#{latest}.#{Process.pid}.tmp"
+        File.delete?(tmp)
+        File.symlink(File.basename(path), tmp)
+        File.rename(tmp, latest)
+      rescue ex : File::Error
+        @@logger.for("point_latest_at").warn { "Could not symlink #{latest} -> #{path} (#{ex.message}); copying instead" }
+        FileUtils.cp(path, latest)
+      end
+
+      # Where `latest` had to be a copy, bring it up to date after a write.
+      def self.refresh_latest
+        return unless file_exists? && File.exists?(latest) && !File.symlink?(latest)
+        FileUtils.cp(@@file, latest)
+      rescue ex : File::Error
+        @@logger.for("refresh_latest").warn { "Could not refresh #{latest}: #{ex.message}" }
       end
 
       def self.ensure_results_file!
@@ -192,14 +238,15 @@ module CNFManager
     end
 
     def self.create_final_results_yml_name
+      dir = Results.dir
       begin
-        FileUtils.mkdir_p("results") unless Dir.exists?("results")
+        FileUtils.mkdir_p(dir) unless Dir.exists?(dir)
       rescue File::AccessDeniedError
-        stdout_failure("ERROR: missing write permission in current directory")
-        @@logger.for("create_final_results_yml_name").error { "Could not create ./results directory, access denied" }
+        stdout_failure("ERROR: missing write permission for results directory #{dir}")
+        @@logger.for("create_final_results_yml_name").error { "Could not create #{dir} directory, access denied" }
         exit 1
       end
-      "results/cnf-testsuite-results-" + Time.local.to_s("%Y%m%d-%H%M%S-%L") + ".yml"
+      File.join(dir, "cnf-testsuite-results-" + Time.local.to_s("%Y%m%d-%H%M%S-%L") + ".yml")
     end
 
     # Version of the results-file schema. Bump when the file's structure changes
@@ -523,6 +570,7 @@ module CNFManager
       merged[YAML::Any.new("status")] = YAML::Any.new(run_status)
       merged[YAML::Any.new("summary")] = YAML.parse(summary.to_yaml)
       File.open("#{Results.file}", "w") { |f| YAML.dump(merged, f) }
+      Results.refresh_latest
     end
 
     def self.failed_required_tasks


### PR DESCRIPTION
Every run writes `results/cnf-testsuite-results-<timestamp>.yml`, and nothing pointed at the newest one — USAGE.md told automation to `ls -t … | head -1`, and four spec sites did the equivalent glob-and-sort by mtime. There was also no way to write results anywhere but `./results`.

## What changes

**`results/latest.yml` always points at the newest results file.** A relative symlink, repointed whenever a results file is created — linked under a temporary name and renamed over the old pointer, so there is no moment the path is missing. Where symlinks are unsupported it is a copy, refreshed after each full write. Relative target, so a results directory stays self-contained when moved.

**`results-dir=PATH` and `CNF_TESTSUITE_RESULTS_DIR` redirect the directory**; the argument wins over the variable. Resolved once per process from ARGV/ENV with no side effects, so `delete_results` reads the same setting and removes the pointer with the files. `results-dir` joins the #2423 allowlist; a blank value is a usage error (64).

**One stable line per run**, printed from the entrypoint for scripts to grep:
```
Results: results/cnf-testsuite-results-20260821-132120-964.yml (latest: results/latest.yml)
```

## Scope note vs #2428

The per-aggregate *"Results have been saved to …"* lines are deliberately left alone here: #2428 removes them together with the aggregate bodies, and touching them on both branches would only manufacture conflicts. Whichever lands second drops #2428's single group-level "saved to" line, since the entrypoint line supersedes it.

## Docs and specs

USAGE.md documents the pointer, the redirect and the line, and drops the `ls -t` advice. `verify_task_result` and the three other spec sites now read the pointer instead of sorting the directory. New `spec/utils/results_spec.cr` (tag `points`) covers: pointer resolves to the newest file; redirect by argument (beating the variable) and by variable; `delete_results` honouring the directory; blank value → 64. Results-file schema untouched.

## Verification

- `crystal spec --tag points` — 38 examples, 0 failures (includes the new spec), with both the binary and the specs compiled by **Crystal 1.6.2**, the version CI pins (first push used `File.realpath`, which 1.6.2 lacks; the spec now checks the symlink via `File.readlink`)
- `crystal spec --tag args` — 5/5 (`utils_spec` with its `delete_results` before/after hooks)
- `crystal spec --tag latest_tag` — 3/3, exercising the rewritten `verify_task_result` end to end on a kind cluster
- Manual: default dir, `results-dir=` beating the env var, env var alone, `delete_results results-dir=`, blank value — all as documented

Pre-existing and unrelated, noticed along the way: `crystal spec spec/utils/utils_spec.cr` on its own fails to compile (`undefined constant SLOG` — it requires `helmenv_setup.cr` directly, which uses `SLOG` without requiring `logging.cr`). Passes when compiled with the rest of `spec/`, which is how CI runs it.

Closes #2432

