### PR TITLE
One name per thing: kebab-case arguments, prefixed environment variables

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -52,7 +52,7 @@ Add any other context about the problem here.
 crystal src/cnf-testsuite.cr -- -l debug test
 
 # ENV variable
-LOGLEVEL=DEBUG ./cnf-testsuite test
+CNF_TESTSUITE_LOG_LEVEL=DEBUG ./cnf-testsuite test
 ```
 
 Check [usage documentation](https://github.com/cncf/cnf-testsuite/blob/main/USAGE.md) for more info about invoking commands and logging

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -344,7 +344,7 @@ jobs:
         crystal build src/cnf-testsuite.cr 
         ./cnf-testsuite setup 
         # cnf-testsuite was already built above; skip spec_helper's redundant rebuild.
-        CNF_TESTSUITE_SKIP_BUILD=1 LOG_LEVEL=debug crystal spec --tag ${{ matrix.spec }} -v
+        CNF_TESTSUITE_SKIP_BUILD=1 CNF_TESTSUITE_LOG_LEVEL=debug crystal spec --tag ${{ matrix.spec }} -v
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
@@ -430,7 +430,7 @@ jobs:
             echo "Waiting for kindnet"
             sleep 1
         done
-        LOG_LEVEL=debug crystal spec --tag ${{ matrix.tag }} -v
+        CNF_TESTSUITE_LOG_LEVEL=debug crystal spec --tag ${{ matrix.tag }} -v
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
@@ -522,9 +522,9 @@ jobs:
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
         # The example CNF is expected to fail some tests (exit 1); only an errored test (exit 2+) fails the job
-        LOG_LEVEL=debug ./cnf-testsuite all ~compatibility ~resilience ~reasonable_startup_time ~reasonable_image_size ~platform ~helm_chart_valid ~helm_chart_published || [ $? -eq 1 ]
-        LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
-        LOG_LEVEL=debug ./cnf-testsuite uninstall_all
+        CNF_TESTSUITE_LOG_LEVEL=debug ./cnf-testsuite all ~compatibility ~resilience ~reasonable_startup_time ~reasonable_image_size ~platform ~helm_chart_valid ~helm_chart_published || [ $? -eq 1 ]
+        CNF_TESTSUITE_LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
+        CNF_TESTSUITE_LOG_LEVEL=debug ./cnf-testsuite uninstall_all
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
@@ -614,9 +614,9 @@ jobs:
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
         # The example CNF is expected to fail some tests (exit 1); only an errored test (exit 2+) fails the job
-        LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~compatibility ~pod_network_latency ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap || [ $? -eq 1 ]
-        LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
-        LOG_LEVEL=debug ./cnf-testsuite uninstall_all
+        CNF_TESTSUITE_LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~compatibility ~pod_network_latency ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~helm_chart_valid ~helm_chart_published ~rollback ~secrets_used ~immutable_configmap || [ $? -eq 1 ]
+        CNF_TESTSUITE_LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
+        CNF_TESTSUITE_LOG_LEVEL=debug ./cnf-testsuite uninstall_all
     - name: Delete Cluster
       if: ${{ always() }}
       run: |
@@ -706,9 +706,9 @@ jobs:
         wget -O cnf-testsuite.yml https://raw.githubusercontent.com/lfn-cnti/testsuite/${GITHUB_SHA}/example-cnfs/coredns/cnf-testsuite.yml
         ./cnf-testsuite cnf_install cnf-config=./cnf-testsuite.yml
         # The example CNF is expected to fail some tests (exit 1); only an errored test (exit 2+) fails the job
-        LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size || [ $? -eq 1 ]
-        LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
-        LOG_LEVEL=debug ./cnf-testsuite uninstall_all
+        CNF_TESTSUITE_LOG_LEVEL=debug ./cnf-testsuite all ~resilience ~platform ~liveness ~readiness ~rolling_update ~rolling_downgrade ~rolling_version_change ~nodeport_not_used ~hostport_not_used ~hardcoded_ip_addresses_in_k8s_runtime_configuration ~rollback ~secrets_used ~immutable_configmap ~reasonable_startup_time ~reasonable_image_size || [ $? -eq 1 ]
+        CNF_TESTSUITE_LOG_LEVEL=debug ./cnf-testsuite cnf_uninstall
+        CNF_TESTSUITE_LOG_LEVEL=debug ./cnf-testsuite uninstall_all
     - name: Delete Cluster
       if: ${{ always() }}
       run: |

--- a/.github/workflows/nightly_free5gc.yml
+++ b/.github/workflows/nightly_free5gc.yml
@@ -84,7 +84,7 @@ jobs:
           crystal build src/cnf-testsuite.cr
       - name: Run Free5GC Spec Test
         run: |
-          LOG_LEVEL=INFO crystal spec spec/free5gc_cert_spec.cr -v
+          CNF_TESTSUITE_LOG_LEVEL=INFO crystal spec spec/free5gc_cert_spec.cr -v
       - name: Delete Kind Cluster
         if: always()
         continue-on-error: true

--- a/USAGE.md
+++ b/USAGE.md
@@ -251,15 +251,15 @@ Each `impacted_resources` entry has `kind` and `name`, plus optional `namespace`
 
 ### Logging Parameters
 
-- **LOG_LEVEL** environment variable: sets minimal log level to display: error (default); info; debug.
-- **LOG_PATH** environment variable: if set - all logs would be appended to the file defined by that variable.
+- **CNF_TESTSUITE_LOG_LEVEL** environment variable: sets minimal log level to display: error (default); info; debug.
+- **CNF_TESTSUITE_LOG_PATH** environment variable: if set - all logs would be appended to the file defined by that variable.
 
 #### Output streams
 
 Result lines, scores and summaries are the suite's output and go to **stdout**; log messages are
-diagnostics and go to **stderr** (or to the `LOG_PATH` file when set). This means
+diagnostics and go to **stderr** (or to the `CNF_TESTSUITE_LOG_PATH` file when set). This means
 `./cnf-testsuite <test> > results.txt 2> debug.log` cleanly separates the two even with
-`LOG_LEVEL=debug`. When capturing the streams separately, their relative ordering is not
+`CNF_TESTSUITE_LOG_LEVEL=debug`. When capturing the streams separately, their relative ordering is not
 guaranteed — merge them with `2>&1` if strict interleaving matters. Cursor-control progress
 rewrites and colors are only emitted when stdout is a terminal.
 
@@ -450,7 +450,7 @@ crystal src/cnf-testsuite.cr -- -l debug test
 #### You can also use env var for logging:
 
 ```
-LOGLEVEL=DEBUG ./cnf-testsuite test
+CNF_TESTSUITE_LOG_LEVEL=DEBUG ./cnf-testsuite test
 ```
 
 :star: Note: When setting log level, the following is the order of precedence:
@@ -484,6 +484,18 @@ immediately:
 CNF_TESTSUITE_NETWORK_RETRY_ATTEMPTS=3   # attempts per fetch
 CNF_TESTSUITE_NETWORK_RETRY_BACKOFF=2    # base seconds between attempts (attempt N waits N x backoff)
 ```
