### PR TITLE
Say why a chaos test failed: surface the chaosresult failStep and probes

### DIFF
--- a/spec/utils/litmus_verdict_spec.cr
+++ b/spec/utils/litmus_verdict_spec.cr
@@ -1,0 +1,26 @@
+require "../spec_helper"
+
+describe "LitmusManager.chaos_failure_summary" do
+  it "extracts the failStep and every non-passing probe", tags: ["points"] do
+    raw = {
+      status: {
+        experimentStatus: {verdict: "Fail", failStep: "AUT: Running check failed"},
+        probeStatuses:    [
+          {name: "app-ready", status: {verdict: "Failed", description: "pod not ready after chaos"}},
+          {name: "node-back", status: {verdict: "Passed"}},
+        ],
+      },
+    }.to_json
+
+    summary = LitmusManager.chaos_failure_summary(raw).not_nil!
+    summary.should contain("failStep: AUT: Running check failed")
+    summary.should contain("probe app-ready: Failed (pod not ready after chaos)")
+    summary.should_not contain("node-back")
+  end
+
+  it "returns nil when there is no detail to report", tags: ["points"] do
+    LitmusManager.chaos_failure_summary({status: {experimentStatus: {failStep: "N/A"}}}.to_json).should be_nil
+    LitmusManager.chaos_failure_summary("{}").should be_nil
+    LitmusManager.chaos_failure_summary("not json at all").should be_nil
+  end
+end

--- a/src/tasks/utils/litmus_manager.cr
+++ b/src/tasks/utils/litmus_manager.cr
@@ -90,20 +90,47 @@ module LitmusManager
   end
 
   ## check_chaos_verdict will check the verdict of chaosexperiment
-  def self.check_chaos_verdict(chaos_result_name, chaos_experiment_name, args, namespace : String = "default") : Bool
+  def self.check_chaos_verdict(chaos_result_name, chaos_experiment_name, args,
+                               namespace : String = "default",
+                               result : CNFManager::TestCaseResult? = nil) : Bool
     _, verdict = get_status_info("chaosresult", chaos_result_name, "jsonpath={.status.experimentStatus.verdict}", namespace)
+    return true if verdict == "Pass"
 
-    if verdict == "Pass"
-      return true
-    else
-      Log.for("LitmusManager.check_chaos_verdict#details").debug do
-        status_code, verdict_details_response = get_status_info("chaosresult", chaos_result_name, "json", namespace)
-        "#{verdict_details_response}"
-      end
+    # The chaosresult knows *why*: surface its failStep and failed probes into
+    # the test's details and the error log, instead of discarding them at a log
+    # level no CI run has enabled. A verdict without its reason cost a full
+    # afternoon of inference the one time node_drain flaked (#2445-adjacent).
+    logger = Log.for("LitmusManager.check_chaos_verdict")
+    status_code, raw_chaos_result = get_status_info("chaosresult", chaos_result_name, "json", namespace)
+    failure = status_code == 0 ? chaos_failure_summary(raw_chaos_result) : nil
+    summary = "#{chaos_experiment_name} verdict: #{verdict}#{failure ? " -- #{failure}" : ""}"
 
-      Log.for("LitmusManager.check_chaos_verdict").info {"#{chaos_experiment_name} chaos test failed: #{chaos_result_name}, verdict: #{verdict}"}
-      return false
+    logger.error { "#{chaos_result_name}: #{summary}" }
+    result.try(&.append_description("Litmus #{summary}"))
+    false
+  end
+
+  # Distills a chaosresult JSON into the line a human needs: the step that
+  # failed and every probe that did not pass. Returns nil when the payload
+  # holds no such detail (or is not JSON at all).
+  def self.chaos_failure_summary(raw_chaos_result : String) : String?
+    json = JSON.parse(raw_chaos_result)
+    parts = [] of String
+
+    fail_step = json.dig?("status", "experimentStatus", "failStep").try(&.as_s?)
+    parts << "failStep: #{fail_step}" if fail_step && !fail_step.empty? && fail_step != "N/A"
+
+    json.dig?("status", "probeStatuses").try(&.as_a?).try &.each do |probe|
+      probe_verdict = probe.dig?("status", "verdict").try(&.as_s?)
+      next if probe_verdict.nil? || probe_verdict == "Passed"
+      name = probe.dig?("name").try(&.as_s?) || "unnamed"
+      description = probe.dig?("status", "description").try(&.as_s?)
+      parts << "probe #{name}: #{probe_verdict}#{description ? " (#{description})" : ""}"
     end
+
+    parts.empty? ? nil : parts.join("; ")
+  rescue JSON::ParseException
+    nil
   end
 
   def self.chaos_manifests_path

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -155,7 +155,7 @@ scored_task "pod_network_latency",
         File.write(chaos_template_path, template)
         KubectlClient::Apply.file(chaos_template_path)
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
-        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
+        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace, result: result)
       end
 
       test_passed
