### PR TITLE
Bump the low-risk tool pins and pin what floated

### DIFF
--- a/.github/actions/install-kind/action.yml
+++ b/.github/actions/install-kind/action.yml
@@ -5,7 +5,7 @@ inputs:
     description: "kind version to install"
     required: false
     # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-    default: "v0.31.0"
+    default: "v0.32.0"
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/test-doc-lint.yml
+++ b/.github/workflows/test-doc-lint.yml
@@ -16,7 +16,7 @@ jobs:
        image: ruby:latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Install mdl
       run: gem install mdl
     - name: Run mdl

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner (Repo mode)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: 'fs'          # 'fs' stands for filesystem (scans your code directly)
           ignore-unfixed: true     # Only show vulnerabilities that actually have a fix

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -17,7 +17,7 @@ DEPLOYMENT_MANIFEST_FILE_NAME = "deployment_manifest.yml"
 # CHART_YAML = "Chart.yaml"
 DEFAULT_POINTSFILENAME = "points_v1.yml"
 # renovate: datasource=github-releases depName=vmware-tanzu/sonobuoy
-SONOBUOY_K8S_VERSION = "0.56.14"
+SONOBUOY_K8S_VERSION = "0.57.5"
 IGNORED_SECRET_TYPES = ["kubernetes.io/service-account-token", "kubernetes.io/dockercfg", "kubernetes.io/dockerconfigjson", "helm.sh/release.v1"]
 EMPTY_JSON = JSON.parse(%({}))
 EMPTY_JSON_ARRAY = JSON.parse(%([]))

--- a/src/tasks/setup/constants.cr
+++ b/src/tasks/setup/constants.cr
@@ -30,18 +30,17 @@ module Setup
 
   # Versions of the tools
   # renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
-  CLUSTER_API_VERSION         = "1.9.6"
+  CLUSTER_API_VERSION         = "1.14.0"
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  KIND_VERSION                = "0.27.0"
+  KIND_VERSION                = "0.32.0"
   # renovate: datasource=github-releases depName=kubescape/kubescape
   KUBESCAPE_VERSION           = "3.0.30"
   # renovate: datasource=github-releases depName=kubescape/regolibrary
   KUBESCAPE_FRAMEWORK_VERSION = "1.0.316"
   # renovate: datasource=github-releases depName=helm/helm
-  HELM_VERSION                = "3.19.0"
-  # (rafal-lal) TODO: configure version of the gatekeeper
+  HELM_VERSION                = "3.21.4"
   # renovate: datasource=helm depName=gatekeeper registryUrl=https://open-policy-agent.github.io/gatekeeper/charts
-  GATEKEEPER_VERSION          = "TODO: USE THIS"
+  GATEKEEPER_VERSION          = "3.23.0"
 
   # Useful consts grouped by tools
   CLUSTER_API_URL    = "https://github.com/kubernetes-sigs/cluster-api/releases/download/" +

--- a/src/tasks/setup/kind_setup.cr
+++ b/src/tasks/setup/kind_setup.cr
@@ -55,7 +55,7 @@ class KindManager
 
   #totod make a create cluster with flannel
 
-  def create_cluster(name : String, kind_config : String?, k8s_version = "1.21.1") : KindManager::Cluster?
+  def create_cluster(name : String, kind_config : String?, k8s_version = "1.35.5") : KindManager::Cluster?
     Log.info { "Creating Kind Cluster" }
     kubeconfig = "#{Setup::KIND_DIR}/#{name}_admin.conf"
     Log.for("kind_kubeconfig").info { kubeconfig }

--- a/src/tasks/setup/opa_setup.cr
+++ b/src/tasks/setup/opa_setup.cr
@@ -21,7 +21,7 @@ task "install_opa", ["setup:install_local_helm", "setup:create_namespace"] do |_
 
   Helm.helm_repo_add("gatekeeper", "https://open-policy-agent.github.io/gatekeeper/charts")
   begin
-    Helm.install("opa-gatekeeper", "gatekeeper/gatekeeper", values: helm_install_args)
+    Helm.install("opa-gatekeeper", "gatekeeper/gatekeeper", values: "--version #{Setup::GATEKEEPER_VERSION} #{helm_install_args}")
   rescue e : Helm::ShellCMD::CannotReuseReleaseNameError
     stdout_warning "gatekeeper already installed"
   end

