### PR TITLE
Catch a missing Helm at the entrypoint: guidance and exit 1, not a backtrace

### DIFF
--- a/spec/modules/helm_spec.cr
+++ b/spec/modules/helm_spec.cr
@@ -31,6 +31,26 @@ describe "Helm" do
       FileUtils.rm_rf(path_without_helm.not_nil!)
       Helm.uninstall_local_helm
     end
+
+    it "fails with guidance and exit 1, not a backtrace, when Helm is missing at runtime", tags: ["helm"] do
+      # Empty PATH and an empty tools dir: no global helm, no suite-managed
+      # helm. install_jaeger reaches Binary.get without the setup guard.
+      empty_path = File.tempname("empty-path")
+      empty_tools = File.tempname("empty-tools")
+      FileUtils.mkdir_p(empty_path)
+      FileUtils.mkdir_p(empty_tools)
+
+      result = ShellCmd.run_testsuite("setup:install_jaeger",
+        "PATH=#{empty_path} CNF_TESTSUITE_DIR=#{empty_tools}")
+
+      result[:status].exit_code.should eq(1)
+      result[:output].should contain("No Helm binary found")
+      result[:output].should contain("cnf-testsuite setup")
+      result[:output].should_not contain("__crystal_main")
+    ensure
+      FileUtils.rm_rf(empty_path.not_nil!)
+      FileUtils.rm_rf(empty_tools.not_nil!)
+    end
   end
 
   describe "global" do

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -90,6 +90,13 @@ rescue e : Sam::NotFound
   end
   stdout_info "Run `#{CLIHelp::BIN_NAME} help tasks` to list every task."
   exit USAGE_EXIT_CODE
+rescue e : Helm::Binary::HelmBinaryNotFoundError
+  # Not a crash: every helm shell-out funnels through Binary.get, which makes
+  # this the one choke point for "helm is not installed" (#2457). A missing
+  # prerequisite gets guidance and exit 1, not a backtrace and exit 2.
+  stdout_failure e.message.to_s
+  stdout_failure "Run `#{CLIHelp::BIN_NAME} setup` to install the prerequisites."
+  exit 1
 rescue e
   # An exception nothing caught: the suite itself broke, the same verdict as
   # a test that errored.

--- a/src/modules/helm/utils.cr
+++ b/src/modules/helm/utils.cr
@@ -52,9 +52,7 @@ module Helm
   # Public helpers
 
   def self.binary_found? : Bool
-    result = ToolChecker::Result.new(tool_name)
-    global_check(result)
-    local_check(result)
+    result = check(run_post_checks: false)
     result.global_ok || result.local_ok
   end
 

--- a/src/modules/tool_checker.cr
+++ b/src/modules/tool_checker.cr
@@ -39,12 +39,14 @@ module ToolChecker
   abstract def local_check(result  : Result) : Nil
   abstract def post_checks(result  : Result) : Nil
 
-  def check : Result
+  # run_post_checks: false skips the checks that need more than the binary --
+  # Helm's post_checks talks to the cluster, which a presence probe must not.
+  def check(run_post_checks : Bool = true) : Result
     result = Result.new(tool_name)
 
     global_check(result)
     local_check(result)
-    post_checks(result)
+    post_checks(result) if run_post_checks
 
     result
   end


### PR DESCRIPTION
**Follow-up to #2403 / #2383**, closing [#2457](https://github.com/lfn-cnti/testsuite/issues/2457).

#2403 guarded the `setup` path, but `Helm::Binary::HelmBinaryNotFoundError` remained rescued **nowhere**. Any entry point reaching helm without that guard — `cnf_uninstall` (with an installed CNF), `setup:install_jaeger`, `install_fluentd`/`fluentbit`, `install_kind` — still died with a raw Crystal backtrace, and since #2451's exit classification, with **exit 2** ("the suite broke"). A missing prerequisite is neither.

## The fix

Every helm shell-out funnels through `Binary.get`, so **one rescue at the entrypoint** covers all of them:

```
$ PATH=/empty CNF_TESTSUITE_DIR=/empty-tools ./cnf-testsuite setup:install_jaeger
No Helm binary found locally or globally.
Run `cnf-testsuite setup` to install the prerequisites.
$ echo $?
1
```

Exit 1 — the precondition-failure code, same class as missing kubeconfig / no CNF installed. Tests under `task_runner` already catch the exception generically and record an errored test without dumping a backtrace; that path is deliberately unchanged.

## Plus the review cleanup from #2403

`Helm.binary_found?` re-implemented two-thirds of `ToolChecker#check` by calling the protected `global_check`/`local_check` hooks directly — a future pre-check added to `Helm` would silently not be probed. `ToolChecker#check` now takes `run_post_checks: false` (skipping only the cluster-touching checks a presence probe must not run), and `binary_found?` goes back through the single code path.

## Verification (Crystal 1.6.2)

- New spec: empty `PATH` + empty tools dir → `setup:install_jaeger` exits 1, names the missing binary, points at `setup`, prints no backtrace
- Full helm spec file 10/10 (includes #2403's missing-helm guard exercising the refactored `binary_found?` end to end), points shard 49/49
- Manual run as above

Closes #2457
