### PR TITLE
Kubescape 3.0.30 -> 4.0.12 and the NSA framework regolibrary 1.0.316 -> 2.0.33

### DIFF
--- a/src/tasks/setup/constants.cr
+++ b/src/tasks/setup/constants.cr
@@ -15,28 +15,15 @@ module Setup
     {% end %}
   end
 
-  KUBESCAPE_TARGET_BINARY_NAME = begin
-    case {TARGET_OS, TARGET_ARCH}
-    when {"darwin", "arm64"}
-      "kubescape-arm64-macos-latest"
-    when {"darwin", "amd64"}
-      "kubescape-macos-latest"
-    when {"linux", "arm64"}
-      "kubescape-arm64-ubuntu-latest"
-    else
-      "kubescape-ubuntu-latest"
-    end
-  end
-
   # Versions of the tools
   # renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
   CLUSTER_API_VERSION         = "1.9.6"
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   KIND_VERSION                = "0.27.0"
   # renovate: datasource=github-releases depName=kubescape/kubescape
-  KUBESCAPE_VERSION           = "3.0.30"
+  KUBESCAPE_VERSION           = "4.0.12"
   # renovate: datasource=github-releases depName=kubescape/regolibrary
-  KUBESCAPE_FRAMEWORK_VERSION = "1.0.316"
+  KUBESCAPE_FRAMEWORK_VERSION = "2.0.33"
   # renovate: datasource=github-releases depName=helm/helm
   HELM_VERSION                = "3.19.0"
   # (rafal-lal) TODO: configure version of the gatekeeper
@@ -63,7 +50,8 @@ module Setup
 
   KUBESCAPE_DIR      = "#{tools_path}/kubescape"
   KUBESCAPE_URL      = "https://github.com/kubescape/kubescape/releases/download/" +
-                       "v#{KUBESCAPE_VERSION}/#{KUBESCAPE_TARGET_BINARY_NAME}"
+                       "v#{KUBESCAPE_VERSION}/kubescape_#{KUBESCAPE_VERSION}_#{TARGET_OS}_#{TARGET_ARCH}.tar.gz"
+  KUBESCAPE_BINARY   = "#{KUBESCAPE_DIR}/kubescape"
   KUBESCAPE_FRAMEWORK_URL = "https://github.com/kubescape/regolibrary/releases/download/" +
                              "v#{KUBESCAPE_FRAMEWORK_VERSION}/nsa"
 

--- a/src/tasks/setup/kubescape_setup.cr
+++ b/src/tasks/setup/kubescape_setup.cr
@@ -12,27 +12,28 @@ namespace "setup" do
     FileUtils.mkdir_p(Setup::KUBESCAPE_DIR)
     version_file = "#{Setup::KUBESCAPE_DIR}/.kubescape_version"
     installed_kubescape_version = File.read(version_file) if File.exists?(version_file)
-    if File.exists?("#{Setup::KUBESCAPE_DIR}/kubescape") && installed_kubescape_version == Setup::KUBESCAPE_VERSION
+    if File.exists?(Setup::KUBESCAPE_BINARY) && installed_kubescape_version == Setup::KUBESCAPE_VERSION
       logger.info { "Kubescape tool already exists and has the required version" }
       next
     end
 
-    kubescape_binary = "#{Setup::KUBESCAPE_DIR}/kubescape"
+    tarball = "#{Setup::KUBESCAPE_DIR}/kubescape.tar.gz"
     begin
-      download_file(Setup::KUBESCAPE_URL, kubescape_binary)
+      download_file(Setup::KUBESCAPE_URL, tarball)
     rescue ex : Exception
       logger.error { "Error while downloading kubescape tool: #{ex.message}" }
       stdout_failure(failed_msg)
       exit(1)
     end
-    logger.debug { "Downloaded Kubescape binary" }
-    File.write(version_file, Setup::KUBESCAPE_VERSION)
+    logger.debug { "Downloaded Kubescape tarball" }
 
-    unless ShellCmd.run("chmod +x #{kubescape_binary}")[:status].success?
-      logger.error { "Error while making kubescape binary: '#{kubescape_binary}' executable" }
+    unless TarClient.untar(tarball, Setup::KUBESCAPE_DIR)[:status].success?
+      logger.error { "Error while extracting kubescape tarball: '#{tarball}'" }
       stdout_failure(failed_msg)
       exit(1)
     end
