### PR TITLE
Resolve config.yml from the CWD, then the suite home

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -457,7 +457,7 @@ LOGLEVEL=DEBUG ./cnf-testsuite test
 
 1. CLI or Command line flag
 2. Environment variable
-3. CNF-Testsuite [Config file](config.yml)
+3. CNF-Testsuite [Config file](config.yml) — `./config.yml` in the working directory, else `config.yml` in the suite home (`~/.cnf-testsuite`, relocatable via `CNF_TESTSUITE_DIR`)
 
 > Note: Available log levels are: `trace`, `debug`, `info`, `notice`, `warn`, `error` and `fatal`.
 

--- a/spec/utils/base_config_spec.cr
+++ b/spec/utils/base_config_spec.cr
@@ -1,0 +1,31 @@
+require "../spec_helper"
+
+describe "config.yml resolution" do
+  it "resolves from the CWD first, then the suite home", tags: ["points"] do
+    home = File.tempname("cfg-home")
+    cwd = File.tempname("cfg-cwd")
+    FileUtils.mkdir_p(home)
+    FileUtils.mkdir_p(cwd)
+    ENV["CNF_TESTSUITE_DIR"] = home
+    File.write(File.join(home, "config.yml"),
+      {"toggles" => [{"name" => "wip", "toggle_on" => true}]}.to_yaml)
+
+    Dir.cd(cwd) do
+      base_config_path.should eq(File.join(home, "config.yml"))
+      toggle("wip").should be_true
+
+      # A project-local config overrides the home one.
+      File.write("config.yml", {"toggles" => [{"name" => "wip", "toggle_on" => false}]}.to_yaml)
+      base_config_path.should eq("config.yml")
+      toggle("wip").should be_false
+
+      File.delete("config.yml")
+      File.delete(File.join(home, "config.yml"))
+      base_config_path.should be_nil
+    end
+  ensure
+    ENV.delete("CNF_TESTSUITE_DIR")
+    FileUtils.rm_rf(home.not_nil!)
+    FileUtils.rm_rf(cwd.not_nil!)
+  end
+end

--- a/src/modules/docker_client/constants.cr
+++ b/src/modules/docker_client/constants.cr
@@ -1,4 +1,3 @@
 module DockerClient
 	DEFAULT_LOCAL_BINARY_PATH = "tools/docker/linux-amd64/docker"
-	BASE_CONFIG = "./config.yml"
 end

--- a/src/modules/docker_client/utils/utils.cr
+++ b/src/modules/docker_client/utils/utils.cr
@@ -5,12 +5,5 @@ require "file_utils"
 require "../constants.cr"
 
 def local_docker_path
-  if File.exists?(DockerClient::BASE_CONFIG)
-    config = Totem.from_file DockerClient::BASE_CONFIG
-    if config[":docker_binary_path"]? && config[":docker_binary_path"].as_s?
-      return config[":docker_binary_path"].as_s
-    end
-  end
-
   File.join(FileUtils.pwd, DockerClient::DEFAULT_LOCAL_BINARY_PATH)
 end

--- a/src/modules/git/constants.cr
+++ b/src/modules/git/constants.cr
@@ -1,4 +1,3 @@
 module GitClient
 	DEFAULT_LOCAL_BINARY_PATH = "tools/git/linux-amd64/git"
-	BASE_CONFIG = "./config.yml"
 end

--- a/src/modules/git/utils/utils.cr
+++ b/src/modules/git/utils/utils.cr
@@ -21,12 +21,5 @@ def stdout_failure(msg)
 end
 
 def local_git_path
-  if File.exists?(GitClient::BASE_CONFIG)
-    config = Totem.from_file GitClient::BASE_CONFIG
-    if config[":git_binary_path"]? && config[":git_binary_path"].as_s?
-      return config[":git_binary_path"].as_s
-    end
-  end
-
   File.join(FileUtils.pwd, GitClient::DEFAULT_LOCAL_BINARY_PATH)
 end

--- a/src/modules/kubectl_client/constants.cr
+++ b/src/modules/kubectl_client/constants.cr
@@ -1,6 +1,5 @@
 module KubectlClient
   DEFAULT_LOCAL_BINARY_PATH  = "tools/kubectl/linux-amd64/kubectl"
-  BASE_CONFIG                = "./config.yml"
   RESOURCE_WAIT_LOG_INTERVAL = 10
   # https://www.capitalone.com/tech/cloud/container-runtime/
   OCI_RUNTIME_REGEX = /containerd|docker|podman|runc|railcar|crun|rkt|gviso|nabla|runv|clearcontainers|kata|cri-o/i

--- a/src/modules/kubectl_client/utils/utils.cr
+++ b/src/modules/kubectl_client/utils/utils.cr
@@ -21,12 +21,5 @@ def stdout_failure(msg)
 end
 
 def local_kubectl_path
