### PR TITLE
Print the results-file path once per run

### DIFF
--- a/src/tasks/cert/cert_compatibility.cr
+++ b/src/tasks/cert/cert_compatibility.cr
@@ -8,23 +8,6 @@ require "./cert_utils.cr"
 
 desc "The CNF test suite checks to see if CNFs support horizontal scaling (across multiple machines) and vertical scaling (between sizes of machines) by using the native K8s kubectl"
 task "cert_compatibility" do |t, args|
-  puts "Compatibility, Installability & Upgradability Tests".colorize(Colorize::ColorRGB.new(0, 255, 255))
-
-  exclude = get_excluded_tasks(args)
-  essential_only = args.raw.includes? "essential"
-  tags = ["compatibility", "cert"]
-  tags << "essential" if essential_only
-
-  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
-  
-  cert_stdout_score(tags, "Compatibility, Installability, and Upgradeability", exclude_warning: !exclude.empty?)
-
-  if invoked_task?("cert_compatibility")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
-
-end
-
-task "_cert_compatibility_title" do |_, args|
-  
+  run_cert_category(t, args, "compatibility", "Compatibility, Installability & Upgradability Tests",
+    "Compatibility, Installability, and Upgradeability")
 end

--- a/src/tasks/cert/cert_configuration.cr
+++ b/src/tasks/cert/cert_configuration.cr
@@ -10,17 +10,5 @@ require "./cert_utils.cr"
 desc "Configuration should be managed in a declarative manner, using ConfigMaps, Operators, or other declarative interfaces."
 
 task "cert_configuration" do |t, args|
-  puts "Configuration Tests".colorize(Colorize::ColorRGB.new(0, 255, 255))
-
-  exclude = get_excluded_tasks(args)
-  essential_only = args.raw.includes? "essential"
-  tags = ["configuration", "cert"]
-  tags << "essential" if essential_only
-
-  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
-
-  cert_stdout_score(tags, "configuration", exclude_warning: !exclude.empty?)
-  if invoked_task?("cert_configuration")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
+  run_cert_category(t, args, "configuration", "Configuration Tests")
 end

--- a/src/tasks/cert/cert_microservice.cr
+++ b/src/tasks/cert/cert_microservice.cr
@@ -11,17 +11,5 @@ require "./cert_utils.cr"
 
 desc "The CNF test suite checks to see if CNFs follows microservice principles"
 task "cert_microservice" do |t, args|
-  puts "Microservice Tests".colorize(Colorize::ColorRGB.new(0, 255, 255))
-
-  exclude = get_excluded_tasks(args)
-  essential_only = args.raw.includes? "essential"
-  tags = ["microservice", "cert"]
-  tags << "essential" if essential_only
-
-  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
-
-  cert_stdout_score(tags, "microservice", exclude_warning: !exclude.empty?)
-  if invoked_task?("cert_microservice")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
+  run_cert_category(t, args, "microservice", "Microservice Tests")
 end

--- a/src/tasks/cert/cert_observability.cr
+++ b/src/tasks/cert/cert_observability.cr
@@ -8,17 +8,6 @@ require "./cert_utils.cr"
 
 desc "In order to maintain, debug, and have insight into a protected environment, its infrastructure elements must have the property of being observable. This means these elements must externalize their internal states in some way that lends itself to metrics, tracing, and logging."
 task "cert_observability" do |t, args|
-  puts "Observability and Diagnostics Tests".colorize(Colorize::ColorRGB.new(0, 255, 255))
-
-  exclude = get_excluded_tasks(args)
-  essential_only = args.raw.includes? "essential"
-  tags = ["observability", "cert"]
-  tags << "essential" if essential_only
-
-  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
-
-  cert_stdout_score(tags, "Observability and Diagnostics", exclude_warning: !exclude.empty?)
-  if invoked_task?("cert_observability")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
+  run_cert_category(t, args, "observability", "Observability and Diagnostics Tests",
+    "Observability and Diagnostics")
 end

--- a/src/tasks/cert/cert_resilience.cr
+++ b/src/tasks/cert/cert_resilience.cr
@@ -6,21 +6,7 @@ require "../utils/utils.cr"
 require "./cert_utils.cr"
 
 desc "The CNF test suite checks to see if the CNFs are resilient to failures."
- task "cert_resilience" do |t, args|
-  puts "Reliability, Resilience, and Availability Tests".colorize(Colorize::ColorRGB.new(0, 255, 255))
-
-  exclude = get_excluded_tasks(args)
-  essential_only = args.raw.includes? "essential"
-  tags = ["resilience", "cert"]
-  tags << "essential" if essential_only
-
-  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
-
-  Log.debug { "resilience" }
-  Log.trace { "resilience args.raw: #{args.raw}" }
-  Log.trace { "resilience args.named: #{args.named}" }
-  cert_stdout_score(tags, "Reliability, Resilience, and Availability", exclude_warning: !exclude.empty?)
-  if invoked_task?("cert_resilience")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
+task "cert_resilience" do |t, args|
+  run_cert_category(t, args, "resilience", "Reliability, Resilience, and Availability Tests",
+    "Reliability, Resilience, and Availability")
 end