+    File.delete(tarball)
+    File.write(version_file, Setup::KUBESCAPE_VERSION)
 
     logger.info { "Kubescape tool has been installed" }
   end

--- a/src/tasks/utils/kubescape.cr
+++ b/src/tasks/utils/kubescape.cr
@@ -20,7 +20,7 @@ module Kubescape
     elsif cli == nil
       cli = "framework nsa --use-from #{tools_path}/kubescape/nsa.json --output #{output_file} #{default_options} #{namespace_option}"
     end
-    cmd = "#{tools_path}/kubescape/kubescape scan #{cli}"
+    cmd = "#{Setup::KUBESCAPE_BINARY} scan #{cli}"
     Log.info { "scan command: #{cmd}" }
     status = Process.run(
       cmd,

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -265,9 +265,10 @@ scored_task "service_account_mapping",
     results_json = Kubescape.parse
     test_json = Kubescape.test_by_test_name(results_json, "Automatic mapping of service account")
     test_report = Kubescape.parse_test_report(test_json)
-    resource_keys = CNFManager.resource_refs(args, config, ["serviceAccount"]) do |serviceAccount|
-      "#{serviceAccount[:namespace]},#{serviceAccount[:kind]}/#{serviceAccount[:name]}".downcase
-    end.compact   
+    # Kubescape reports the workloads that will actually mount a token (a
+    # pod-level automountServiceAccountToken overrides the service account's),
+    # so match on the CNF's workloads, not its ServiceAccount objects.
+    resource_keys = CNFManager.workload_resource_keys(args, config)
     test_report = Kubescape.filter_cnf_resources(test_report, resource_keys)
 
     if test_report.failed_resources.size == 0


### PR DESCRIPTION
## Summary
Phase 4 of the dependency refresh.

- `KUBESCAPE_VERSION` 3.0.30 → 4.0.12, `KUBESCAPE_FRAMEWORK_VERSION` 1.0.316 → 2.0.33.
- v4 release assets are `kubescape_<ver>_<os>_<arch>.tar.gz` (the raw binary is 267 MB vs a 109 MB tarball), so `install_kubescape` downloads and untars instead of download + chmod. `KUBESCAPE_TARGET_BINARY_NAME` is gone; `KUBESCAPE_BINARY` is the single path used by setup and `Kubescape.scan`.
- No parser changes needed: `--format-version=v1` still produces the `controlReports/ruleReports/ruleResponses/alertObject.k8sApiObjects` structure (v4 logs it as deprecated; migrating to v2 is a follow-up). All 16 NSA control names the tests match on are unchanged in regolibrary 2.0.33; C-0048 (HostPath mount) is still scanned by ID.
- **One rule changed what it reports**: C-0034 (`service_account_mapping`) now alerts on the *workloads* that will mount a token (pod-level `automountServiceAccountToken` overrides the SA's) instead of on `ServiceAccount` objects. The test filtered findings to the CNF's ServiceAccounts, so it could never fail under the new rule (caught by the `security` CI shard). It now filters on the CNF's workloads like every other kubescape-backed test.

## Test plan
- [x] `crystal build src/cnf-testsuite.cr`
- [x] kind cluster, kubescape 4.0.12 + regolibrary 2.0.33: `setup:kubescape_scan` and all 14 workload tests (`privilege_escalation` … `hostpath_mounts`) plus `platform:control_plane_hardening`, `platform:cluster_admin`, `platform:verify_secrets_encryption` yield verdicts with no errors
- [x] Spec fixtures behave as specs expect: `sample-nonroot-containers`/`sample-privilege-escalation` (privilege_escalation pass/fail), `sample-nonroot`/`sample-coredns-cnf` (non_root_containers pass/fail), `sample-immutable-fs`/`sample-coredns-cnf` (immutable_file_systems pass/fail), coredns fails `linux_hardening` and `ingress_egress_blocked` as specced
- [x] `service_account_mapping`: `sample-service-accounts` FAILS naming `Pod/nginx` (exit 1); in `sample_multiple_deployments` only the deployment without `automountServiceAccountToken: false` is flagged
- [x] Cross-checked one suspicious result against kubescape 3.0.30 + regolibrary 1.0.316 offline: identical verdict (not a v4 regression)
- [ ] CI shards: `security`, `privileges`, `capabilities`, `platform_security`, and the other kubescape-backed tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)