### PR TITLE
One owned workspace directory: cnti/ replaces results/ and installed_cnf_files/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,7 @@
 *.swp
 *.swo
 /cnfs
-/installed_cnf_files
-/results
+/cnti
 admin.conf
 cnf-testsuite
 results.yml

--- a/K8S_OPERATORS.md
+++ b/K8S_OPERATORS.md
@@ -8,7 +8,7 @@ Operators are Kubernetes controllers that manage custom resources and automate a
 
 1. **Label-based Identification**
    - The test suite fetches resources matching label selectors defined in `cnf-testsuite.yml` under `workload_resource_labels`.
-   - After all deployments are installed, resources with these labels are identified and appended to the composite manifest (`installed_cnf_files/common-manifest.yml`).
+   - After all deployments are installed, resources with these labels are identified and appended to the composite manifest (`cnti/installed-cnf/common_manifest.yml`).
    - This enables tests to reference resources reliably, regardless of when or how they are created by the operator.
 
 2. **OwnerReference-based Identification**

--- a/SOURCE_INSTALL.md
+++ b/SOURCE_INSTALL.md
@@ -151,7 +151,7 @@ crystal spec
 
 ### Preparation
 
-Now that we have a `cnf-testsuite` binary, we can run `setup` to ensure it has all the pre-requisites needed in order to successfully run tests and prepare required installed_cnf_files/ directory and other files required for cnf-testsuite.
+Now that we have a `cnf-testsuite` binary, we can run `setup` to ensure it has all the pre-requisites needed in order to successfully run tests and prepare the required `cnti/` workspace directory and other files required for cnf-testsuite.
 
 - Run the following to prepare cnf-testsuite:
   ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -46,20 +46,20 @@ Failed/errored tests also print indented detail lines beneath the result:
 
 #### Results file
 
-Each run writes a **timestamped YAML file** into the results directory — `results/` under the
+Each run writes a **timestamped YAML file** into the results directory — `cnti/results/` under the
 current working directory unless redirected (see below):
 
 ```
-results/cnf-testsuite-results-<YYYYMMDD-HHMMSS-mmm>.yml
+cnti/results/cnf-testsuite-results-<YYYYMMDD-HHMMSS-mmm>.yml
 ```
 
-A new file is created per run, and **`results/latest.yml` always points at the newest one** — a
+A new file is created per run, and **`cnti/results/latest.yml` always points at the newest one** — a
 relative symlink, repointed whenever a results file is created (a copy, kept current, on
 filesystems without symlinks). Scripts should read `latest.yml` rather than sorting the
 directory. Every run also ends with one stable line naming both paths:
 
 ```
-Results: results/cnf-testsuite-results-<timestamp>.yml (latest: results/latest.yml)
+Results: cnti/results/cnf-testsuite-results-<timestamp>.yml (latest: cnti/results/latest.yml)
 ```
 
 To write somewhere else, pass `results-dir=PATH` on the command line or set the

--- a/docs/cnf-testsuite-results.schema.json
+++ b/docs/cnf-testsuite-results.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/lfn-cnti/testsuite/main/docs/cnf-testsuite-results.schema.json",
   "title": "CNTi Test Suite results file",
