### PR TITLE
Install helm 4.2.4 when no helm is found

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ This will detail the required minimum requirements needed in order to support cn
 * **containerd runtime** - for K8s cluster running the CNF to be tested
 * **kubectl** *(run commands against K8s clusters, see [installing kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) for more details.)*
 * **curl**
-* **helm 3.8.2* *or newer* *(cnf-testsuite installs if not found locally)*
+* **helm 3.8.2** *or newer* (helm 4 supported; cnf-testsuite installs helm 4 if not found locally)
 * **docker**  *(needed for the cni_compatibility test)*
 
 #### Requirements for source installation

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To get the CNTi Test Suite up and running, see the [Installation Guide](INSTALL.
 
 #### To give it a try immediately you can use these quick install steps
 
-Prereqs: Kubernetes cluster, wget, curl, helm 3.1.1 or greater on your system already.
+Prereqs: Kubernetes cluster, wget, curl, helm 3.8.2 or greater (helm 4 supported) on your system already.
 
 1. Install the latest test suite binary: `source <(curl -s https://raw.githubusercontent.com/lfn-cnti/testsuite/main/curl_install.sh)`
 2. Run `setup` to prepare the cnf-testsuite: `cnf-testsuite setup`

--- a/SOURCE_INSTALL.md
+++ b/SOURCE_INSTALL.md
@@ -19,7 +19,7 @@ This INSTALL guide will detail the minimum requirements needed for cnf-testsuite
 - **kubernetes multi-node cluster** _(Working k8s cluster, see [supported k8s and installation details](#Details-on-supported-k8s-clusters-and-installation) on installation._
 - **kubectl** _(run commands against k8s clusters, see [installing kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) for more details._
 - **curl**
-- **helm 3.8.2** _or newer_ _(cnf-testsuite installs if not found locally)_
+- **helm 3.8.2** _or newer_ (helm 4 supported; cnf-testsuite installs helm 4 if not found locally)
 - **git** _(used to check out code from github)_
 - **crystal-lang** version >=1.6.0 _(to compile the source and build the binary, see [crystal installation](https://crystal-lang.org/install/)) for more information._
 - **shards** ([dependency manager](https://github.com/crystal-lang/shards) for crystal-lang)
@@ -68,7 +68,7 @@ cd tools/ && git clone https://github.com/crosscloudci/k8s-infra.git
 
 We can assume you have access to a working kubernetes cluster. We recommend only running the cnf-testsuite on dev or test clusters. The source install steps have been verified on most Linux distributions (Ubuntu, Debian and CentOS), Mac OS X and WSL as long as crystal-lang >=v1.6.0 is installed.
 
-_NOTE: Currently Mac OS X users will need to ensure helm 3.1.1 or greater is installed locally._
+_NOTE: Currently Mac OS X users will need to ensure helm 3.8.2 or greater is installed locally._
 
 - Verify your KUBECONFIG points to your correct k8s cluster:
   ```
@@ -83,7 +83,7 @@ _NOTE: Currently Mac OS X users will need to ensure helm 3.1.1 or greater is ins
   kubectl cluster-info
   ```
 - You'll need crystal-lang >=v1.6.0 installed with [shards](https://github.com/crystal-lang/shards). You can follow their [install instructions](https://crystal-lang.org/install/) for their different install methods.
-- cnf-testsuite needs helm-3.1.1 or greater but is optional as the prerequisite checks will install if not found. You can install helm by checking their [installation methods](https://helm.sh/docs/helm/helm_install/).
+- cnf-testsuite needs helm 3.8.2 or greater (helm 4 supported) but it is optional as the prerequisite checks will install if not found. You can install helm by checking their [installation methods](https://helm.sh/docs/helm/helm_install/).
 - Checkout the source code with git:
   ```
   git clone git@github.com:lfn-cnti/testsuite.git

--- a/src/tasks/setup/constants.cr
+++ b/src/tasks/setup/constants.cr
@@ -25,7 +25,7 @@ module Setup
   # renovate: datasource=github-releases depName=kubescape/regolibrary
   KUBESCAPE_FRAMEWORK_VERSION = "2.0.33"
   # renovate: datasource=github-releases depName=helm/helm
-  HELM_VERSION                = "3.21.4"
+  HELM_VERSION                = "4.2.4"
   # renovate: datasource=helm depName=gatekeeper registryUrl=https://open-policy-agent.github.io/gatekeeper/charts
   GATEKEEPER_VERSION          = "3.23.0"
 


### PR DESCRIPTION
## Summary
Phase 6.1 of the dependency refresh.

- `HELM_VERSION` 3.19.0 → 4.2.4 for the helm the suite downloads when the system has none. Tarball layout (`linux-amd64/helm`) is unchanged.
- The helm module only uses `install/uninstall/template/pull/push/package/registry login/repo add/get manifest`, none of which changed in helm 4, and the Debian/arm64 CI jobs already run the full `cert` flow on helm 4 (`get-helm-4`).
- Docs unified: `INSTALL.md`, `SOURCE_INSTALL.md`, `README.md` now all say helm 3.8.2 or newer, helm 4 supported (README still said 3.1.1).

## Test plan
- [x] `crystal build src/cnf-testsuite.cr`
- [x] kind cluster, `force_install=1 setup:install_local_helm` → local helm 4.2.4 is preferred over the system's 3.20.0 (`setup` reports both)
- [x] With helm 4.2.4: `cnf_install` of `sample-coredns-cnf` (repo chart) and `sample_coredns_chart_directory` (helm dir); `helm_chart_valid`, `helm_chart_published`, `helm_deploy`, `increase_decrease_capacity` PASS; `cnf_uninstall` clean
- [x] `helm pull oci://registry-1.docker.io/bitnamicharts/nginx --version 15.10.0` + `helm template` of the result with 4.2.4 (the `sample_oci_repo` fixture itself needs the spec-managed local registry)
- [ ] CI: spec matrix (uses the runner's global helm), `debian`/`arm64` (helm 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)