### PR TITLE
Retry transient network failures on external fetches

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -474,6 +474,17 @@ CNF_TESTSUITE_NODE_DRAIN_TOTAL_CHAOS_DURATION=90
 CNF_TESTSUITE_LABEL_RESOURCE_SLEEP=5
 ```
 
+#### Network retries:
+
+Network-bound fetches (chart pulls, repo adds, binary downloads) are retried on transient
+failures — resets, timeouts, DNS blips, 5xx — while a missing chart or auth error still fails
+immediately:
+
+```
+CNF_TESTSUITE_NETWORK_RETRY_ATTEMPTS=3   # attempts per fetch
+CNF_TESTSUITE_NETWORK_RETRY_BACKOFF=2    # base seconds between attempts (attempt N waits N x backoff)
+```
+
 #### Running The Linter
 
 Ameba (https://github.com/crystal-ameba/ameba) is a static code linter for crystal-lang.

--- a/spec/utils/net_retry_spec.cr
+++ b/spec/utils/net_retry_spec.cr
@@ -1,0 +1,115 @@
+require "../spec_helper"
+require "http/server"
+
+# In-process: exercises the wrapper and download_file directly, with backoff
+# zeroed so exhaustion paths stay fast.
+private def without_backoff(&)
+  ENV[NetRetry::BACKOFF_ENV] = "0"
+  yield
+ensure
+  ENV.delete(NetRetry::BACKOFF_ENV)
+  ENV.delete(NetRetry::ATTEMPTS_ENV)
+end
+
+private def serve(&handler : HTTP::Server::Context, Int32 -> Nil) : {HTTP::Server, String}
+  hits = 0
+  server = HTTP::Server.new do |context|
+    hits += 1
+    handler.call(context, hits)
+  end
+  address = server.bind_tcp("127.0.0.1", 0)
+  spawn { server.listen }
+  Fiber.yield
+  {server, "http://#{address}"}
+end
+
+describe "NetRetry" do
+  it "classifies transient and permanent failures", tags: ["points"] do
+    ["connection reset by peer", "dial tcp: lookup x: i/o timeout", "unexpected EOF",
+     "TLS handshake timeout", "Temporary failure in name resolution",
+     "Unsuccessful request, status code: [503], msg: Service Unavailable",
+     "server responded with 502 Bad Gateway"].each do |message|
+      NetRetry.transient?(Exception.new(message)).should be_true
+    end
+
+    ["chart \"nope\" not found in https://example.com repository",
+     "401 Unauthorized", "Error: INSTALLATION FAILED: values don't meet the specifications",
+     "Unsuccessful request, status code: [404], msg: Not Found"].each do |message|
+      NetRetry.transient?(Exception.new(message)).should be_false
+    end
+
+    NetRetry.transient?(NetRetry::TransientError.new("anything")).should be_true
+    NetRetry.transient?(IO::TimeoutError.new("read timed out")).should be_true
+    NetRetry.transient?(File::NotFoundError.new("gone", file: "gone")).should be_false
+  end
+
+  it "retries transient failures up to the configured attempts and re-raises", tags: ["points"] do
+    without_backoff do
+      ENV[NetRetry::ATTEMPTS_ENV] = "3"
+
+      calls = 0
+      result = NetRetry.with_retries("flaky") do
+        calls += 1
+        raise NetRetry::TransientError.new("blip") if calls < 3
+        "recovered"
+      end
+      result.should eq("recovered")
+      calls.should eq(3)
+
+      calls = 0
+      expect_raises(NetRetry::TransientError) do
+        NetRetry.with_retries("hopeless") do
+          calls += 1
+          raise NetRetry::TransientError.new("still down")
+        end
+      end
+      calls.should eq(3)
+    end
+  end
+
+  it "does not retry a permanent failure", tags: ["points"] do
+    without_backoff do
+      calls = 0
+      expect_raises(Exception, "not found") do
+        NetRetry.with_retries("permanent") do
+          calls += 1
+          raise "chart not found"
+        end
+      end
+      calls.should eq(1)
+    end
+  end
+
+  it "download_file absorbs a 5xx blip but fails a 404 immediately", tags: ["points"] do
+    without_backoff do
+      output = File.tempname("net-retry", ".bin")
+
+      server, url = serve do |context, hits|
+        if hits < 3
+          context.response.status_code = 503
+        else
+          context.response.print "payload"
+        end
+      end
+      begin
+        download_file(url, output)
+        File.read(output).should eq("payload")
+      ensure
+        server.close
+        File.delete?(output)
+      end
+
+      server, url = serve do |context, hits|
+        context.response.status_code = 404
+      end
+      begin
+        requests = 0
+        expect_raises(Exception, "status code: [404]") { download_file(url, output) }
+        File.exists?(output).should be_false
+      ensure
+        server.close
+        File.delete?(output)
+      end
+    end
+  end
+end

--- a/src/modules/helm/helm.cr
+++ b/src/modules/helm/helm.cr
@@ -1,4 +1,5 @@
 require "../kubectl_client"
+require "../net_retry"
 require "./utils.cr"
 
 module Helm
@@ -285,7 +286,9 @@ module Helm
 
     resp = nil
     begin
-      resp = ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger, false, stdin: password) }
+      resp = NetRetry.with_retries("helm repo add #{helm_repo_name}", logger) do
+        ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger, false, stdin: password) }
+      end
     rescue ex : ShellCMD::RepoNotFound
       logger.error { "Failed to add helm repository '#{helm_repo_name}': #{ex.message}" }
     rescue ex : ShellCMD::HelmCMDException
@@ -351,7 +354,12 @@ module Helm
     cmd = "#{cmd} --create-namespace" if create_namespace
     cmd = "#{cmd} #{values}" if values
 
-    ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
+    # A remote chart reference is fetched by this command, so it is as
+    # network-bound as a pull; the transient filter keeps chart/values errors
+    # failing immediately.
+    NetRetry.with_retries("helm install #{helm_chart}", logger) do
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
+    end
   end
 
   def self.uninstall(release_name : String, namespace : String? = nil, wait : Bool = false) : CMDResult
@@ -381,7 +389,9 @@ module Helm
     cmd = "#{cmd} --untar" if untar
     cmd = "#{cmd} --destination #{destination}" if destination
 
-    ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
+    NetRetry.with_retries("helm pull #{full_chart_name}", logger) do
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
+    end
   end
 
   def self.pull_oci(
@@ -408,7 +418,9 @@ module Helm
     cmd = "#{cmd} --insecure-skip-tls-verify"   if insecure_skip_tls_verify
     cmd = "#{cmd} --plain-http"                 if plain_http
 
-    ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
+    NetRetry.with_retries("helm pull #{oci_address}", logger) do
+      ShellCMD.raise_exc_on_error { ShellCMD.run(cmd, logger) }
+    end
   end
 
   # Create a new chart directory

--- a/src/modules/net_retry/net_retry.cr
+++ b/src/modules/net_retry/net_retry.cr
@@ -1,0 +1,92 @@
+require "log"
+
+# Bounded retry for network-bound external fetches: chart pulls, repo adds,
+# binary downloads. Every one of these used to be a single attempt, so one
+# transient blip from a host we do not control failed a run that said nothing
+# about the code under test (#2445).
+#
+# Only failures that look transient are retried. A missing chart, a 404 or an
+# auth error raises immediately: blindly retrying everything would make
+# genuine failures take attempts-times longer to report and dress a missing
+# chart up as a network problem.
+module NetRetry
+  Log = ::Log.for("NetRetry")
+
+  ATTEMPTS_ENV = "CNF_TESTSUITE_NETWORK_RETRY_ATTEMPTS"
+  BACKOFF_ENV  = "CNF_TESTSUITE_NETWORK_RETRY_BACKOFF"
+
+  DEFAULT_ATTEMPTS = 3
+  DEFAULT_BACKOFF  = 2
+
+  # For raising a failure that is known to be worth retrying (e.g. an HTTP 5xx,
+  # where the status line alone already settles the question).
+  class TransientError < Exception
+  end
+
+  # What a transient network failure looks like in an error message, across the
+  # tools we shell out to (helm, skopeo) and our own HTTP clients: resets,
+  # network timeouts, DNS blips, handshake interruptions and server-side 5xx.
+  # Deliberately narrow -- "chart not found" or "401" must never match.
+  TRANSIENT_PATTERNS = [
+    /connection reset/i,
+    /connection refused/i,
+    /broken pipe/i,
+    /\bEOF\b/,
+    /i\/o timeout/i,
+    /tls handshake/i,
+    /deadline exceeded/i,
+    /temporary failure/i,
+    /no such host/i,
+    /name resolution/i,
+    /unexpected end of/i,
+    /status code: \[5\d\d\]/,
+    /internal server error/i,
+    /bad gateway/i,
+    /service unavailable/i,
+    /gateway timeout/i,
+  ]
+
+  def self.attempts : Int32
+    value = ENV[ATTEMPTS_ENV]?.try(&.to_i?) || DEFAULT_ATTEMPTS
+    value < 1 ? 1 : value
+  end
+
+  # Base delay in seconds; attempt N waits N * backoff, so the default gives
+  # 2s, 4s. Zero disables sleeping (used by specs).
+  def self.backoff : Int32
+    value = ENV[BACKOFF_ENV]?.try(&.to_i?) || DEFAULT_BACKOFF
+    value < 0 ? 0 : value
+  end
+
+  # An error is transient when its class says so (our own TransientError,
+  # socket/TLS-level errors -- but not File errors, which share IO::Error) or
+  # when its message matches a known-transient pattern.
+  def self.transient?(ex : Exception) : Bool
+    return true if ex.is_a?(TransientError) || ex.is_a?(OpenSSL::Error)
+    return true if ex.is_a?(IO::Error) && !ex.is_a?(File::Error)
+    message = ex.message
+    !message.nil? && TRANSIENT_PATTERNS.any? { |pattern| pattern.match(message) }
+  end
+
+  # Runs the block up to `attempts` times. Non-transient errors raise
+  # immediately; exhausting the attempts logs how many were made and re-raises
+  # the last error.
+  def self.with_retries(what : String, logger : ::Log = Log, &)
+    attempt = 0
+    loop do
+      attempt += 1
+      begin
+        return yield
+      rescue ex : Exception
+        raise ex unless transient?(ex)
+        if attempt >= attempts
+          logger.error { "#{what}: giving up after #{attempt} attempt(s): #{ex.message.to_s[0, 300]}" }
+          raise ex
+        end
+        delay = backoff * attempt
+        logger.warn { "#{what}: attempt #{attempt}/#{attempts} failed (#{ex.message.to_s[0, 300]}); retrying in #{delay}s" }
+        sleep(delay) if delay > 0
+      end
+    end
+  end
+end

--- a/src/modules/tar/tar.cr
+++ b/src/modules/tar/tar.cr
@@ -1,5 +1,6 @@
 require "colorize"
 require "log"
+require "../net_retry"
 
 # todo put in a separate library. it shold go under ./tools for now
 module TarClient
@@ -106,10 +107,12 @@ module TarClient
     download_full_path = download_path + download_name
     Log.info { "download_name: #{download_name}" }
     Log.info { "download_full_path: #{download_full_path}" }
-    Halite.get("#{url}") do |response| 
-       File.open("/tmp/" + download_full_path, "w") do |file| 
-         IO.copy(response.body_io, file)
-       end
+    NetRetry.with_retries("download #{url}") do
+      Halite.get("#{url}") do |response|
+        File.open("/tmp/" + download_full_path, "w") do |file|
+          IO.copy(response.body_io, file)
+        end
+      end
     end
     TarClient.append(append_file, "/tmp", download_full_path)
   ensure

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -13,6 +13,7 @@ require "./timeouts.cr"
 require "./cnf_installation/config.cr"
 require "ecr"
 require "http/client"
+require "../../modules/net_retry"
 
 module ShellCmd
   def self.run(cmd, log_prefix = "ShellCmd.run", force_output = false, joined_output = false)
@@ -455,17 +456,26 @@ end
 
 def download_file(url : String, output_path : String,
                   redirect_limit : Int = 5, headers : HTTP::Headers? = nil)
+  NetRetry.with_retries("download #{url}") do
+    follow_and_download(url, output_path, redirect_limit, headers)
+  end
+end
+
+private def follow_and_download(url : String, output_path : String,
+                                redirect_limit : Int, headers : HTTP::Headers?)
   raise "Too many redirects" if redirect_limit == 0
 
   response = HTTP::Client.get(url, headers: headers)
   if response.status_code >= 300 && response.status_code < 400
     new_location = response.headers["Location"]
     raise "Status code 3xx, but redirect location missing" unless new_location
-    return download_file(new_location, output_path, redirect_limit - 1, headers)
+    return follow_and_download(new_location, output_path, redirect_limit - 1, headers)
   end
 
   unless response.success?
-    raise "Unsuccessful request, status code: [#{response.status_code}], msg: #{response.status_message}"
+    message = "Unsuccessful request, status code: [#{response.status_code}], msg: #{response.status_message}"
+    raise NetRetry::TransientError.new(message) if response.status_code >= 500
+    raise message
   end
   File.write(output_path, response.body.to_s)
 end


### PR DESCRIPTION
Every network fetch the suite performs was a **single attempt** — one blip from `cncf.gitlab.io`, `registry-1.docker.io` or `dl.k8s.io` failed the operation, the spec, and the whole shard, saying nothing about the code under test. #2445 documents three incidents within days; in one, the *identical* chart pull had succeeded three times in the same job minutes earlier.

## Design

**`NetRetry`** ([src/modules/net_retry](src/modules/net_retry/net_retry.cr)) — bounded attempts (3), linear backoff (2s, 4s), both tunable via `CNF_TESTSUITE_NETWORK_RETRY_ATTEMPTS` / `_BACKOFF` per the existing env-var convention. Each retry logs at WARN with attempt number and error, so a flake stays **visible** in the log rather than silently smoothed over; exhaustion logs the count and re-raises the last error **unchanged**, so existing rescue sites keep working.

**Only transient-looking failures retry** — the issue's central caution. Decided two ways:
- by class: socket/TLS-level errors and a `NetRetry::TransientError` (raised by `download_file` for 5xx) — but **not** `File::Error`, which shares `IO::Error` and must not be retried
- by a deliberately narrow message-pattern list: resets, `i/o timeout`, DNS (`no such host`, `name resolution`), `tls handshake`, `EOF`, 5xx status text

`chart not found`, `401`, `404`, values/validation errors → raise on attempt one.

## Applied to (the sites the issue names)

| site | note |
|---|---|
| `download_file` | retry wraps the whole redirect chain; 5xx now classified transient |
| `Helm.helm_repo_add` | `RepoNotFound` stays immediate (permanent) |
| `Helm.install` | remote chart refs are fetched by this command; the filter keeps chart/values errors immediate |
| `Helm.pull` / `Helm.pull_oci` | |
| `TarClient.tar_file_by_url` (Halite) | |

## Verification (Crystal 1.6.2)

- New `net_retry_spec.cr` (tag `points`, 4 examples): classifier both ways (7 transient / 4 permanent messages, class checks incl. the `File::Error` exclusion); succeed-on-attempt-3; exhaust-at-3 and re-raise; permanent = exactly 1 call; **`download_file` end to end** against a local server — recovers after two 503s, fails a 404 on the first attempt
- `crystal spec --tag points` — 53/53
- Live run: `cnf_install` of the coredns sample (real `helm repo add` + remote install through the wrapped paths) — clean

Not addressed: the leaked kind cluster in the issue's "Related" note — that's runner hygiene, not code.

Small doc-merge note: the USAGE.md env-var addition will trivially conflict with #2455's "Other environment variables" section; whichever merges second rebases in seconds.

Closes #2445
