### PR TITLE
LitmusChaos 3.6.0 -> 3.31.0, with the fault RBAC shipped in the binary

### DIFF
--- a/embedded_files/litmus_rbac/disk-fill.yaml
+++ b/embedded_files/litmus_rbac/disk-fill.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: disk-fill-sa
+  namespace: default
+  labels:
+    name: disk-fill-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: disk-fill-sa
+  namespace: default
+  labels:
+    name: disk-fill-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+  # Create and monitor the experiment & helper pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+  # Performs CRUD operations on the events inside chaosengine and chaosresult
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","get","list","patch","update"]
+  # Fetch configmaps details and mount it to the experiment pod (if specified)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list"]
+  # Track and get the runner, experiment, and helper pods log
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get","list","watch"]
+  # for creating and managing to execute comands inside target container
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get","list","create"]
+  # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+  - apiGroups: ["apps"]
+    resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get","list"]
+  # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
+    verbs: ["list","get"]
+  # for configuring and monitor the experiment job by the chaos-runner pod
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create","list","get","delete","deletecollection"]
+  # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosengines","chaosexperiments","chaosresults"]
+    verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: disk-fill-sa
+  namespace: default
+  labels:
+    name: disk-fill-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: disk-fill-sa
+subjects:
+- kind: ServiceAccount
+  name: disk-fill-sa
+  namespace: default

--- a/embedded_files/litmus_rbac/node-drain.yaml
+++ b/embedded_files/litmus_rbac/node-drain.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-drain-sa
+  namespace: default
+  labels:
+    name: node-drain-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: node-drain-sa
+  labels:
+    name: node-drain-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+# Create and monitor the experiment & helper pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+  # Performs CRUD operations on the events inside chaosengine and chaosresult
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","get","list","patch","update"]
+  # Fetch configmaps details and mount it to the experiment pod (if specified)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list"]
+  # Track and get the runner, experiment, and helper pods log
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get","list","watch"]
+  # for creating and managing to execute comands inside target container
+  - apiGroups: [""]
+    resources: ["pods/exec","pods/eviction"]
+    verbs: ["get","list","create"]
+  # ignore daemonsets while draining the node
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["list","get","delete"]
+  # for configuring and monitor the experiment job by the chaos-runner pod
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create","list","get","delete","deletecollection"]
+  # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosengines","chaosexperiments","chaosresults"]
+    verbs: ["create","list","get","patch","update","delete"]
+  # for experiment to perform node status checks
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get","list","patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: node-drain-sa
+  labels:
+    name: node-drain-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: node-drain-sa
+subjects:
+- kind: ServiceAccount
+  name: node-drain-sa
+  namespace: default

--- a/embedded_files/litmus_rbac/pod-delete.yaml
+++ b/embedded_files/litmus_rbac/pod-delete.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-delete-sa
+  namespace: default
+  labels:
+    name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-delete-sa
+  namespace: default
+  labels:
+    name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+  # Create and monitor the experiment & helper pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+  # Performs CRUD operations on the events inside chaosengine and chaosresult
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","get","list","patch","update"]
+  # Fetch configmaps details and mount it to the experiment pod (if specified)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list"]
+  # Track and get the runner, experiment, and helper pods log
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get","list","watch"]
+  # for creating and managing to execute comands inside target container
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get","list","create"]
+  # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+  - apiGroups: ["apps"]
+    resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get","list"]
+  # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
+    verbs: ["list","get"]
+  # for configuring and monitor the experiment job by the chaos-runner pod
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create","list","get","delete","deletecollection"]
+  # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosengines","chaosexperiments","chaosresults"]
+    verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-delete-sa
+  namespace: default
+  labels:
+    name: pod-delete-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-delete-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-delete-sa
+  namespace: default
+