-  if File.exists?(KubectlClient::BASE_CONFIG)
-    config = Totem.from_file KubectlClient::BASE_CONFIG
-    if config[":kubectl_binary_path"]? && config[":kubectl_binary_path"].as_s?
-      return config[":kubectl_binary_path"].as_s
-    end
-  end
-
   File.join(FileUtils.pwd, KubectlClient::DEFAULT_LOCAL_BINARY_PATH)
 end

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -6,7 +6,6 @@ DEPLOYMENTS_DIR = File.join(CNF_DIR, "deployments")
 CNF_TEMP_FILES_DIR = File.join(CNF_DIR, "temp_files")
 CNF_INSTALL_LOG_FILE = File.join(CNF_TEMP_FILES_DIR, "installation.log")
 CONFIG_FILE = "cnf-testsuite.yml"
-BASE_CONFIG = "./config.yml"
 COMMON_MANIFEST_FILE_PATH = "#{CNF_DIR}/common_manifest.yml"
 DEPLOYMENT_MANIFEST_FILE_NAME = "deployment_manifest.yml"
 # todo move to helm module

--- a/src/tasks/utils/logging.cr
+++ b/src/tasks/utils/logging.cr
@@ -77,8 +77,8 @@ private def loglevel
   # 3. Config file is last level of precedence
 
   # lowest priority is first
-  if File.exists?(BASE_CONFIG)
-    config = Totem.from_file BASE_CONFIG
+  if config_path = base_config_path
+    config = Totem.from_file config_path
     if config["loglevel"].as_s?
       level_str = config["loglevel"].as_s
     end

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -79,20 +79,33 @@ def check_cnf_config(args)
   cnf
 end
 
+BASE_CONFIG_NAME = "config.yml"
+
+# The suite's own settings file (feature toggles, loglevel): the working
+# directory wins as a project-local override, else the suite home. Home is
+# checked without creating it, so read-only invocations stay side-effect free.
+def base_config_path : String?
+  return BASE_CONFIG_NAME if File.exists?(BASE_CONFIG_NAME)
+  home_config = File.join(ENV.fetch("CNF_TESTSUITE_DIR", "#{ENV["HOME"]}/.cnf-testsuite"), BASE_CONFIG_NAME)
+  File.exists?(home_config) ? home_config : nil
+end
+
 module BaseConfigWarning
   @@warned = false
 
   def self.warn_missing_once
     return if @@warned
     @@warned = true
-    stdout_warning "No #{BASE_CONFIG} found in the current directory; feature toggles (wip, alpha, beta, poc, destructive, multi-cnf) default to disabled."
+    stdout_warning "No #{BASE_CONFIG_NAME} found in the current directory or the suite home " \
+                   "(#{ENV.fetch("CNF_TESTSUITE_DIR", "~/.cnf-testsuite")}); feature toggles " \
+                   "(wip, alpha, beta, poc, destructive, multi-cnf) default to disabled."
   end
 end
 
 def toggle(toggle_name)
   toggle_on = false
-  if File.exists?(BASE_CONFIG)
-    config = Totem.from_file BASE_CONFIG
+  if config_path = base_config_path
+    config = Totem.from_file config_path
     if config["toggles"].as_a?
       feature_flag = config["toggles"].as_a.find do |x|
         x["name"] == toggle_name


### PR DESCRIPTION
`config.yml` — the suite's own settings (feature toggles, loglevel) — was read from `./config.yml` **only**, and `BASE_CONFIG` was defined **four times** (tasks + kubectl/docker/git modules). Running the binary anywhere but a directory holding a `config.yml` silently reverted toggles and loglevel to defaults — the last "behaves differently outside the checkout" item on the CLI plan (A4.3/A4.8).

## Resolution order

1. `./config.yml` — project-local override
2. `$CNF_TESTSUITE_DIR/config.yml` (default `~/.cnf-testsuite/config.yml`) — the suite home
3. neither → defaults, with a warning that now names **both** locations it looked in

One `base_config_path` resolver feeds both consumers (`toggle()`, loglevel). The home lookup is a plain existence check that **creates nothing** — read-only invocations (`help`, `version`) stay side-effect free, preserving #2420's guarantee.

## The four definitions become one — by deleting three

The module copies existed to read undocumented `:kubectl_binary_path`-style overrides from a CWD `config.yml`: never documented, never in the example config, duplicated per module. Removed along with their `BASE_CONFIG` constants (breaking-window cleanup; the local-binary prereq checks keep their path defaults). One row for the migration table: those overrides are gone.

## Verification (Crystal 1.6.2)

- New resolution spec: home honored when CWD has none, CWD wins when both exist, nil when neither
- points 50/50, logger 8/8
- **Live**: from an empty directory, a home `config.yml` with `loglevel: debug` turns debug logging on; adding a CWD `config.yml` with `loglevel: error` overrides it back off — exercising the require-time loglevel path, not just `toggle()`

With this, Phase 3's small items are done; the remaining breaking work is the GNU options RFC (#2459).