@@ -218,7 +218,7 @@ scored_task "pod_network_corruption",
         File.write(chaos_template_path, template)
         KubectlClient::Apply.file(chaos_template_path)
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
-        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name, args, namespace: app_namespace)
+        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name, args, namespace: app_namespace, result: result)
       end
 
       test_passed
@@ -279,7 +279,7 @@ scored_task "pod_network_duplication",
         File.write(chaos_template_path, template)
         KubectlClient::Apply.file(chaos_template_path)
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
-        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
+        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace, result: result)
       end
 
       test_passed
@@ -339,7 +339,7 @@ scored_task "disk_fill",
         File.write(chaos_template_path, template)
         KubectlClient::Apply.file(chaos_template_path)
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
-        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name, chaos_experiment_name, args, namespace: app_namespace)
+        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name, chaos_experiment_name, args, namespace: app_namespace, result: result)
       end
 
       test_passed
@@ -443,7 +443,7 @@ scored_task "pod_delete",
         KubectlClient::Apply.file(chaos_template_path)
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
       end
-      test_passed=LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
+      test_passed=LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace, result: result)
       test_passed
     end
     unless args.named["pod_labels"]?
@@ -504,7 +504,7 @@ scored_task "pod_memory_hog",
         File.write(chaos_template_path, template)
         KubectlClient::Apply.file(chaos_template_path)
         LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
-        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
+        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace, result: result)
       end
       test_passed
     end
@@ -565,7 +565,7 @@ scored_task "pod_io_stress",
         File.write(chaos_template_path, template)
         KubectlClient::Apply.file(chaos_template_path)
         LitmusManager.wait_for_test(chaos_test_name, chaos_experiment_name, args, namespace: app_namespace)
-        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
+        test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace, result: result)
       end
 
       test_passed
@@ -636,7 +636,7 @@ scored_task "pod_dns_error",
           File.write(chaos_template_path, template)
           KubectlClient::Apply.file(chaos_template_path)
           LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
-          test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace)
+          test_passed = LitmusManager.check_chaos_verdict(chaos_result_name,chaos_experiment_name,args, namespace: app_namespace, result: result)
         end
 
         test_passed

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -325,7 +325,7 @@ scored_task "node_drain",
             File.write(chaos_template_path, template)
             KubectlClient::Apply.file(chaos_template_path)
             LitmusManager.wait_for_test(test_name, chaos_experiment_name, args, namespace: app_namespace)
-            test_passed = LitmusManager.check_chaos_verdict(chaos_result_name, chaos_experiment_name, args, namespace: app_namespace)
+            test_passed = LitmusManager.check_chaos_verdict(chaos_result_name, chaos_experiment_name, args, namespace: app_namespace, result: result)
           end
         ensure
           # Uncordon the node whatever happened above. Without this, a test that raises


### PR DESCRIPTION
When a Litmus experiment fails, the `chaosresult` object holds the reason — `.status.experimentStatus.failStep` and per-probe verdicts. The suite *fetched* that JSON and logged it at **DEBUG** (the one-line notice at INFO), while CI runs at the default `error` level. So every chaos failure reported exactly `chaos test failed`, and the run threw the explanation away. Diagnosing yesterday's `node_drain` flake on the `debian (sid)` leg took an afternoon of timeline inference that this JSON would have answered in one line.

## What changes

On a non-`Pass` verdict, `check_chaos_verdict` distills the chaosresult — `failStep` + every probe that didn't pass, with descriptions — and puts the summary in three places:

1. **the error log** — visible at the default level, so CI output carries it
2. **the test's `details`** in the results file, via an optional `result` parameter all nine call sites (node_drain + the eight reliability chaos tests) now pass
3. therefore also the **indented `>` detail line** under the FAILED output, per the results contract

```
🏆FAILED: [node_drain] node_drain chaos test failed 🗡️💀♻
   > Litmus node-drain verdict: Fail -- failStep: AUT: Running check failed; probe app-ready: Failed (pod not ready after chaos)
```

`chaos_failure_summary` is defensive: missing fields, `"N/A"` failStep, passing probes, and non-JSON payloads all reduce to `nil`, leaving just the bare verdict. A `Pass` verdict short-circuits exactly as before.

## Verification (Crystal 1.6.2)

- Unit specs: failStep + failed-probe extraction (passing probes excluded), and the nil cases (`N/A`, empty, not JSON)
- points shard 51/51
- Live `node_drain` on a kind cluster exercises the rewritten function end to end on the Pass path

The Fail path's exact rendering is unit-tested rather than provoked live — deterministically forcing a chaos verdict failure means breaking a cluster mid-experiment. The next real flake is the integration test, which is rather the point: it will explain itself.

Related: results-file `details` coverage (#2155); the node_drain zero-headroom discussion in #2449.