--- a/embedded_files/litmus_rbac/pod-dns-error.yaml
+++ b/embedded_files/litmus_rbac/pod-dns-error.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-dns-error-sa
+  namespace: default
+  labels:
+    name: pod-dns-error-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-dns-error-sa
+  namespace: default
+  labels:
+    name: pod-dns-error-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+  # Create and monitor the experiment & helper pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+  # Performs CRUD operations on the events inside chaosengine and chaosresult
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","get","list","patch","update"]
+  # Fetch configmaps details and mount it to the experiment pod (if specified)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list"]
+  # Track and get the runner, experiment, and helper pods log
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get","list","watch"]
+  # for creating and managing to execute comands inside target container
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get","list","create"]
+  # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+  - apiGroups: ["apps"]
+    resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get","list"]
+  # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
+    verbs: ["list","get"]
+  # for configuring and monitor the experiment job by the chaos-runner pod
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create","list","get","delete","deletecollection"]
+  # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosengines","chaosexperiments","chaosresults"]
+    verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-dns-error-sa
+  namespace: default
+  labels:
+    name: pod-dns-error-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-dns-error-sa
+subjects:
+  - kind: ServiceAccount
+    name: pod-dns-error-sa
+    namespace: default

--- a/embedded_files/litmus_rbac/pod-io-stress.yaml
+++ b/embedded_files/litmus_rbac/pod-io-stress.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-io-stress-sa
+  namespace: default
+  labels:
+    name: pod-io-stress-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-io-stress-sa
+  namespace: default
+  labels:
+    name: pod-io-stress-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+  # Create and monitor the experiment & helper pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+  # Performs CRUD operations on the events inside chaosengine and chaosresult
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","get","list","patch","update"]
+  # Fetch configmaps details and mount it to the experiment pod (if specified)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list"]
+  # Track and get the runner, experiment, and helper pods log
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get","list","watch"]
+  # for creating and managing to execute comands inside target container
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get","list","create"]
+  # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+  - apiGroups: ["apps"]
+    resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get","list"]
+  # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
+    verbs: ["list","get"]
+  # for configuring and monitor the experiment job by the chaos-runner pod
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create","list","get","delete","deletecollection"]
+  # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosengines","chaosexperiments","chaosresults"]
+    verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-io-stress-sa
+  namespace: default
+  labels:
+    name: pod-io-stress-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-io-stress-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-io-stress-sa
+  namespace: default

--- a/embedded_files/litmus_rbac/pod-memory-hog.yaml
+++ b/embedded_files/litmus_rbac/pod-memory-hog.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-memory-hog-sa
+  namespace: default
+  labels:
+    name: pod-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-memory-hog-sa
+  namespace: default
+  labels:
+    name: pod-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+  # Create and monitor the experiment & helper pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+  # Performs CRUD operations on the events inside chaosengine and chaosresult
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","get","list","patch","update"]
+  # Fetch configmaps details and mount it to the experiment pod (if specified)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list"]
+  # Track and get the runner, experiment, and helper pods log
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get","list","watch"]
+  # for creating and managing to execute comands inside target container
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get","list","create"]
+  # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+  - apiGroups: ["apps"]
+    resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get","list"]
+  # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
+    verbs: ["list","get"]
+  # for configuring and monitor the experiment job by the chaos-runner pod
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create","list","get","delete","deletecollection"]
+  # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosengines","chaosexperiments","chaosresults"]
+    verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-memory-hog-sa
+  namespace: default
+  labels:
+    name: pod-memory-hog-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-memory-hog-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-memory-hog-sa
+  namespace: default

--- a/embedded_files/litmus_rbac/pod-network-corruption.yaml
+++ b/embedded_files/litmus_rbac/pod-network-corruption.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-network-corruption-sa
+  namespace: default
+  labels:
+    name: pod-network-corruption-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-network-corruption-sa
+  namespace: default
+  labels:
+    name: pod-network-corruption-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+  # Create and monitor the experiment & helper pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+  # Performs CRUD operations on the events inside chaosengine and chaosresult
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","get","list","patch","update"]
+  # Fetch configmaps details and mount it to the experiment pod (if specified)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list"]
+  # Track and get the runner, experiment, and helper pods log
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get","list","watch"]
+  # for creating and managing to execute comands inside target container
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get","list","create"]
+  # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+  - apiGroups: ["apps"]
+    resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get","list"]
+  # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
+    verbs: ["list","get"]
+  # for configuring and monitor the experiment job by the chaos-runner pod
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create","list","get","delete","deletecollection"]
+  # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosengines","chaosexperiments","chaosresults"]
+    verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-network-corruption-sa
+  namespace: default
+  labels:
+    name: pod-network-corruption-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-network-corruption-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-network-corruption-sa
+  namespace: default