--- a/src/tasks/utils/jaeger.cr
+++ b/src/tasks/utils/jaeger.cr
@@ -3,6 +3,7 @@ require "../../modules/cluster_tools"
 module JaegerManager
   # JAEGER_PORT = "14271" # agent port
   JAEGER_PORT = "14269" # collector port
+  JAEGER_CHART_VERSION = "4.12.0"
   def self.match()
     ClusterTools.local_match_by_image_name_with_retries("jaegertracing/jaeger-collector")
   end
@@ -17,7 +18,7 @@ module JaegerManager
     Log.info {"Installing Jaeger daemonset "}
     Helm.helm_repo_add("jaegertracing","https://jaegertracing.github.io/helm-charts")
     CNFManager.ensure_namespace_exists!("jaeger")
-    Helm.install("jaeger", "jaegertracing/jaeger", namespace: "jaeger", values: "--set cassandra.config.cluster_size=1 --set cassandra.config.seed_size=1")
+    Helm.install("jaeger", "jaegertracing/jaeger", namespace: "jaeger", values: "--version #{JAEGER_CHART_VERSION} --set cassandra.config.cluster_size=1 --set cassandra.config.seed_size=1")
     KubectlClient::Wait.resource_wait_for_install("Deployment", "jaeger-collector", 300, namespace: "jaeger")
     KubectlClient::Wait.resource_wait_for_install("Deployment", "jaeger-query", 300, namespace: "jaeger")
     KubectlClient::Wait.resource_wait_for_install("Daemonset", "jaeger-agent", 300, namespace: "jaeger")

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -520,7 +520,7 @@ def setup_calico_cluster(cluster_name : String) : KindManager::Cluster
   calico_cluster = KindManager.create_cluster_with_chart_and_wait(
     cluster_name,
     KindManager.disable_cni_config,
-    "projectcalico/tigera-operator --version v3.20.2"
+    "projectcalico/tigera-operator --version v3.32.1"
   )
 
   return calico_cluster
@@ -539,7 +539,7 @@ def setup_cilium_cluster(cluster_name : String) : KindManager::Cluster
   cluster = kind_manager.create_cluster(cluster_name, KindManager.disable_cni_config)
   Helm.helm_repo_add("cilium","https://helm.cilium.io/")
   chart = "cilium/cilium"
-  chart_opts.push("--version 1.15.4")
+  chart_opts.push("--version 1.20.1")
   with_kubeconfig(cluster.kubeconfig) { Helm.install("#{cluster_name}-plugin", "#{chart}", namespace: "kube-system", values: "#{chart_opts.join(" ")}") }
 
   cluster.wait_until_pods_ready()


### PR DESCRIPTION
## Summary
Phase 1 of the dependency refresh: the mechanical version bumps that need no code adaptation.

| Dependency | Before | After |
|---|---|---|
| kind (runtime + CI action) | 0.27.0 / v0.31.0 | 0.32.0 |
| kindest/node default | v1.21.1 | v1.35.5 |
| helm (local download) | 3.19.0 | 3.21.4 |
| sonobuoy | 0.56.14 | 0.57.5 |
| clusterctl | 1.9.6 | 1.14.0 |
| gatekeeper chart | unpinned (`TODO` placeholder) | 3.23.0 |
| jaeger chart | unpinned | 4.12.0 (what it resolves to today) |
| calico / cilium (cni_compatible) | v3.20.2 / 1.15.4 | v3.32.1 / 1.20.1 |
| `actions/checkout` (doc-lint) | v3 | v4 |
| `aquasecurity/trivy-action` | `@master` | v0.36.0 |

Kubescape, kyverno, and LitmusChaos bumps need parsing/RBAC changes and follow in separate PRs.

## Test plan
- [x] `crystal build src/cnf-testsuite.cr`
- [x] All new download URLs return 200 for linux/amd64
- [x] On a kind cluster with an isolated `CNF_TESTSUITE_DIR`: `setup`, `install_kind` (kind v0.32.0), `setup:install_sonobuoy` (v0.57.5), `install_opa` (gatekeeper-3.23.0 pods Running) and `uninstall_opa`
- [ ] CI: `cni_compatible`, `k8s_conformance`, and the setup-dependent tag shards

🤖 Generated with [Claude Code](https://claude.com/claude-code)