-  "description": "Schema for the results/cnf-testsuite-results-<timestamp>.yml file produced by a completed CNTi Test Suite run. Matches schema_version 1. The file is YAML; this schema validates it as JSON (YAML is a JSON superset).",
+  "description": "Schema for the cnti/results/cnf-testsuite-results-<timestamp>.yml file produced by a completed CNTi Test Suite run. Matches schema_version 1. The file is YAML; this schema validates it as JSON (YAML is a JSON superset).",
   "type": "object",
   "required": [
     "name",

--- a/spec/utils/artifact_paths_spec.cr
+++ b/spec/utils/artifact_paths_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
-# A run must only ever touch results/ and installed_cnf_files/ in the working
-# directory; every other runtime artifact lives with the tools.
+# A run must only ever touch the cnti/ workspace in the working directory;
+# every other runtime artifact lives with the tools.
 describe "Runtime artifact locations" do
   it "keeps runtime artifacts out of the working directory", tags: ["points"] do
     [

--- a/spec/utils/results_spec.cr
+++ b/spec/utils/results_spec.cr
@@ -2,11 +2,11 @@ require "../spec_helper"
 require "../../src/tasks/utils/cli_args_validation"
 
 describe "Results location" do
-  it "keeps results/latest.yml pointing at the newest results file", tags: ["points"] do
+  it "keeps cnti/results/latest.yml pointing at the newest results file", tags: ["points"] do
     ShellCmd.run_testsuite("_divide_by_zero")
     latest = CNFManager::Points::Results.latest
     File.exists?(latest).should be_true
-    newest = Dir.glob("results/cnf-testsuite-results-*.yml").max_by { |path| File.info(path).modification_time }.not_nil!
+    newest = Dir.glob("cnti/results/cnf-testsuite-results-*.yml").max_by { |path| File.info(path).modification_time }.not_nil!
     File.symlink?(latest).should be_true
     File.readlink(latest).should eq(File.basename(newest))
     YAML.parse(File.read(latest))["items"].as_a.should_not be_empty
@@ -16,14 +16,14 @@ describe "Results location" do
     cli_dir = File.tempname("results-cli")
     env_dir = File.tempname("results-env")
     begin
-      default_count = Dir.glob("results/cnf-testsuite-results-*.yml").size
+      default_count = Dir.glob("cnti/results/cnf-testsuite-results-*.yml").size
 
       result = ShellCmd.run_testsuite("_divide_by_zero results-dir=#{cli_dir}", "CNF_TESTSUITE_RESULTS_DIR=#{env_dir}")
       result[:output].should contain("Results: #{cli_dir}/")
       Dir.glob(File.join(cli_dir, "cnf-testsuite-results-*.yml")).size.should eq(1)
       File.exists?(File.join(cli_dir, "latest.yml")).should be_true
       Dir.exists?(env_dir).should be_false
-      Dir.glob("results/cnf-testsuite-results-*.yml").size.should eq(default_count)
+      Dir.glob("cnti/results/cnf-testsuite-results-*.yml").size.should eq(default_count)
 
       ShellCmd.run_testsuite("_divide_by_zero", "CNF_TESTSUITE_RESULTS_DIR=#{env_dir}")
       env_files = Dir.glob(File.join(env_dir, "cnf-testsuite-results-*.yml"))

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -1,7 +1,12 @@
 require "./utils/embedded_file_manager.cr"
 
 ESSENTIAL_PASSED_THRESHOLD = 15
-CNF_DIR = "installed_cnf_files"
+# The one directory the suite owns in the user's working directory. Everything
+# a run writes into the CWD lives under it: the installed CNF's files and the
+# results (unless results-dir/CNF_TESTSUITE_RESULTS_DIR redirect those).
+CNTI_DIR = "cnti"
+
+CNF_DIR = File.join(CNTI_DIR, "installed-cnf")
 DEPLOYMENTS_DIR = File.join(CNF_DIR, "deployments")
 CNF_TEMP_FILES_DIR = File.join(CNF_DIR, "temp_files")
 CNF_INSTALL_LOG_FILE = File.join(CNF_TEMP_FILES_DIR, "installation.log")

--- a/src/tasks/setup/constants.cr
+++ b/src/tasks/setup/constants.cr
@@ -46,7 +46,7 @@ module Setup
 
   # Manifests and helm values the suite renders at runtime. Kept with the
   # tools rather than scattered into the user's working directory: a run must
-  # only ever touch results/ and installed_cnf_files/ in the CWD.
+  # only ever touch the cnti/ workspace in the CWD.
   RENDERED_MANIFESTS_DIR = "#{tools_path}/rendered-manifests"
   CLUSTER_TOOLS_MANIFEST = "#{RENDERED_MANIFESTS_DIR}/cluster_tools.yml"
   FIVE_G_TOOLS_DIR       = "#{tools_path}/5g"

--- a/src/tasks/utils/cli_help.cr
+++ b/src/tasks/utils/cli_help.cr
@@ -181,7 +181,7 @@ module CLIHelp
     ARGUMENTS (key=value, after the task name)
       cnf-config=PATH   a cnf-testsuite.yml or the directory holding one (alias: cnf-path)
       timeout=SECONDS   how long to wait for install and uninstall operations
-      results-dir=PATH  where results files go (default: ./results, or $CNF_TESTSUITE_RESULTS_DIR)
+      results-dir=PATH  where results files go (default: ./cnti/results, or $CNF_TESTSUITE_RESULTS_DIR)
       All known arguments: #{named_args}
 
     FLAGS

--- a/src/tasks/utils/cnf_manager/points.cr
+++ b/src/tasks/utils/cnf_manager/points.cr
@@ -152,14 +152,14 @@ module CNFManager
 
       @@logger : ::Log = Log.for("Points").for("Results")
 
-      DEFAULT_DIR     = "results"
+      DEFAULT_DIR     = File.join(CNTI_DIR, "results")
       RESULTS_DIR_ARG = "results-dir"
       RESULTS_DIR_ENV = "CNF_TESTSUITE_RESULTS_DIR"
       LATEST_NAME     = "latest.yml"
 
       # Directory results are written to: `results-dir=PATH` on the command line,
-      # else CNF_TESTSUITE_RESULTS_DIR, else ./results. Resolved once per process
-      # and creates nothing -- delete_results reads it too.
+      # else CNF_TESTSUITE_RESULTS_DIR, else ./cnti/results. Resolved once
+      # per process and creates nothing -- delete_results reads it too.
       def self.dir : String
         @@dir ||= begin
           arg = ARGV.find(&.starts_with?("#{RESULTS_DIR_ARG}="))


### PR DESCRIPTION
Part of the breaking-release cleanup: the two directories a run writes into the user's project had **generic names**. `results/` could be anyone's directory — the suite runs inside the user's own CNF project, and `delete_results` deletes inside it. `installed_cnf_files/` is `rm -rf`'d on uninstall — exactly where a name should make ownership unmistakable.

## After

```
cnti/
├── results/          # cnf-testsuite-results-<ts>.yml, latest.yml
└── installed-cnf/    # config copy, deployments/, common_manifest.yml
```

**A run creates exactly one directory in your project, and its name says who owns it.** `installed-cnf` is singular (matching the one-CNF-at-a-time invariant) and kebab-case like the rest of the surface.

Why `cnti` and not `cnf-testsuite`: in a source checkout the built binary is a **file** named `./cnf-testsuite` in the same directory — a file and a directory cannot share a name.

## Mechanics

- New `CNTI_DIR` constant anchors `CNF_DIR` (`cnti/installed-cnf`) and the results default (`cnti/results`)
- `results-dir=` / `CNF_TESTSUITE_RESULTS_DIR` unchanged — only the **default** moved
- USAGE.md, schema description, help text, results-spec globs follow
- `.gitignore`: the two entries collapse to `/cnti`

## Migration table rows (for the release notes)

| was | is |
|---|---|
| `results/latest.yml` | `cnti/results/latest.yml` |
| `installed_cnf_files/` | `cnti/installed-cnf/` |
| stale `results/`, `installed_cnf_files/` in old checkouts | no longer gitignored — delete them |

## Verification (Crystal 1.6.2)

- points shard 49/49 (results specs exercise the new default end to end)
- Live `cnf_install` → `_divide_by_zero` → `cnf_uninstall` cycle: only `cnti/` created, `Results: cnti/results/…` printed, `cnti/installed-cnf` removed on uninstall, and **no directory of either old name** appears

Note for reviewers: trivially overlaps #2460's acceptance phrasing ("only `results/` and `installed_cnf_files/`" → now "only `cnti/`") and #2460/#2456 touch neighboring constants/docs — whichever merges second is a seconds-long rebase, which I'll handle.