--- a/embedded_files/litmus_rbac/pod-network-duplication.yaml
+++ b/embedded_files/litmus_rbac/pod-network-duplication.yaml
@@ -1,0 +1,79 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-network-duplication-sa
+  namespace: default
+  labels:
+    name: pod-network-duplication-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-network-duplication-sa
+  namespace: default
+  labels:
+    name: pod-network-duplication-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+  # Create and monitor the experiment & helper pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+  # Performs CRUD operations on the events inside chaosengine and chaosresult
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","get","list","patch","update"]
+  # Fetch configmaps details and mount it to the experiment pod (if specified)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list"]
+  # Track and get the runner, experiment, and helper pods log
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get","list","watch"]
+  # for creating and managing to execute comands inside target container
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get","list","create"]
+  # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+  - apiGroups: ["apps"]
+    resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get","list"]
+  # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
+    verbs: ["list","get"]
+  # for configuring and monitor the experiment job by the chaos-runner pod
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create","list","get","delete","deletecollection"]
+  # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosengines","chaosexperiments","chaosresults"]
+    verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-network-duplication-sa
+  namespace: default
+  labels:
+    name: pod-network-duplication-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-network-duplication-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-network-duplication-sa
+  namespace: default

--- a/embedded_files/litmus_rbac/pod-network-latency.yaml
+++ b/embedded_files/litmus_rbac/pod-network-latency.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-network-latency-sa
+  namespace: default
+  labels:
+    name: pod-network-latency-sa
+    app.kubernetes.io/part-of: litmus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-network-latency-sa
+  namespace: default
+  labels:
+    name: pod-network-latency-sa
+    app.kubernetes.io/part-of: litmus
+rules:
+  # Create and monitor the experiment & helper pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+  # Performs CRUD operations on the events inside chaosengine and chaosresult
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create","get","list","patch","update"]
+  # Fetch configmaps details and mount it to the experiment pod (if specified)
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get","list"]
+  # Track and get the runner, experiment, and helper pods log
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get","list","watch"]
+  # for creating and managing to execute comands inside target container
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get","list","create"]
+  # deriving the parent/owner details of the pod(if parent is anyof {deployment, statefulset, daemonsets})
+  - apiGroups: ["apps"]
+    resources: ["deployments","statefulsets","replicasets", "daemonsets"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: ["apps.openshift.io"]
+    resources: ["deploymentconfigs"]
+    verbs: ["list","get"]
+  # deriving the parent/owner details of the pod(if parent is deploymentConfig)
+  - apiGroups: [""]
+    resources: ["replicationcontrollers"]
+    verbs: ["get","list"]
+  # deriving the parent/owner details of the pod(if parent is argo-rollouts)
+  - apiGroups: ["argoproj.io"]
+    resources: ["rollouts"]
+    verbs: ["list","get"]
+  # for configuring and monitor the experiment job by the chaos-runner pod
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create","list","get","delete","deletecollection"]
+  # for creation, status polling and deletion of litmus chaos resources used within a chaos workflow
+  - apiGroups: ["litmuschaos.io"]
+    resources: ["chaosengines","chaosexperiments","chaosresults"]
+    verbs: ["create","list","get","patch","update","delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-network-latency-sa
+  namespace: default
+  labels:
+    name: pod-network-latency-sa
+    app.kubernetes.io/part-of: litmus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-network-latency-sa
+subjects:
+- kind: ServiceAccount
+  name: pod-network-latency-sa
+  namespace: default

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -36,6 +36,7 @@ EmbeddedFileManager.reboot_daemon
 EmbeddedFileManager.chaos_network_loss
 EmbeddedFileManager.chaos_cpu_hog
 EmbeddedFileManager.chaos_container_kill
+EmbeddedFileManager.litmus_rbac
 EmbeddedFileManager.enforce_image_tag
 EmbeddedFileManager.constraint_template
 EmbeddedFileManager.disable_cni

--- a/src/tasks/utils/embedded_file_manager.cr
+++ b/src/tasks/utils/embedded_file_manager.cr
@@ -40,4 +40,21 @@ module EmbeddedFileManager
   macro ueransim_helmconfig
     UERANSIM_HELMCONFIG = Base64.decode_string("{{ `cat ./embedded_files/ue.yaml | base64`}}")
   end
+  # Minimal per-fault RBAC for the LitmusChaos faults the suite runs, as
+  # published in the Litmus docs (chaos-charts stopped shipping rbac.yaml in 3.x).
+  # Each manifest targets the "default" namespace; LitmusManager.install_fault
+  # rewrites that to the CNF's namespace before applying.
+  macro litmus_rbac
+    LITMUS_RBAC = {
+      "pod-network-latency" => Base64.decode_string("{{ `cat ./embedded_files/litmus_rbac/pod-network-latency.yaml | base64` }}"),
+      "pod-network-corruption" => Base64.decode_string("{{ `cat ./embedded_files/litmus_rbac/pod-network-corruption.yaml | base64` }}"),
+      "pod-network-duplication" => Base64.decode_string("{{ `cat ./embedded_files/litmus_rbac/pod-network-duplication.yaml | base64` }}"),
+      "disk-fill" => Base64.decode_string("{{ `cat ./embedded_files/litmus_rbac/disk-fill.yaml | base64` }}"),
+      "pod-delete" => Base64.decode_string("{{ `cat ./embedded_files/litmus_rbac/pod-delete.yaml | base64` }}"),
+      "pod-memory-hog" => Base64.decode_string("{{ `cat ./embedded_files/litmus_rbac/pod-memory-hog.yaml | base64` }}"),
+      "pod-io-stress" => Base64.decode_string("{{ `cat ./embedded_files/litmus_rbac/pod-io-stress.yaml | base64` }}"),
+      "pod-dns-error" => Base64.decode_string("{{ `cat ./embedded_files/litmus_rbac/pod-dns-error.yaml | base64` }}"),
+      "node-drain" => Base64.decode_string("{{ `cat ./embedded_files/litmus_rbac/node-drain.yaml | base64` }}"),
+    }
+  end
 end

--- a/src/tasks/utils/litmus_manager.cr
+++ b/src/tasks/utils/litmus_manager.cr
@@ -1,11 +1,8 @@
 module LitmusManager
 
   # renovate: datasource=github-tags depName=litmuschaos/chaos-charts
-  Version = "3.6.0"
-  # renovate: datasource=github-tags depName=litmuschaos/chaos-charts
-  RBAC_VERSION = "2.6.0"
-  # Version = "1.13.8"
-  # Version = "3.0.0-beta12"
+  Version = "3.31.0"
+  CHAOS_CHARTS = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{Version}"
   NODE_LABEL = "kubernetes.io/hostname"
   #https://raw.githubusercontent.com/litmuschaos/chaos-operator/v2.14.x/deploy/operator.yaml
   LITMUS_OPERATOR = "https://litmuschaos.github.io/litmus/litmus-operator-v#{LitmusManager::Version}.yaml"
@@ -147,6 +144,21 @@ module LitmusManager
       FileUtils.mkdir_p(chaos_manifests)
     end
     chaos_manifests
+  end
+
+  # Install a LitmusChaos fault into the CNF's namespace: the ChaosExperiment
+  # from chaos-charts at LitmusManager::Version, and the fault's service
+  # account, role and binding embedded in the binary. Returns the path of the
+  # downloaded experiment manifest.
+  def self.install_fault(fault : String, namespace : String, task_name : String) : String
+    experiment_path = download_template("#{CHAOS_CHARTS}/faults/kubernetes/#{fault}/fault.yaml", "#{task_name}_experiment.yaml")
+    KubectlClient::Apply.file(experiment_path, namespace: namespace)
+
+    rbac_path = "#{chaos_manifests_path}/#{task_name}_rbac.yaml"
+    File.write(rbac_path, LITMUS_RBAC[fault].gsub("namespace: default", "namespace: #{namespace}"))
+    KubectlClient::Apply.file(rbac_path)
+
+    experiment_path
   end
 
   def self.download_template(url, filename)

--- a/src/tasks/workload/reliability.cr
+++ b/src/tasks/workload/reliability.cr
@@ -115,16 +115,7 @@ scored_task "pod_network_latency",
       if test_passed
         Log.info { "Running for: #{spec_labels}"}
         Log.info { "Spec Hash: #{args.named["pod-labels"]?}" }
-        experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/pod-network-latency/fault.yaml"
-        rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/pod-network-latency/rbac.yaml"
-        
-        experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
-        KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
-        rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
-        rbac_yaml = File.read(rbac_path)
-        rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
-        File.write(rbac_path, rbac_yaml)
-        KubectlClient::Apply.file(rbac_path)
+        LitmusManager.install_fault("pod-network-latency", app_namespace, t.name)
 
         #TODO Use Labels to Annotate, not resource["name"]
         KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
@@ -190,15 +181,7 @@ scored_task "pod_network_corruption",
         test_passed = false
       end
       if test_passed
-        experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/pod-network-corruption/fault.yaml"
-        rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/pod-network-corruption/rbac.yaml"
-        experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
-        KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
-        rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
-        rbac_yaml = File.read(rbac_path)
-        rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
-        File.write(rbac_path, rbac_yaml)
-        KubectlClient::Apply.file(rbac_path)
+        LitmusManager.install_fault("pod-network-corruption", app_namespace, t.name)
  
         KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
 
@@ -249,17 +232,7 @@ scored_task "pod_network_duplication",
         test_passed = false
       end
       if test_passed
-        experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/pod-network-duplication/fault.yaml"
-        rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/pod-network-duplication/rbac.yaml"
-
-        experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
-        KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
-
-        rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
-        rbac_yaml = File.read(rbac_path)
-        rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
-        File.write(rbac_path, rbac_yaml)
-        KubectlClient::Apply.file(rbac_path)
+        LitmusManager.install_fault("pod-network-duplication", app_namespace, t.name)
         Log.for(t.name).debug { "annotating resource for chaos: #{resource["name"]}" }
         KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
 
@@ -307,17 +280,7 @@ scored_task "disk_fill",
         test_passed = false
       end
       if test_passed
-        experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/disk-fill/fault.yaml"
-        rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/disk-fill/rbac.yaml"
-
-        experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
-        KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
-
-        rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
-        rbac_yaml = File.read(rbac_path)
-        rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
-        File.write(rbac_path, rbac_yaml)
-        KubectlClient::Apply.file(rbac_path)
+        LitmusManager.install_fault("disk-fill", app_namespace, t.name)
 
         KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
 
@@ -394,19 +357,7 @@ scored_task "pod_delete",
       if test_passed
         Log.info { "Running for: #{spec_labels}"}
         Log.info { "Spec Hash: #{args.named["pod-labels"]?}" }
-        experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/pod-delete/fault.yaml"
-        rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/pod-delete/rbac.yaml"
-
-        experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
-
-        rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
-        rbac_yaml = File.read(rbac_path)
-        rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
-        File.write(rbac_path, rbac_yaml)
-
-
-        KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
-        KubectlClient::Apply.file(rbac_path)
+        LitmusManager.install_fault("pod-delete", app_namespace, t.name)
 
         Log.info { "resource: #{resource["name"]}" }
         KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
@@ -471,17 +422,7 @@ scored_task "pod_memory_hog",
         test_passed = false
       end
       if test_passed
-        experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/pod-memory-hog/fault.yaml"
-        rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/pod-memory-hog/rbac.yaml"
-
-        experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
-        KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
-
-        rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
-        rbac_yaml = File.read(rbac_path)
-        rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
-        File.write(rbac_path, rbac_yaml)
-        KubectlClient::Apply.file(rbac_path)
+        LitmusManager.install_fault("pod-memory-hog", app_namespace, t.name)
 
         KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
 
@@ -532,17 +473,7 @@ scored_task "pod_io_stress",
         test_passed = false
       end
       if test_passed
-        experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/pod-io-stress/fault.yaml"
-        rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/pod-io-stress/rbac.yaml"
-
-        experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
-        KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
-
-        rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
-        rbac_yaml = File.read(rbac_path)
-        rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
-        File.write(rbac_path, rbac_yaml)
-        KubectlClient::Apply.file(rbac_path)
+        LitmusManager.install_fault("pod-io-stress", app_namespace, t.name)
 
         KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
 
@@ -605,17 +536,7 @@ scored_task "pod_dns_error",
           test_passed = false
         end
         if test_passed
-          experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/pod-dns-error/fault.yaml"
-          rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/pod-dns-error/rbac.yaml"
-
-          experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
-          KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
-
-          rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
-          rbac_yaml = File.read(rbac_path)
-          rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
-          File.write(rbac_path, rbac_yaml)
-          KubectlClient::Apply.file(rbac_path)
+          LitmusManager.install_fault("pod-dns-error", app_namespace, t.name)
 
           KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
 

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -294,17 +294,7 @@ scored_task "node_drain",
           end
 
           if skip_reason.nil? && app_node_name
-            experiment_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::Version}/faults/kubernetes/node-drain/fault.yaml"
-            rbac_url = "https://raw.githubusercontent.com/litmuschaos/chaos-charts/#{LitmusManager::RBAC_VERSION}/charts/generic/node-drain/rbac.yaml"
-
-            experiment_path = LitmusManager.download_template(experiment_url, "#{t.name}_experiment.yaml")
-            KubectlClient::Apply.file(experiment_path, namespace: app_namespace)
-
-            rbac_path = LitmusManager.download_template(rbac_url, "#{t.name}_rbac.yaml")
-            rbac_yaml = File.read(rbac_path)
-            rbac_yaml = rbac_yaml.gsub("namespace: default", "namespace: #{app_namespace}")
-            File.write(rbac_path, rbac_yaml)
-            KubectlClient::Apply.file(rbac_path)
+            LitmusManager.install_fault("node-drain", app_namespace, t.name)
 
             KubectlClient::Utils.annotate(resource["kind"], resource["name"], ["litmuschaos.io/chaos=\"true\""], namespace: app_namespace)
 


### PR DESCRIPTION
## Summary
Phase 2 of the dependency refresh.

- `LitmusManager::Version` 3.6.0 → 3.31.0 (operator manifest + all nine `faults/kubernetes/*/fault.yaml`). Upstream diff between the two is image tags only.
- chaos-charts 3.x no longer ships per-fault `rbac.yaml`, which is why the suite was still fetching RBAC from the 2.6.0 tree (`RBAC_VERSION`). Litmus 3.x's documented minimal RBAC is identical to it, so the nine manifests are now embedded (`embedded_files/litmus_rbac/`) and `RBAC_VERSION` is removed — one fewer network fetch per chaos test.
- The nine duplicated download/apply blocks in `reliability.cr` / `state.cr` become `LitmusManager.install_fault(fault, namespace, task_name)`.

## Test plan
- [x] `crystal build src/cnf-testsuite.cr`
- [x] kind cluster: `setup:install_litmus` brings chaos-operator to 3.31.0; `pod_delete` on `sample-coredns-cnf` → PASSED (chaosresult verdict `Pass`), `pod-delete-sa` SA/Role/RoleBinding created in the CNF namespace with the embedded manifest
- [ ] CI `chaos` job (`pod_delete`, `disk_fill`, `pod_io_stress`, `pod_memory_hog`, `pod_network_*`, `pod_dns_error`, `node_drain`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)