--- a/src/tasks/cert/cert_security.cr
+++ b/src/tasks/cert/cert_security.cr
@@ -8,17 +8,5 @@ require "./cert_utils.cr"
 
 desc "CNF containers should be isolated from one another and the host.  The CNF Test suite uses tools like Sysdig Inspect and gVisor"
 task "cert_security" do |t, args|
-  puts "Security Tests".colorize(Colorize::ColorRGB.new(0, 255, 255))
-
-  exclude = get_excluded_tasks(args)
-  essential_only = args.raw.includes? "essential"
-  tags = ["security", "cert"]
-  tags << "essential" if essential_only
-
-  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
-
-  cert_stdout_score(tags, "security", exclude_warning: !exclude.empty?)
-  if invoked_task?("cert_security")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
+  run_cert_category(t, args, "security", "Security Tests")
 end

--- a/src/tasks/cert/cert_state.cr
+++ b/src/tasks/cert/cert_state.cr
@@ -9,17 +9,5 @@ require "./cert_utils.cr"
 
 desc "The CNF test suite checks if state is stored in a custom resource definition or a separate database (e.g. etcd) rather than requiring local storage.  It also checks to see if state is resilient to node failure"
 task "cert_state" do |t, args|
-  puts "State Tests".colorize(Colorize::ColorRGB.new(0, 255, 255))
-
-  exclude = get_excluded_tasks(args)
-  essential_only = args.raw.includes? "essential"
-  tags = ["state", "cert"]
-  tags << "essential" if essential_only
-
-  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
-
-  cert_stdout_score(tags, "state", exclude_warning: !exclude.empty?)
-  if invoked_task?("cert_state")
-    stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green)
-  end
+  run_cert_category(t, args, "state", "State Tests")
 end

--- a/src/tasks/cert/cert_utils.cr
+++ b/src/tasks/cert/cert_utils.cr
@@ -32,6 +32,20 @@ def invoke_tasks_by_tag_list(parent_task, args, tags, exclude_tasks=[] of String
   end
 end
 
+# One cert category: the colored section heading, the tag-selected member
+# tests (honoring `exclude=` and the `essential` flag), and the section score.
+# The results-file path is printed once per run by the entrypoint.
+def run_cert_category(t, args, category : String, heading : String, score_name : String? = nil)
+  puts heading.colorize(Colorize::ColorRGB.new(0, 255, 255))
+
+  exclude = get_excluded_tasks(args)
+  tags = [category, "cert"]
+  tags << "essential" if args.raw.includes?("essential")
+
+  invoke_tasks_by_tag_list(t, args, tags, exclude_tasks: exclude)
+  cert_stdout_score(tags, score_name || category, exclude_warning: !exclude.empty?)
+end
+
 def cert_stdout_score(tags, full_name, exclude_warning = false)
   stdout_score(tags, full_name)
   if exclude_warning

--- a/src/tasks/utils/group_task.cr
+++ b/src/tasks/utils/group_task.cr
@@ -184,7 +184,6 @@ module GroupTaskDSL
         end
       end
       stdout_group_verdict(path)
-      stdout_info "Results have been saved to #{CNFManager::Points::Results.file}".colorize(:green) if invoked_task?(name)
     end
   end
 end


### PR DESCRIPTION
Since #2452 the entrypoint ends every run with one stable, greppable line:

```
Results: results/cnf-testsuite-results-<ts>.yml (latest: results/latest.yml)
```

**Eight** older `Results have been saved to …` prints survived alongside it — one in the group task body ([group_task.cr](src/tasks/utils/group_task.cr)), one in each of the seven `cert_*` category tasks — so a `cert` run named the same file up to nine times. This drops them all. The entrypoint line prints on the same runs the removed lines did (an invoked task that produced a results file), and nothing greps the removed text — no spec, workflow, or doc.

## The cert_* dedup that fell out

The seven `cert_*` tasks were carrying more than the extra line: each was a copy of the same twelve-line body, differing only in category tag, section heading, and score title. Editing seven copies to remove one line was the moment to stop having seven copies: `run_cert_category` in [cert_utils.cr](src/tasks/cert/cert_utils.cr) now holds the body (heading, `exclude=` handling, the `essential` flag, tag-selected invocation, section score), and each task declares its three strings:

```crystal
task "cert_state" do |t, args|
  run_cert_category(t, args, "state", "State Tests")
end
```

Output is byte-identical apart from the dropped line — headings and score titles are passed through verbatim, including the legacy spelling differences (`Upgradability` heading vs `Upgradeability` score). Two bits of debris went with it: the empty `_cert_compatibility_title` task (referenced nowhere) and two stray trace logs in `cert_resilience`.

Net: **+25 / −102.**

## Verification

Binary and specs compiled with **Crystal 1.6.2** (the CI/release compiler):

- `crystal spec --tag points` — 49/49 (includes the `cert_state ~node_drain` arg-forwarding example, which exercises the rewritten path end to end)
- `./cnf-testsuite cert_state ~node_drain` → exactly **one** line mentioning the results file
- `./cnf-testsuite _divide_by_zero` → zero `saved to` lines, one `Results:` line