+
+#### Other environment variables:
+
+- **CNF_TESTSUITE_FORCE_INSTALL**: set (to any value) to reinstall the suite-managed local Helm even when an installation is already present.
+- **CNF_TESTSUITE_ENV**: set to `TEST` for test-mode shortcuts (smaller samples, quicker platform checks). Used by the spec suite; not meant for normal runs.
+- **CNF_TESTSUITE_RESULTS_DIR**: redirect the results directory; see [Results file](#results-file).
+
+Every variable that configures the suite's own behavior carries the `CNF_TESTSUITE_` prefix.
+Credentials and ecosystem-wide standards deliberately keep their conventional names, so one
+export serves every tool that honors them: `KUBECONFIG`, `GITHUB_TOKEN`,
+`DOCKERHUB_USERNAME`/`DOCKERHUB_PASSWORD` (shared by `docker login`, `helm registry login`,
+and the suite's registry queries — see [INSTALL.md](INSTALL.md)), `NO_COLOR`, and `HOME`.
 
 #### Running The Linter
 

--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -535,7 +535,7 @@ Setup and use elastic persistent volumes instead of local storage.
 
 #### Usage
 
-`./cnf-testsuite elastic_volume`
+`./cnf-testsuite elastic_volumes`
 
 ----------
 
@@ -1346,7 +1346,7 @@ Declarative APIs for an immutable infrastructure are anything that configures th
 
 ### Usage
 
-All configuration: `./cnf-testsuite configuration_lifecycle`
+All configuration: `./cnf-testsuite configuration`
 
 ----------
 

--- a/spec/5g/core_spec.cr
+++ b/spec/5g/core_spec.cr
@@ -26,7 +26,7 @@ describe "Core" do
   it "'smf_upf_heartbeat' should fail if the smf_upf core is not resilient to network latency", tags: ["core"]  do
     begin
       ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_open5gs/cnf-testsuite.yml")
-      result = ShellCmd.run_testsuite("smf_upf_heartbeat baseline_count=300")
+      result = ShellCmd.run_testsuite("smf_upf_heartbeat baseline-count=300")
       (/(FAILED).*(Chaos service degradation is more than 50%)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()

--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -58,14 +58,6 @@ describe "Installation" do
   end
 
   it "'cnf_install' should pass with a minimal cnf-testsuite.yml", tags: ["cnf_installation1"] do
-    result = ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample-minimal-cnf/")
-    (/CNF installation complete/ =~ result[:output]).should_not be_nil
-  ensure
-    result = ShellCmd.cnf_uninstall()
-    (/All CNF deployments were uninstalled/ =~ result[:output]).should_not be_nil
-  end
-
-  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-config arg as an alias for cnf-path", tags: ["cnf_installation1"] do
     result = ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-minimal-cnf/")
     (/CNF installation complete/ =~ result[:output]).should_not be_nil
   ensure
@@ -73,9 +65,9 @@ describe "Installation" do
     (/All CNF deployments were uninstalled/ =~ result[:output]).should_not be_nil
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config (.yml)", tags: ["cnf_installation1"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall from a cnf-testsuite.yml file path", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=example-cnfs/coredns/cnf-testsuite.yml")
+      result = ShellCmd.cnf_install("cnf-config=example-cnfs/coredns/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -83,9 +75,9 @@ describe "Installation" do
     end
   end
 
-  it "'cnf_install/cnf_uninstall' should install/uninstall with cnf-path arg as an alias for cnf-config (.yaml)", tags: ["cnf_installation1"] do
+  it "'cnf_install/cnf_uninstall' should install/uninstall from a .yaml config file path", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=spec/fixtures/cnf-testsuite.yaml")
+      result = ShellCmd.cnf_install("cnf-config=spec/fixtures/cnf-testsuite.yaml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -95,7 +87,7 @@ describe "Installation" do
 
   it "'cnf_install/cnf_uninstall' should fail on incorrect config", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=spec/fixtures/sample-bad-config.yml", expect_failure: true)
+      result = ShellCmd.cnf_install("cnf-config=spec/fixtures/sample-bad-config.yml", expect_failure: true)
       (/Error during parsing CNF config/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -104,7 +96,7 @@ describe "Installation" do
 
   it "'cnf_install/cnf_uninstall' should fail on invalid config path", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=spec/fixtures/bad-config-path", expect_failure: true)
+      result = ShellCmd.cnf_install("cnf-config=spec/fixtures/bad-config-path", expect_failure: true)
       (/Invalid CNF configuration file: spec\/fixtures\/bad-config-path\./ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -134,7 +126,7 @@ describe "Installation" do
 
   it "'cnf_install/cnf_uninstall' should install/uninstall with helm_directory that descends multiple directories", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/multi_helm_directories/cnf-testsuite.yml")
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/multi_helm_directories/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -144,7 +136,7 @@ describe "Installation" do
 
   it "'cnf_install/cnf_uninstall' should install/uninstall with manifest_directory that descends multiple directories", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-nested-manifest-dirs/cnf-testsuite.yml")
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-nested-manifest-dirs/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -154,7 +146,7 @@ describe "Installation" do
 
   it "'cnf_install/cnf_uninstall' should install/uninstall a CRD-based deployment where the Kind name doesn't directly resolve in kubectl", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-nad/cnf-testsuite.yml")
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-nad/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
       (/All \"infra\" deployment custom resources are ready/ =~ result[:output]).should_not be_nil
     ensure
@@ -166,7 +158,7 @@ describe "Installation" do
 
   it "'cnf_install/cnf_uninstall' should properly install/uninstall old versions of cnf configs", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=spec/fixtures/cnf-testsuite-v1-example.yml")
+      result = ShellCmd.cnf_install("cnf-config=spec/fixtures/cnf-testsuite-v1-example.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -176,9 +168,9 @@ describe "Installation" do
 
   it "'cnf_install' should fail if another CNF is already installed", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml")
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_coredns/cnf-testsuite.yml")
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-minimal-cnf/cnf-testsuite.yml", expect_failure: true)
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-minimal-cnf/cnf-testsuite.yml", expect_failure: true)
       (/A CNF is already installed. Installation of multiple CNFs is not allowed./ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -188,7 +180,7 @@ describe "Installation" do
 
   it "'cnf_install/cnf_uninstall' should install/uninstall a cnf with multiple deployments", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_multiple_deployments/cnf-testsuite.yml")
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_multiple_deployments/cnf-testsuite.yml")
       (/All "coredns" deployment resources are up/ =~ result[:output]).should_not be_nil
       (/All "memcached" deployment resources are up/ =~ result[:output]).should_not be_nil
       (/All "nginx" deployment resources are up/ =~ result[:output]).should_not be_nil
@@ -204,7 +196,7 @@ describe "Installation" do
 
   it "'cnf_install/cnf_uninstall' should install/uninstall deployment with mixed installation methods", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-nginx-redis/cnf-testsuite.yml")
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-nginx-redis/cnf-testsuite.yml")
       (/All "nginx" deployment resources are up/ =~ result[:output]).should_not be_nil
       (/All "redis" deployment resources are up/ =~ result[:output]).should_not be_nil
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
@@ -218,7 +210,7 @@ describe "Installation" do
 
   it "'cnf_install/cnf_uninstall' should handle partial deployment failures gracefully", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-partial-deployment-failure/cnf-testsuite.yml", expect_failure: true)
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-partial-deployment-failure/cnf-testsuite.yml", expect_failure: true)
       (/All "nginx" deployment resources are up/ =~ result[:output]).should_not be_nil
       (/Deployment of "coredns" failed during CNF installation/ =~ result[:output]).should_not be_nil
     ensure
@@ -230,7 +222,7 @@ describe "Installation" do
 
   it "'cnf_install' should detect and report conflicts between deployments", tags: ["cnf_installation1"] do
     begin
-      result = ShellCmd.cnf_install("cnf-path=spec/fixtures/sample-conflicting-deployments.yml", expect_failure: true)
+      result = ShellCmd.cnf_install("cnf-config=spec/fixtures/sample-conflicting-deployments.yml", expect_failure: true)
       (/Deployment names should be unique/ =~ result[:output]).should_not be_nil
     ensure
       ShellCmd.cnf_uninstall()
@@ -240,7 +232,7 @@ describe "Installation" do
   it "'cnf_install' should correctly handle deployment priority", tags: ["cnf_installation_priority"] do
     # (kosstennbl) ELK stack requires to be installed with specific order, otherwise it would give errors
     begin
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-elk-stack/cnf-testsuite.yml", timeout: 600)
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-elk-stack/cnf-testsuite.yml", timeout: 600)
       result[:status].success?.should be_true
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
   
@@ -298,7 +290,7 @@ describe "Installation" do
   end
 
   it "'cnf_uninstall' should fail for a stuck manifest deployment", tags: ["cnf_installation2"] do
-    result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_stuck_finalizer/cnf-testsuite.yml")
+    result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_stuck_finalizer/cnf-testsuite.yml")
     result[:status].success?.should be_true
 
     result = ShellCmd.cnf_uninstall(timeout: 30, expect_failure: true)
@@ -318,7 +310,7 @@ describe "Installation" do
   end
 
   it "'cnf_uninstall' should fail for a stuck helm deployment", tags: ["cnf_installation2"] do
-    result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_stuck_helm_deployment/")
+    result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_stuck_helm_deployment/")
     result[:status].success?.should be_true
 
     # Inject finalizer into Deployment pod template
@@ -388,7 +380,7 @@ describe "Installation" do
       # Logout before install
       ShellCmd.run("helm registry logout localhost:#{local_registry_port}")
 
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_oci_repo/")
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_oci_repo/")
       result[:status].success?.should be_true
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
     ensure
@@ -439,7 +431,7 @@ describe "Installation" do
       upload = ShellCmd.run(%(curl -fsS -u dummy:secret --data-binary @#{tgz} http://localhost:#{chart_museum_port}/api/charts))
       upload[:status].success?.should be_true
 
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_private_repo/")
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_private_repo/")
       result[:status].success?.should be_true
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
     ensure
@@ -526,7 +518,7 @@ describe "Installation" do
       ShellCmd.run("helm registry logout #{reg_host_port}")
 
       # Install via testsuite (pull requires mTLS)
-      result = ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_tls_repo/")
+      result = ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_tls_repo/")
       result[:status].success?.should be_true
       (/CNF installation complete/ =~ result[:output]).should_not be_nil
     ensure

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -13,7 +13,7 @@ require "../src/modules/k8s_netstat"
 require "../src/modules/cluster_tools"
 require "../src/modules/kubectl_client"
 
-ENV["CRYSTAL_ENV"] = "TEST"
+ENV["CNF_TESTSUITE_ENV"] = "TEST"
 
 # Specs assume no CNF is installed; a leftover installation can make them fail
 # in ways that are hard to trace back to the environment.

--- a/spec/utils/cli_args_spec.cr
+++ b/spec/utils/cli_args_spec.cr
@@ -15,6 +15,11 @@ describe "CLI argument validation" do
     result = ShellCmd.run_testsuite("cnf_install cnf-config=whatever timeout=abc")
     result[:status].exit_code.should eq(64)
     result[:output].should contain("not a number")
+
+    # cnf-path was an undocumented alias of cnf-config; retired.
+    result = ShellCmd.run_testsuite("cnf_install cnf-path=whatever")
+    result[:status].exit_code.should eq(64)
+    result[:output].should contain("Unknown argument 'cnf-path='")
   end
 
   it "warns on unmatched exclusions and task names in argument positions", tags: ["points"] do
@@ -32,7 +37,7 @@ describe "CLI argument validation" do
     result[:status].exit_code.should eq(USAGE_EXIT_CODE)
     result[:output].should contain("Usage: update_config")
 
-    result = ShellCmd.run_testsuite("update_config input_config=/nonexistent.yml output_config=/tmp/ignored.yml")
+    result = ShellCmd.run_testsuite("update_config input-config=/nonexistent.yml output-config=/tmp/ignored.yml")
     result[:status].exit_code.should eq(USAGE_EXIT_CODE)
     result[:output].should contain("does not exist")
 
@@ -52,7 +57,7 @@ describe "CLI argument validation" do
   it "exits 1, never 0, when a command refuses to do what was asked", tags: ["points"] do
     output_config = File.tempname("already-latest", ".yml")
     begin
-      result = ShellCmd.run_testsuite("update_config input_config=spec/fixtures/cnf-testsuite-v2-example.yml output_config=#{output_config}")
+      result = ShellCmd.run_testsuite("update_config input-config=spec/fixtures/cnf-testsuite-v2-example.yml output-config=#{output_config}")
       result[:status].exit_code.should eq(1)
       result[:output].should contain("already the latest version")
       File.exists?(output_config).should be_false

--- a/spec/utils/cnf_manager_spec.cr
+++ b/spec/utils/cnf_manager_spec.cr
@@ -396,7 +396,7 @@ describe "SampleUtils" do
   it "Helm_values should be used during the installation of a cnf", tags: ["cnf-config"]  do
     begin
       # fails because doesn't have a service
-      ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample_coredns_values")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_coredns_values")
       deployment_containers = KubectlClient::Get.resource_containers("deployment", "coredns-coredns", "cnf-default")
       image_tags = KubectlClient::Get.container_image_tags(deployment_containers)
       Log.info { "image_tags: #{image_tags}" }

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -138,7 +138,7 @@ describe "Utils" do
     `sed -i 's/loglevel: error/loglevel: warn/' config.yml`
     ($?.success?).should be_true
 
-    result = ShellCmd.run_testsuite("test", cmd_prefix: "unset LOG_LEVEL;")
+    result = ShellCmd.run_testsuite("test", cmd_prefix: "unset CNF_TESTSUITE_LOG_LEVEL;")
     result[:status].success?.should be_true
     (/DEBUG -- CNTI: debug test/ =~ result[:output]).should be_nil
     (/INFO -- CNTI: info test/ =~ result[:output]).should be_nil
@@ -155,22 +155,35 @@ describe "Utils" do
     (/DEBUG -- CNTI: debug test/ =~ result[:output]).should_not be_nil
   end
 
-  it "'logger' LOGLEVEL NO underscore environment variable level setting works", tags: ["logger"]  do
+  it "'logger' ignores the retired LOGLEVEL alias", tags: ["logger"]  do
+    result = ShellCmd.run_testsuite("test", cmd_prefix: "unset CNF_TESTSUITE_LOG_LEVEL; LOGLEVEL=DEBUG")
+    result[:status].success?.should be_true
+    (/DEBUG -- CNTI: debug test/ =~ result[:output]).should be_nil
+  end
+
+  it "'logger' CNF_TESTSUITE_LOG_LEVEL environment variable level setting works", tags: ["logger"]  do
     # Note: implicitly tests the override of config.yml if it exist in repo root
-    result = ShellCmd.run_testsuite("test", cmd_prefix: "unset LOG_LEVEL; LOGLEVEL=DEBUG")
+    result = ShellCmd.run_testsuite("test", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=DEBUG")
     result[:status].success?.should be_true
     (/DEBUG -- CNTI: debug test/ =~ result[:output]).should_not be_nil
   end
 
-  it "'logger' LOG_LEVEL WITH underscore environment variable level setting works", tags: ["logger"]  do
-    # Note: implicitly tests the override of config.yml if it exist in repo root
-    result = ShellCmd.run_testsuite("test", cmd_prefix: "LOG_LEVEL=DEBUG")
+  it "'logger' ignores the retired unprefixed LOG_LEVEL", tags: ["logger"]  do
+    result = ShellCmd.run_testsuite("test", cmd_prefix: "unset CNF_TESTSUITE_LOG_LEVEL; LOG_LEVEL=DEBUG")
     result[:status].success?.should be_true
-    (/DEBUG -- CNTI: debug test/ =~ result[:output]).should_not be_nil
+    (/DEBUG -- CNTI: debug test/ =~ result[:output]).should be_nil
+  end
+
+  it "'logger' ignores the retired unprefixed LOG_PATH", tags: ["logger"] do
+    path = File.tempname("retired-log-path", ".log")
+    `LOG_PATH=#{path} ./cnf-testsuite test`
+    File.exists?(path).should be_false
+  ensure
+    File.delete?(path.not_nil!)
   end
 
   it "'logger' command line level setting overrides environment variable", tags: ["logger"]  do
-    result = ShellCmd.run_testsuite("-l error test", cmd_prefix: "LOG_LEVEL=DEBUG")
+    result = ShellCmd.run_testsuite("-l error test", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=DEBUG")
     result[:status].success?.should be_true
     (/DEBUG -- CNTI: debug test/ =~ result[:output]).should be_nil
     (/INFO -- CNTI: info test/ =~ result[:output]).should be_nil
@@ -180,13 +193,13 @@ describe "Utils" do
 
   it "'logger' defaults to error when level set is missplled", tags: ["logger"]  do
     # Note: implicitly tests the override of config.yml if it exist in repo root
-    result = ShellCmd.run_testsuite("test", cmd_prefix: "unset LOG_LEVEL; LOG_LEVEL=DEGUB")
+    result = ShellCmd.run_testsuite("test", cmd_prefix: "unset CNF_TESTSUITE_LOG_LEVEL; CNF_TESTSUITE_LOG_LEVEL=DEGUB")
     result[:status].success?.should be_true
     (/ERROR -- CNTI: Invalid logging level set. defaulting to ERROR/ =~ result[:output]).should_not be_nil
   end
 
-  it "'logger' should write logs to the file when LOG_PATH is set", tags: ["logger"] do
-    response_s = `LOG_PATH=spec-test-testsuite.log ./cnf-testsuite test`
+  it "'logger' should write logs to the file when CNF_TESTSUITE_LOG_PATH is set", tags: ["logger"] do
+    response_s = `unset LOG_PATH; CNF_TESTSUITE_LOG_PATH=spec-test-testsuite.log ./cnf-testsuite test`
     $?.success?.should be_true
     (/ERROR -- CNTI: error test/ =~ response_s).should be_nil
     File.exists?("spec-test-testsuite.log").should be_true

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -17,7 +17,7 @@ describe CnfTestSuite do
   it "'liveness' should pass when livenessProbe is set", tags: ["liveness"] do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml")
-      result = ShellCmd.run_testsuite("liveness", cmd_prefix:"LOG_LEVEL=debug")
+      result = ShellCmd.run_testsuite("liveness", cmd_prefix:"CNF_TESTSUITE_LOG_LEVEL=debug")
       result[:status].success?.should be_true
       (/(PASSED).*(All workload resources have at least one container with a liveness probe)/ =~ result[:output]).should_not be_nil
       verify_task_result("liveness", "passed")
@@ -41,7 +41,7 @@ describe CnfTestSuite do
   it "'readiness' should pass when readinessProbe is set", tags: ["readiness"] do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/k8s-multiple-deployments/cnf-testsuite.yml")
-      result = ShellCmd.run_testsuite("readiness", cmd_prefix: "LOG_LEVEL=debug")
+      result = ShellCmd.run_testsuite("readiness", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=debug")
       result[:status].success?.should be_true
       (/(PASSED).*(All workload resources have at least one container with a readiness probe)/ =~ result[:output]).should_not be_nil
       verify_task_result("readiness", "passed")
@@ -152,7 +152,7 @@ describe CnfTestSuite do
 
   it "'nodeport_not_used' should fail when a node port is being used", tags: ["nodeport_not_used"] do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_nodeport")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_nodeport")
       result = ShellCmd.run_testsuite("nodeport_not_used")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(NodePort is being used)/ =~ result[:output]).should_not be_nil
@@ -175,7 +175,7 @@ describe CnfTestSuite do
 
   it "'hostport_not_used' should fail when a host port is being used", tags: ["hostport_not_used"] do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_hostport")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_hostport")
       result = ShellCmd.run_testsuite("hostport_not_used")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(HostPort is being used)/ =~ result[:output]).should_not be_nil
@@ -198,8 +198,8 @@ describe CnfTestSuite do
 
   it "'hardcoded_ip_addresses_in_k8s_runtime_configuration' should fail when a hardcoded ip is found in the K8s configuration", tags: ["ip_addresses"] do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns_hardcoded_ips")
-      result = ShellCmd.run_testsuite("hardcoded_ip_addresses_in_k8s_runtime_configuration", cmd_prefix: "LOG_LEVEL=info")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_coredns_hardcoded_ips")
+      result = ShellCmd.run_testsuite("hardcoded_ip_addresses_in_k8s_runtime_configuration", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=info")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(Hard-coded IP addresses found in the runtime K8s configuration)/ =~ result[:output]).should_not be_nil
     ensure

--- a/spec/workload/installability_spec.cr
+++ b/spec/workload/installability_spec.cr
@@ -8,7 +8,7 @@ describe CnfTestSuite do
 
 
   it "'helm_deploy' should fail on a manifest CNF", tags: ["helm_validation"] do
-    ShellCmd.cnf_install("cnf-path=./sample-cnfs/k8s-non-helm")
+    ShellCmd.cnf_install("cnf-config=./sample-cnfs/k8s-non-helm")
     result = ShellCmd.run_testsuite("helm_deploy")
     result[:status].exit_code.should eq(1)
     (/(FAILED).*(CNF has deployments that are not installed with helm)/ =~ result[:output]).should_not be_nil
@@ -53,7 +53,7 @@ describe CnfTestSuite do
 
   it "'helm_chart_published' should pass on a good helm chart repo", tags: ["helm_validation"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-coredns-cnf")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-coredns-cnf")
       result = ShellCmd.run_testsuite("helm_chart_published")
       result[:status].success?.should be_true
       (/(PASSED).*(All Helm charts are published)/ =~ result[:output]).should_not be_nil
@@ -65,7 +65,7 @@ describe CnfTestSuite do
   it "'helm_chart_published' should fail on a bad helm chart repo", tags: ["helm_validation"] do
     begin
       result = ShellCmd.run("helm search repo stable/coredns", force_output: true)
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-bad-helm-repo skip_wait_for_install", expect_failure: true)
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-bad-helm-repo skip_wait_for_install", expect_failure: true)
       result = ShellCmd.run("helm search repo stable/coredns", force_output: true)
       result = ShellCmd.run_testsuite("helm_chart_published")
       result[:status].exit_code.should eq(1)

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -15,7 +15,7 @@ describe "Microservice" do
 
   it "'shared_database' should be skipped no MariaDB containers are found", tags: ["shared_database1"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns/cnf-testsuite.yml")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_coredns/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("shared_database")
       result[:status].success?.should be_true
       (/(N\/A).*(No MariaDB containers were found)/ =~ result[:output]).should_not be_nil
@@ -28,7 +28,7 @@ describe "Microservice" do
 
   it "'shared_database' should pass if no database is used by two microservices", tags: ["shared_database2"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-statefulset-cnf/cnf-testsuite.yml")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-statefulset-cnf/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("shared_database")
       result[:status].success?.should be_true
       (/(PASSED).*(No shared database found)/ =~ result[:output]).should_not be_nil
@@ -41,7 +41,7 @@ describe "Microservice" do
 
   it "'shared_database' should pass if one service connects to a database but other non-service connections are made to the database", tags: ["shared_database3"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-multi-db-connections-exempt/cnf-testsuite.yml")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-multi-db-connections-exempt/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("shared_database")
       result[:status].success?.should be_true
       (/(PASSED).*(No shared database found)/ =~ result[:output]).should_not be_nil
@@ -54,7 +54,7 @@ describe "Microservice" do
 
   it "'shared_database' should fail if two services on the cluster connect to the same database", tags: ["shared_database_flaky"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/ndn-multi-db-connections-fail/cnf-testsuite.yml")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/ndn-multi-db-connections-fail/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("shared_database")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(Found a shared database)/ =~ result[:output]).should_not be_nil
@@ -68,7 +68,7 @@ describe "Microservice" do
 
   it "'shared_database' should pass if two services on the cluster connect to the same database but they are not in the helm chart of the cnf", tags: ["shared_database4"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_coredns")
       KubectlClient::Apply.namespace(DEFAULT_CNF_NAMESPACE)
       ShellCmd.run("kubectl label namespace #{DEFAULT_CNF_NAMESPACE} pod-security.kubernetes.io/enforce=privileged", "Label.namespace")
       Helm.install("multi-db", "sample-cnfs/ndn-multi-db-connections-fail/wordpress/", DEFAULT_CNF_NAMESPACE)
@@ -93,7 +93,7 @@ describe "Microservice" do
 
   it "'single_process_type' should pass if the containers in the cnf have only one process type", tags: ["process_check"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_coredns")
       result = ShellCmd.run_testsuite("single_process_type")
       result[:status].success?.should be_true
       (/(PASSED).*(Only one process type used)/ =~ result[:output]).should_not be_nil
@@ -106,7 +106,7 @@ describe "Microservice" do
 
   it "'single_process_type' should pass if a container uses a non-specialized init system supervising a single process type", tags: ["process_check"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-nonspecialized-init")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-nonspecialized-init")
       result = ShellCmd.run_testsuite("single_process_type")
       result[:status].success?.should be_true
       (/(PASSED).*(Only one process type used)/ =~ result[:output]).should_not be_nil
@@ -120,7 +120,7 @@ describe "Microservice" do
 
   it "'single_process_type' should fail if the containers in the cnf have more than one process type", tags: ["process_check"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/k8s-multiple-processes")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/k8s-multiple-processes")
       result = ShellCmd.run_testsuite("single_process_type")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(More than one process type used)/ =~ result[:output]).should_not be_nil
@@ -133,7 +133,7 @@ describe "Microservice" do
 
   it "'single_process_type' should fail if the containers in the cnf have more than one process type and in a pod", tags: ["process_check"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample-multiple-processes")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample-multiple-processes")
       result = ShellCmd.run_testsuite("single_process_type")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(More than one process type used)/ =~ result[:output]).should_not be_nil
@@ -146,7 +146,7 @@ describe "Microservice" do
 
   it "'reasonable_startup_time' should pass if the cnf has a reasonable startup time(helm_directory)", tags: ["reasonable_startup_time"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_coredns")
       result = ShellCmd.run_testsuite("reasonable_startup_time")
       result[:status].success?.should be_true
       (/(PASSED).*(CNF had a reasonable startup time)/ =~ result[:output]).should_not be_nil
@@ -180,7 +180,7 @@ describe "Microservice" do
     #else
     cnf = "./sample-cnfs/sample-coredns-cnf"
     #end
-    ShellCmd.cnf_install("cnf-path=#{cnf}")
+    ShellCmd.cnf_install("cnf-config=#{cnf}")
     result = ShellCmd.run_testsuite("reasonable_image_size")
     result[:status].success?.should be_true
     (/Image size is good/ =~ result[:output]).should_not be_nil
@@ -190,7 +190,7 @@ describe "Microservice" do
   end
 
   it "'reasonable_image_size' should fail if image is larger than 5gb", tags: ["reasonable_image_size"] do
-    ShellCmd.cnf_install("cnf-path=./sample-cnfs/ndn-reasonable-image-size skip_wait_for_install")
+    ShellCmd.cnf_install("cnf-config=./sample-cnfs/ndn-reasonable-image-size skip_wait_for_install")
     result = ShellCmd.run_testsuite("reasonable_image_size")
     result[:status].exit_code.should eq(1)
     (/Image size too large/ =~ result[:output]).should_not be_nil
@@ -198,7 +198,7 @@ describe "Microservice" do
   end
 
   it "'specialized_init_system' should fail if pods do not use specialized init systems", tags: ["specialized_init_system"] do
-    ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample-coredns-cnf")
+    ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-coredns-cnf")
     result = ShellCmd.run_testsuite("specialized_init_system")
     (/Containers do not use specialized init systems/ =~ result[:output]).should_not be_nil
 
@@ -213,7 +213,7 @@ describe "Microservice" do
   end
 
   it "'specialized_init_system' should pass if pods use specialized init systems", tags: ["specialized_init_system"] do
-    ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample-init-systems")
+    ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-init-systems")
     result = ShellCmd.run_testsuite("specialized_init_system")
     result[:status].success?.should be_true
     (/Containers use specialized init systems/ =~ result[:output]).should_not be_nil
@@ -246,7 +246,7 @@ describe "Microservice" do
 
   it "'service_discovery' should pass if any containers in the cnf are exposed as a service", tags: ["service_discovery"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_coredns")
       result = ShellCmd.run_testsuite("service_discovery")
       result[:status].success?.should be_true
       (/(PASSED).*(Some containers exposed as a service)/ =~ result[:output]).should_not be_nil
@@ -259,7 +259,7 @@ describe "Microservice" do
 
   it "'service_discovery' should fail if no containers in the cnf are exposed as a service", tags: ["service_discovery"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample-ndn-privileged")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-ndn-privileged")
       result = ShellCmd.run_testsuite("service_discovery")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(No containers exposed as a service)/ =~ result[:output]).should_not be_nil
@@ -277,7 +277,7 @@ describe "Microservice" do
       #todo 3. Collect all signals sent, if SIGKILL is captured, application fails test because it doesn't exit child processes cleanly
       #todo 3. Collect all signals sent, if SIGTERM is captured, application pass test because it  exits child processes cleanly
       #todo 4. Make sure that threads are not counted as new processes.  A thread does not get a signal (sigterm or sigkill)
-      ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample_good_signal_handling/")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_good_signal_handling/")
       result = ShellCmd.run_testsuite("sig_term_handled")
       result[:status].success?.should be_true
       (/(PASSED).*(Sig Term handled)/ =~ result[:output]).should_not be_nil
@@ -295,7 +295,7 @@ describe "Microservice" do
       #todo 3. Collect all signals sent, if SIGKILL is captured, application fails test because it doesn't exit child processes cleanly
       #todo 3. Collect all signals sent, if SIGTERM is captured, application pass test because it  exits child processes cleanly
       #todo 4. Make sure that threads are not counted as new processes.  A thread does not get a signal (sigterm or sigkill)
-      ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample_bad_signal_handling/")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_bad_signal_handling/")
       result = ShellCmd.run_testsuite("sig_term_handled")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(Sig Term not handled)/ =~ result[:output]).should_not be_nil
@@ -313,7 +313,7 @@ describe "Microservice" do
       #todo 3. Collect all signals sent, if SIGKILL is captured, application fails test because it doesn't exit child processes cleanly
       #todo 3. Collect all signals sent, if SIGTERM is captured, application pass test because it  exits child processes cleanly
       #todo 4. Make sure that threads are not counted as new processes.  A thread does not get a signal (sigterm or sigkill)
-      ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample_good_signal_handling_tini/")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_good_signal_handling_tini/")
 
       # Workaround to wait using kubectl because Jenkins pod takes a LONG time to start.
       result = ShellCmd.run("kubectl wait --for=condition=ready=True pod/jenkins-0 -n cnfspace --timeout=500s", force_output: true)
@@ -331,7 +331,7 @@ describe "Microservice" do
   it "'zombie_handled' should pass if a zombie is succesfully reaped by PID 1", tags: ["zombie"]  do
     begin
 
-      ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample_good_zombie_handling/")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_good_zombie_handling/")
       result = ShellCmd.run_testsuite("zombie_handled")
       result[:status].success?.should be_true
       (/(PASSED).*(Zombie handled)/ =~ result[:output]).should_not be_nil
@@ -345,7 +345,7 @@ describe "Microservice" do
   it "'zombie_handled' should failed if a zombie is not succesfully reaped by PID 1", tags: ["zombie"]  do
     begin
 
-      ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample-bad-zombie/")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-bad-zombie/")
       result = ShellCmd.run_testsuite("zombie_handled")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(Zombie not handled)/ =~ result[:output]).should_not be_nil

--- a/spec/workload/operator_spec.cr
+++ b/spec/workload/operator_spec.cr
@@ -22,12 +22,12 @@ describe "Operator" do
     Helm.install("operator", "#{install_dir}/deploy/chart/", values: "--set olm.image.ref=quay.io/operator-framework/olm:v0.22.0 --set catalog.image.ref=quay.io/operator-framework/olm:v0.22.0 --set package.image.ref=quay.io/operator-framework/olm:v0.22.0")
 
     begin
-      ShellCmd.cnf_install("cnf-path=./sample-cnfs/sample_operator", cmd_prefix: "LOG_LEVEL=info")
-      result = ShellCmd.run_testsuite("operator_installed", cmd_prefix: "LOG_LEVEL=info")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_operator", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=info")
+      result = ShellCmd.run_testsuite("operator_installed", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=info")
       (/(PASSED).*(Operator is installed)/ =~ result[:output]).should_not be_nil
       verify_task_result("operator_installed", "passed")
     ensure
-      result = ShellCmd.cnf_uninstall(cmd_prefix: "LOG_LEVEL=info")
+      result = ShellCmd.cnf_uninstall(cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=info")
       result[:status].success?.should be_true
       pods = KubectlClient::Get.pods_by_resource_labels(KubectlClient::Get.resource("deployment", "catalog-operator", "operator-lifecycle-manager"), "operator-lifecycle-manager") + 
         KubectlClient::Get.pods_by_resource_labels(KubectlClient::Get.resource("deployment", "olm-operator", "operator-lifecycle-manager"), "operator-lifecycle-manager") +
@@ -69,8 +69,8 @@ describe "Operator" do
   
   it "'operator_test' operator should not be found", tags: ["operator_test"]  do
     begin
-      ShellCmd.cnf_install("cnf-path=sample-cnfs/sample_coredns")
-      result = ShellCmd.run_testsuite("operator_installed", cmd_prefix: "LOG_LEVEL=info")
+      ShellCmd.cnf_install("cnf-config=sample-cnfs/sample_coredns")
+      result = ShellCmd.run_testsuite("operator_installed", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=info")
       (/(N\/A).*(No Operators Found)/ =~ result[:output]).should_not be_nil
       verify_task_result("operator_installed", "na")
     ensure

--- a/spec/workload/registry_spec.cr
+++ b/spec/workload/registry_spec.cr
@@ -37,7 +37,7 @@ describe "Private Registry: Image" do
   it "'reasonable_image_size' should pass if using local registry and a port", tags: ["private_registry_image"]  do
     cnf="./sample-cnfs/sample_local_registry"
 
-    ShellCmd.cnf_install("cnf-path=#{cnf}")
+    ShellCmd.cnf_install("cnf-config=#{cnf}")
     result = ShellCmd.run_testsuite("reasonable_image_size")
     result[:status].success?.should be_true
     (/Image size is good/ =~ result[:output]).should_not be_nil
@@ -48,7 +48,7 @@ describe "Private Registry: Image" do
   it "'reasonable_image_size' should pass if using local registry, a port and an org", tags: ["private_registry_image"]  do
     cnf="./sample-cnfs/sample_local_registry_org_image"
 
-    ShellCmd.cnf_install("cnf-path=#{cnf}")
+    ShellCmd.cnf_install("cnf-config=#{cnf}")
     result = ShellCmd.run_testsuite("reasonable_image_size")
     result[:status].success?.should be_true
     (/Image size is good/ =~ result[:output]).should_not be_nil
@@ -94,7 +94,7 @@ describe "Private Registry: Rolling" do
     begin
       cnf="./sample-cnfs/sample_local_registry_rolling"
 
-      ShellCmd.cnf_install("cnf-path=#{cnf}")
+      ShellCmd.cnf_install("cnf-config=#{cnf}")
       result = ShellCmd.run_testsuite("rolling_update")
       result[:status].success?.should be_true
       (/Passed/ =~ result[:output]).should_not be_nil
@@ -107,7 +107,7 @@ describe "Private Registry: Rolling" do
     begin
       cnf="./sample-cnfs/sample_local_registry_rolling"
 
-      ShellCmd.cnf_install("cnf-path=#{cnf}")
+      ShellCmd.cnf_install("cnf-config=#{cnf}")
       result = ShellCmd.run_testsuite("rolling_update")
       result[:status].success?.should be_true
       (/Passed/ =~ result[:output]).should_not be_nil
@@ -120,7 +120,7 @@ describe "Private Registry: Rolling" do
     begin
       cnf="./sample-cnfs/sample_local_registry_rolling"
 
-      ShellCmd.cnf_install("cnf-path=#{cnf}")
+      ShellCmd.cnf_install("cnf-config=#{cnf}")
       result = ShellCmd.run_testsuite("rolling_version_change")
       result[:status].success?.should be_true
       (/Passed/ =~ result[:output]).should_not be_nil

--- a/spec/workload/state_spec.cr
+++ b/spec/workload/state_spec.cr
@@ -9,8 +9,8 @@ describe "State" do
   
   it "'elastic_volumes' should fail if the cnf does not use volumes that are elastic volume", tags: ["elastic_volume"]  do
     begin
-      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-elastic-volume/cnf-testsuite.yml", cmd_prefix: "LOG_LEVEL=debug")
-      result = ShellCmd.run_testsuite("elastic_volumes", cmd_prefix: "LOG_LEVEL=debug")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-elastic-volume/cnf-testsuite.yml", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=debug")
+      result = ShellCmd.run_testsuite("elastic_volumes", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=debug")
       (/(PASSED).*(All used volumes are elastic)/ =~ result[:output]).should be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -22,8 +22,8 @@ describe "State" do
   # This CNF does not use any volumes except the ones that Kubernetes might mount by default (like the service account token)
   it "'elastic_volumes' should fail if the cnf does not use any elastic volumes", tags: ["elastic_volume"]  do
     begin
-      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_nonroot", cmd_prefix: "LOG_LEVEL=debug")
-      result = ShellCmd.run_testsuite("elastic_volumes", cmd_prefix: "LOG_LEVEL=debug")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_nonroot", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=debug")
+      result = ShellCmd.run_testsuite("elastic_volumes", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=debug")
       (/FAILED/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -36,7 +36,7 @@ describe "State" do
       Log.debug { "Installing Mysql " }
       # todo make helm directories work with parameters
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-mysql/cnf-testsuite.yml")
-      result = ShellCmd.run_testsuite("database_persistence", cmd_prefix: "LOG_LEVEL=debug")
+      result = ShellCmd.run_testsuite("database_persistence", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=debug")
       (/(PASSED).*(CNF uses database with cloud-native persistence)/ =~ result[:output]).should_not be_nil
     ensure
       #todo fix cleanup for helm directory with parameters
@@ -47,8 +47,8 @@ describe "State" do
 
   it "'elastic_volumes' should fail if the cnf doesn't use an elastic volume", tags: ["elastic_volume"]  do
     begin
-      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml", cmd_prefix: "LOG_LEVEL=debug")
-      result = ShellCmd.run_testsuite("elastic_volumes", cmd_prefix: "LOG_LEVEL=debug")
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=debug")
+      result = ShellCmd.run_testsuite("elastic_volumes", cmd_prefix: "CNF_TESTSUITE_LOG_LEVEL=debug")
       (/(FAILED).*(Some of the used volumes are not elastic)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()

--- a/src/modules/release_manager/release_manager.cr
+++ b/src/modules/release_manager/release_manager.cr
@@ -87,7 +87,7 @@ module ReleaseManager
 
       # NOTE: build MUST be done first so we can sha256sum for release notes
       # Build a static binary so it will be portable on other machines in non test
-      unless ENV["CRYSTAL_ENV"]? == "TEST"
+      unless ENV["CNF_TESTSUITE_ENV"]? == "TEST"
         # Rely on the docker ci to create the static binary
         # rm_resp = `rm ./cnf-testsuite`
         # Log.info {"rm_resp: #{rm_resp}"}

--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -26,8 +26,8 @@ namespace "platform" do
 
       # Run the tests
       testrun_stdout = IO::Memory.new
-      Log.debug { "CRYSTAL_ENV: #{ENV["CRYSTAL_ENV"]?}" }
-      if ENV["CRYSTAL_ENV"]? == "TEST"
+      Log.debug { "CNF_TESTSUITE_ENV: #{ENV["CNF_TESTSUITE_ENV"]?}" }
+      if ENV["CNF_TESTSUITE_ENV"]? == "TEST"
         Log.info { "Running Sonobuoy using Quick Mode" }
         cmd = "#{sonobuoy} run --wait --mode quick"
         Process.run(

--- a/src/tasks/setup/helmenv_setup.cr
+++ b/src/tasks/setup/helmenv_setup.cr
@@ -7,12 +7,12 @@ namespace "setup" do
     logger = SLOG.for("install_local_helm")
     logger.info { "Installing Helm tool" }
 
-    if !ENV.has_key?("force_install") && Helm.binary_found?
+    if !ENV.has_key?("CNF_TESTSUITE_FORCE_INSTALL") && Helm.binary_found?
       logger.notice { "Helm installation has been found on the system, skipping" }
       next
     end
 
-    unless Helm.install_local_helm(force: ENV.has_key?("force_install"))
+    unless Helm.install_local_helm(force: ENV.has_key?("CNF_TESTSUITE_FORCE_INSTALL"))
       stdout_failure("Task 'install_local_helm' failed")
       exit(1)
     end

--- a/src/tasks/update_config.cr
+++ b/src/tasks/update_config.cr
@@ -7,12 +7,12 @@ require "./utils/cnf_installation/config"
 desc "Updates an old configuration file to the latest version and saves it to the specified location"
 task "update_config" do |_, args|
   # Ensure both arguments are provided
-  if !((args.named.keys.includes? "input_config") && (args.named.keys.includes? "output_config"))
-    usage_error! "Usage: update_config input_config=OLD_CONFIG_PATH output_config=NEW_CONFIG_PATH"
+  if !((args.named.keys.includes? "input-config") && (args.named.keys.includes? "output-config"))
+    usage_error! "Usage: update_config input-config=OLD_CONFIG_PATH output-config=NEW_CONFIG_PATH"
   end
 
-  input_config = args.named["input_config"].as(String)
-  output_config = args.named["output_config"].as(String)
+  input_config = args.named["input-config"].as(String)
+  output_config = args.named["output-config"].as(String)
 
   # Check if the input config file exists
   unless File.exists?(input_config)

--- a/src/tasks/utils/cli_args_validation.cr
+++ b/src/tasks/utils/cli_args_validation.cr
@@ -13,11 +13,11 @@ end
 
 # Every key=value argument some task actually reads.
 KNOWN_CLI_NAMED_ARGS = [
-  "cnf-config", "cnf-path", "timeout", "input_config", "output_config",
-  "exclude", "pod_labels", "baseline_count", "results-dir",
+  "cnf-config", "timeout", "input-config", "output-config",
+  "exclude", "pod-labels", "baseline-count", "results-dir",
 ]
 # Named arguments whose value must be an integer.
-NUMERIC_CLI_NAMED_ARGS = ["timeout", "baseline_count"]
+NUMERIC_CLI_NAMED_ARGS = ["timeout", "baseline-count"]
 # Every bare-word flag some task actually reads from the raw arguments.
 KNOWN_CLI_FLAGS = [
   "strict", "essential", "poc", "wip", "alpha", "beta", "destructive",

--- a/src/tasks/utils/cli_completion.cr
+++ b/src/tasks/utils/cli_completion.cr
@@ -15,7 +15,7 @@ module CLICompletion
   FUNCTION_NAME = "_cnf_testsuite_completions"
 
   # Named arguments whose value is a path, completed with file names.
-  FILE_VALUED_ARGS = ["cnf-config", "cnf-path", "input_config", "output_config"]
+  FILE_VALUED_ARGS = ["cnf-config", "input-config", "output-config"]
 
   def self.script(shell : String, bin_name : String = self.bin_name) : String
     case shell

--- a/src/tasks/utils/cli_help.cr
+++ b/src/tasks/utils/cli_help.cr
@@ -179,7 +179,7 @@ module CLIHelp
           --version          print the version and exit
 
     ARGUMENTS (key=value, after the task name)
-      cnf-config=PATH   a cnf-testsuite.yml or the directory holding one (alias: cnf-path)
+      cnf-config=PATH   a cnf-testsuite.yml or the directory holding one
       timeout=SECONDS   how long to wait for install and uninstall operations
       results-dir=PATH  where results files go (default: ./cnti/results, or $CNF_TESTSUITE_RESULTS_DIR)
       All known arguments: #{named_args}

--- a/src/tasks/utils/cnf_installation/install_common.cr
+++ b/src/tasks/utils/cnf_installation/install_common.cr
@@ -18,7 +18,7 @@ module CNFInstall
     parsed_args = parse_install_cli_args(cli_args)
     cnf_config_path = parsed_args[:config_path]
     if cnf_config_path.empty?
-      usage_error! "cnf-config or cnf-path parameter with valid CNF configuration should be provided."
+      usage_error! "cnf-config parameter with valid CNF configuration should be provided."
     end
     config = Config.parse_cnf_config_from_file(cnf_config_path)
     ensure_cnf_dir_structure()
@@ -40,8 +40,6 @@ module CNFInstall
 
     if cli_args.named.keys.includes? "cnf-config"
       cnf_config_path = cli_args.named["cnf-config"].as(String)
-    elsif cli_args.named.keys.includes? "cnf-path"
-      cnf_config_path = cli_args.named["cnf-path"].as(String)
     end
     cnf_config_path = self.ensure_cnf_config_path_file(cnf_config_path)
 

--- a/src/tasks/utils/logging.cr
+++ b/src/tasks/utils/logging.cr
@@ -37,8 +37,8 @@ PLOG = Log.for("Platform")
 SLOG = Log.for("Setup")
 
 private def log_backend
-  if ENV.has_key?("LOGPATH") || ENV.has_key?("LOG_PATH")
-    log_file = ENV.has_key?("LOGPATH") ? ENV["LOGPATH"] : ENV["LOG_PATH"]
+  if ENV.has_key?("CNF_TESTSUITE_LOG_PATH")
+    log_file = ENV["CNF_TESTSUITE_LOG_PATH"]
   else
     log_file = ""
   end
@@ -84,12 +84,8 @@ private def loglevel
     end
   end
 
-  if ENV.has_key?("LOGLEVEL")
-    level_str = ENV["LOGLEVEL"]
-  end
-
-  if ENV.has_key?("LOG_LEVEL")
-    level_str = ENV["LOG_LEVEL"]
+  if ENV.has_key?("CNF_TESTSUITE_LOG_LEVEL")
+    level_str = ENV["CNF_TESTSUITE_LOG_LEVEL"]
   end
 
   # highest priority is last

--- a/src/tasks/workload/5g_validator.cr
+++ b/src/tasks/workload/5g_validator.cr
@@ -25,8 +25,8 @@ scored_task "smf_upf_heartbeat" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     Log.for(t.name).info { "named args: #{args.named}" }
     baseline_count : Int32 | Float64 | String | Nil
-    if args.named["baseline_count"]?
-      baseline_count = args.named["baseline_count"].to_i
+    if args.named["baseline-count"]?
+      baseline_count = args.named["baseline-count"].to_i
     else
       baseline_count = nil
     end
@@ -57,7 +57,7 @@ scored_task "smf_upf_heartbeat" do |t, args|
       sync_channel = Channel(Nil).new
       spawn do
         Log.info { "before invoke of pod delete" }
-        args.named["pod_labels"]="#{smf},#{upf}"
+        args.named["pod-labels"]="#{smf},#{upf}"
       # t.invoke("pod_delete", args)
         t.invoke("pod_network_latency", args)
         Log.info { "after invoke of pod delete" }

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -212,7 +212,7 @@ scored_task "reasonable_startup_time" do |t, args|
     else
       startup_time_limit = 30
     end
-    # if ENV["CRYSTAL_ENV"]? == "TEST"
+    # if ENV["CNF_TESTSUITE_ENV"]? == "TEST"
     #   startup_time_limit = 35 
     #   Log.info { "startup_time_limit TEST mode: #{startup_time_limit}" }
     # end
@@ -230,10 +230,10 @@ end
 
 # There aren't any 5gb images to test.
 # To run this test in a test environment or for testing purposes,
-# set the env var CRYSTAL_ENV=TEST when running the test.
+# set the env var CNF_TESTSUITE_ENV=TEST when running the test.
 #
 # Example:
-#    CRYSTAL_ENV=TEST ./cnf-testsuite reasonable_image_size
+#    CNF_TESTSUITE_ENV=TEST ./cnf-testsuite reasonable_image_size
 #
 desc "Does the CNF have a reasonable container image size (< 5GB)?"
 scored_task "reasonable_image_size",
@@ -311,7 +311,7 @@ scored_task "reasonable_image_size",
         # TODO save auths array to a file
         Log.info { "compressed_size: #{fqdn_image} = '#{compressed_size.to_s}'" }
         max_size = 5_000_000_000
-        if ENV["CRYSTAL_ENV"]? == "TEST"
+        if ENV["CNF_TESTSUITE_ENV"]? == "TEST"
            Log.info { "Using Test Mode max_size" }
            max_size = 16_000_000
         end

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -91,8 +91,8 @@ scored_task "pod_network_latency",
 
       current_pod_key = ""
       current_pod_value = ""
-      if args.named["pod_labels"]?
-          pod_label = args.named["pod_labels"]?
+      if args.named["pod-labels"]?
+          pod_label = args.named["pod-labels"]?
           match_array = pod_label.to_s.split(",")
 
         test_passed = match_array.any? do |key_value|
@@ -109,12 +109,12 @@ scored_task "pod_network_latency",
         end
       end
 
-      Log.info { "Spec Hash: #{args.named["pod_labels"]?}" }
+      Log.info { "Spec Hash: #{args.named["pod-labels"]?}" }
 
 
       if test_passed
         Log.info { "Running for: #{spec_labels}"}
-        Log.info { "Spec Hash: #{args.named["pod_labels"]?}" }
+        Log.info { "Spec Hash: #{args.named["pod-labels"]?}" }
         experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/pod-network-latency/fault.yaml"
         rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/pod-network-latency/rbac.yaml"
         
@@ -134,7 +134,7 @@ scored_task "pod_network_latency",
         chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
 
         #spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"]).as_h
-        if args.named["pod_labels"]?
+        if args.named["pod-labels"]?
             template = ChaosTemplates::PodNetworkLatency.new(
               test_name,
               "#{chaos_experiment_name}",
@@ -160,7 +160,7 @@ scored_task "pod_network_latency",
 
       test_passed
     end
-    unless args.named["pod_labels"]?
+    unless args.named["pod-labels"]?
         #todo if in pod specific mode, dont do upserts and resp = ""
         if task_response
           result.passed("pod_network_latency chaos test passed")
@@ -370,8 +370,8 @@ scored_task "pod_delete",
 
       current_pod_key = ""
       current_pod_value = ""
-      if args.named["pod_labels"]?
-          pod_label = args.named["pod_labels"]?
+      if args.named["pod-labels"]?
+          pod_label = args.named["pod-labels"]?
           match_array = pod_label.to_s.split(",")
 
         test_passed = match_array.any? do |key_value|
@@ -388,12 +388,12 @@ scored_task "pod_delete",
         end
       end
 
-      Log.info { "Spec Hash: #{args.named["pod_labels"]?}" }
+      Log.info { "Spec Hash: #{args.named["pod-labels"]?}" }
 
 
       if test_passed
         Log.info { "Running for: #{spec_labels}"}
-        Log.info { "Spec Hash: #{args.named["pod_labels"]?}" }
+        Log.info { "Spec Hash: #{args.named["pod-labels"]?}" }
         experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/pod-delete/fault.yaml"
         rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/pod-delete/rbac.yaml"
 
@@ -417,7 +417,7 @@ scored_task "pod_delete",
         chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
 
         # spec_labels = KubectlClient::Get.resource_spec_labels(resource["kind"], resource["name"], resource["namespace"]).as_h
-      if args.named["pod_labels"]?
+      if args.named["pod-labels"]?
         template = ChaosTemplates::PodDelete.new(
           test_name,
           "#{chaos_experiment_name}",
@@ -446,7 +446,7 @@ scored_task "pod_delete",
       test_passed=LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace, result: result)
       test_passed
     end
-    unless args.named["pod_labels"]?
+    unless args.named["pod-labels"]?
         if task_response
           result.passed("pod_delete chaos test passed")
         else

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -67,7 +67,7 @@ module Volume
   #   end
   #   Log.info {"Provisoners: #{provisoners}"}
   #   provisoners.each do |provisoner|
-  #     if ENV["CRYSTAL_ENV"]? == "TEST"
+  #     if ENV["CNF_TESTSUITE_ENV"]? == "TEST"
   #       if (provisoner =~ ELASTIC_PROVISIONING_DRIVERS_REGEX_SPEC) 
   #         Log.info {"provisioner test mode"}
   #         Log.info {"Provisoners: #{provisoners}"}
@@ -126,7 +126,7 @@ module StorageClass
 
     Log.info {"Provisioners: #{provisioners}"}
     provisioners.each do |provisioner|
-      if ENV["CRYSTAL_ENV"]? == "TEST"
+      if ENV["CNF_TESTSUITE_ENV"]? == "TEST"
         if (provisioner =~ ELASTIC_PROVISIONING_DRIVERS_REGEX_SPEC)
           Log.info {"provisioner test mode"}
           Log.info {"Elastic provisioner: #{provisioner}"}


### PR DESCRIPTION
The CLI had several names for the same thing and several styles for naming things: kebab-case `cnf-config` next to snake_case `input_config`, an undocumented `cnf-path` alias, `LOGLEVEL`/`LOG_LEVEL` **and** `LOGPATH`/`LOG_PATH` both honored, an unprefixed lowercase `force_install` env var, and `CRYSTAL_ENV=TEST` — a variable named after the compiler — silently switching test-mode behavior.

**One name per thing. Clean breaks, no aliases** — per the release plan: the next release already changes exit-code semantics, and all backward-incompatible changes ship together in it, announced once. The deprecation-alias cycle sketched in #2435 is deliberately dropped.

## Renames

| was | is |
|---|---|
| `cnf-path=` (undocumented alias) | `cnf-config=` |
| `input_config=` / `output_config=` | `input-config=` / `output-config=` |
| `pod_labels=` / `baseline_count=` | `pod-labels=` / `baseline-count=` |
| `force_install` (env) | `CNF_TESTSUITE_FORCE_INSTALL` |
| `CRYSTAL_ENV=TEST` | `CNF_TESTSUITE_ENV=TEST` |
| `LOG_LEVEL` / `LOG_PATH` (and the undocumented `LOGLEVEL`/`LOGPATH` duplicates) | `CNF_TESTSUITE_LOG_LEVEL` / `CNF_TESTSUITE_LOG_PATH` |

## Why the breaks are safe to make

Every retired spelling **fails fast instead of silently doing nothing**: #2423's validation rejects unknown arguments with exit 64 and the list of known ones —

```
$ cnf-testsuite cnf_install cnf-path=x
Unknown argument 'cnf-path='. Known arguments: cnf-config, timeout, input-config, …
$ echo $?
64
```

— and help + completion updated **automatically**, because validation, help, and completion all read the same registry (#2429/#2430's design paying off: this PR touches the allowlist once and never edits the help or completion text for the arg lists).

Env vars are the one place validation can't reject a retired spelling, so each break has its own guard spec: `LOGLEVEL`, `LOG_LEVEL` and `LOG_PATH` must all do nothing now. With this, every variable that configures the **suite's own behavior** carries the `CNF_TESTSUITE_` prefix (credentials and ecosystem standards — `KUBECONFIG`, `GITHUB_TOKEN`, `DOCKERHUB_USERNAME`/`PASSWORD`, `NO_COLOR` — deliberately keep their conventional names so one export serves every tool that honors them; a full sweep of ENV reads in `src/` confirms these are the only unprefixed ones, and USAGE.md now states the rule) — `LOG_LEVEL` was the last unprefixed one and the most collision-prone name of the lot (plenty of tools honor some `LOG_LEVEL`, so a variable exported for another tool silently flipped this suite's logging). The CI workflows that set it are updated in the same commit.

## Also

- USAGE.md gains an **Other environment variables** section (`CNF_TESTSUITE_FORCE_INSTALL`, `CNF_TESTSUITE_ENV`, pointer to `CNF_TESTSUITE_RESULTS_DIR`); the `LOGLEVEL` example and the bug-report template now use `LOG_LEVEL`.
- Doc drift from A3.4: `elastic_volume` → `elastic_volumes`, and the nonexistent `configuration_lifecycle` → `configuration`.
- Specs updated wholesale: `cnf-path=` → `cnf-config=` across 7 files (56 sites), kebab args elsewhere; two new guards on the breaks themselves (`cnf-path=` → 64, `LOGLEVEL` ignored).

## Verification (Crystal 1.6.2 — the CI/release compiler)

- `crystal spec --tag points` — 49/49 (includes the new `cnf-path` guard and the kebab `update_config` paths)
- `crystal spec --tag logger` — 10/10 (includes the three retired-spelling guards)
- `mdl` doc lint — clean
- Manual: each rename exercised against the built binary (`help`, `completion`, `update_config`, `LOGLEVEL` vs `LOG_LEVEL`)

Release notes for the bundled breaking release should carry this table as the migration guide.

Closes #2435


