### PR TITLE
Let Renovate watch every pinned tool, chart and image

### DIFF
--- a/.github/actions/install-kind/action.yml
+++ b/.github/actions/install-kind/action.yml
@@ -4,6 +4,7 @@ inputs:
   version:
     description: "kind version to install"
     required: false
+    # renovate: datasource=github-releases depName=kubernetes-sigs/kind
     default: "v0.31.0"
 runs:
   using: "composite"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -415,6 +415,7 @@ jobs:
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
+        # renovate: datasource=github-releases depName=crystal-lang/crystal
         crystal: 1.6.2
     - name: Setup CNF-Conformance
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,27 @@ For general advice on how to submit a pull request, please see [Creating a pull 
 7. (optional) Accept the original pull request if the review and tests pass.
 8. (optional -- changes required) Create a new PR, make changes, and merge into main (Github will automatically merge the original PR since it's changes will be included in the new PR)
 
+## Dependency updates
+
+[Renovate](https://docs.renovatebot.com/) watches the tools and images the suite pins and opens a
+pull request when a newer version exists, on a weekly schedule (`renovate.json`). It finds a pin by
+the comment on the line above it:
+
+```crystal
+# renovate: datasource=github-releases depName=kubescape/kubescape
+KUBESCAPE_VERSION = "3.0.30"
+```
+
+When you add or move a pinned version, image or chart, keep (or add) that comment so the pin stays
+watched. The datasources in use are `github-releases`, `github-tags`, `helm` (with `registryUrl=`)
+and `docker`; the version, or the `tag` and `digest` of an image, must sit on the next line.
+
+What happens to an update depends on what it can break, see `packageRules` in `renovate.json`:
+low-risk tool pins and CI images merge on their own once the spec matrix is green; tools whose rules
+decide test verdicts (kubescape, kyverno, LitmusChaos, gatekeeper) get one PR each and a human
+review, because a red CI run there usually means a rule changed meaning rather than a bug; majors
+wait on the dependency dashboard issue until someone approves them.
+
 ## Community Meeting:
 
 The CNTI community meets weekly on Tuesdays at 8:00 - 9:00 AM Pacific Time

--- a/embedded_files/fluentbit-values.yml
+++ b/embedded_files/fluentbit-values.yml
@@ -1,3 +1,4 @@
+# renovate: datasource=docker depName=cr.fluentbit.io/fluent/fluent-bit
 image:
   repository: cr.fluentbit.io/fluent/fluent-bit
   tag: latest

--- a/embedded_files/fluentd-values.yml
+++ b/embedded_files/fluentd-values.yml
@@ -1,3 +1,4 @@
+# renovate: datasource=docker depName=fluent/fluentd-kubernetes-daemonset
 image:
   repository: fluent/fluentd-kubernetes-daemonset
   tag: v1.19.1-debian-elasticsearch8-1.0

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommitsDisabled"],
+  "timezone": "Etc/UTC",
+  "schedule": ["before 6am on monday"],
+  "prConcurrentLimit": 10,
+  "rangeStrategy": "pin",
+  "separateMajorMinor": true,
+  "separateMultipleMinor": true,
+  "labels": ["dependencies"],
+  "commitMessagePrefix": "",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Version constant on the line after a '# renovate:' annotation (Crystal, YAML, action.yml, Dockerfile ARG)",
+      "fileMatch": ["\\.cr$", "\\.ya?ml$", "\\.ecr$", "(^|/)Dockerfile$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+?)(?: registryUrl=(?<registryUrl>[^\\s]+))?(?: versioning=(?<versioning>[^\\s]+))?\\n[^\\S\\n]*(?:ARG )?[A-Za-z0-9_]+:?\\s*=?\\s*\"?v?(?<currentValue>\\d+\\.\\d+\\.\\d+(?:[-+.][\\w.]+)?)\"?"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Container image with tag and digest in a Crystal string, or a YAML image: line, after a '# renovate:' annotation",
+      "fileMatch": ["\\.cr$", "\\.ecr$"],
+      "matchStrings": [
+        "# renovate: datasource=docker depName=(?<depName>[^\\s]+)\\n[^\\S\\n]*(?:image: |\")(?:[^\\s\"@:]+/)?[^\\s\"@:]+:(?<currentValue>[^\\s\"@]+)(?:@(?<currentDigest>sha256:[a-f0-9]{64}))?\"?"
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Helm values image block (repository/tag/digest) after a '# renovate:' annotation",
+      "fileMatch": ["^embedded_files/.*-values\\.ya?ml$"],
+      "matchStrings": [
+        "# renovate: datasource=docker depName=(?<depName>[^\\s]+)\\nimage:\\n\\s+repository: [^\\n]+\\n\\s+tag: (?<currentValue>[^\\s]+)(?:\\n\\s+digest: (?<currentDigest>sha256:[a-f0-9]{64}))?"
+      ],
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": ".crystal-version holds the bare Crystal version",
+      "fileMatch": ["^\\.crystal-version$"],
+      "matchStrings": ["^(?<currentValue>\\d+\\.\\d+\\.\\d+)\\s*$"],
+      "depNameTemplate": "crystal-lang/crystal",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Low risk, proven by the CI matrix: automerge once green",
+      "matchDepNames": [
+        "kubernetes-sigs/kind", "helm/helm", "vmware-tanzu/sonobuoy", "kubernetes-sigs/cluster-api",
+        "lfncnti/cluster-tools", "fluent/fluent-bit", "cr.fluentbit.io/fluent/fluent-bit", "fluent/fluentd-kubernetes-daemonset"
+      ],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "groupName": "tool pins",
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "description": "GitHub Actions and runner/CI images: automerge once green",
+      "matchManagers": ["github-actions", "dockerfile"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin", "pinDigest"],
+      "groupName": "ci",
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "description": "Tools whose rules decide test verdicts: one PR each, human review, never automerge",
+      "matchDepNames": ["kubescape/kubescape", "kubescape/regolibrary", "kyverno/kyverno", "litmuschaos/chaos-charts", "gatekeeper"],
+      "labels": ["dependencies", "needs-review"],
+      "automerge": false
+    },
+    {
+      "description": "Kubescape binary and its rule library move together",
+      "matchDepNames": ["kubescape/kubescape", "kubescape/regolibrary"],
+      "groupName": "kubescape"
+    },
+    {
+      "description": "Crystal toolchain: one PR for every place the version is pinned",
+      "matchDepNames": ["crystal-lang/crystal"],
+      "groupName": "crystal",
+      "automerge": false
+    },
+    {
+      "description": "Majors wait on the dependency dashboard until someone approves them",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "automerge": false
+    }
+  ]
+}

--- a/src/modules/cluster_tools/templates/manifest.yml.ecr
+++ b/src/modules/cluster_tools/templates/manifest.yml.ecr
@@ -16,6 +16,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: cluster-tools
+          # renovate: datasource=docker depName=lfncnti/cluster-tools
           image: lfncnti/cluster-tools:v1.0.8
           imagePullPolicy: Always
           command:

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -12,6 +12,7 @@ DEPLOYMENT_MANIFEST_FILE_NAME = "deployment_manifest.yml"
 # todo move to helm module
 # CHART_YAML = "Chart.yaml"
 DEFAULT_POINTSFILENAME = "points_v1.yml"
+# renovate: datasource=github-releases depName=vmware-tanzu/sonobuoy
 SONOBUOY_K8S_VERSION = "0.56.14"
 IGNORED_SECRET_TYPES = ["kubernetes.io/service-account-token", "kubernetes.io/dockercfg", "kubernetes.io/dockerconfigjson", "helm.sh/release.v1"]
 EMPTY_JSON = JSON.parse(%({}))

--- a/src/tasks/setup/constants.cr
+++ b/src/tasks/setup/constants.cr
@@ -29,12 +29,18 @@ module Setup
   end
 
   # Versions of the tools
+  # renovate: datasource=github-releases depName=kubernetes-sigs/cluster-api
   CLUSTER_API_VERSION         = "1.9.6"
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   KIND_VERSION                = "0.27.0"
+  # renovate: datasource=github-releases depName=kubescape/kubescape
   KUBESCAPE_VERSION           = "3.0.30"
+  # renovate: datasource=github-releases depName=kubescape/regolibrary
   KUBESCAPE_FRAMEWORK_VERSION = "1.0.316"
+  # renovate: datasource=github-releases depName=helm/helm
   HELM_VERSION                = "3.19.0"
   # (rafal-lal) TODO: configure version of the gatekeeper
+  # renovate: datasource=helm depName=gatekeeper registryUrl=https://open-policy-agent.github.io/gatekeeper/charts
   GATEKEEPER_VERSION          = "TODO: USE THIS"
 
   # Useful consts grouped by tools

--- a/src/tasks/utils/fluent_manager.cr
+++ b/src/tasks/utils/fluent_manager.cr
@@ -53,6 +53,7 @@ module FluentManager
             "https://fluent.github.io/helm-charts",
             "fluentd-values.yml",
             FLUENTD_VALUES,
+            # renovate: datasource=docker depName=fluent/fluentd-kubernetes-daemonset
             "fluent/fluentd-kubernetes-daemonset:v1.19.1-debian-elasticsearch8-1.0@sha256:4bad75452717d2de0e3c4857339d8e91f11b2712fa9319302a401d9c86388c90",
             "fluentd/fluentd")
     end
@@ -75,6 +76,7 @@ module FluentManager
             "https://fluent.github.io/helm-charts",
             "fluentbit-values.yml",
             FLUENTBIT_VALUES,
+            # renovate: datasource=docker depName=fluent/fluent-bit
             "fluent/fluent-bit:latest@sha256:7d727245767ae632eb296c2ff4d206bf2e205b5f244c1f37b8fdd61f9fb33985",
             "fluent-bit/fluent-bit")
     end

--- a/src/tasks/utils/kyverno.cr
+++ b/src/tasks/utils/kyverno.cr
@@ -1,6 +1,7 @@
 require "http/client"
 
 module Kyverno
+  # renovate: datasource=github-releases depName=kyverno/kyverno
   VERSION = "1.8.4"
 
   def self.binary_path

--- a/src/tasks/utils/litmus_manager.cr
+++ b/src/tasks/utils/litmus_manager.cr
@@ -1,6 +1,8 @@
 module LitmusManager
 
+  # renovate: datasource=github-tags depName=litmuschaos/chaos-charts
   Version = "3.6.0"
+  # renovate: datasource=github-tags depName=litmuschaos/chaos-charts
   RBAC_VERSION = "2.6.0"
   # Version = "1.13.8"
   # Version = "3.0.0-beta12"

--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -1,5 +1,6 @@
 FROM myoung34/github-runner:2.313.0-ubuntu-bionic
 
+# renovate: datasource=github-releases depName=crystal-lang/crystal
 ARG CRYSTAL_VERSION=1.6.2
 ARG CRYSTAL_URL=https://github.com/crystal-lang/crystal/releases/download
 


### PR DESCRIPTION
## Summary
Follow-up to the dependency refresh: keep it refreshed.

- **`renovate.json`** with custom regex managers for the places stock bots don't understand: Crystal `NAME = "x.y.z"` constants, `image:` lines in the ECR manifest, `repo:tag@sha256` strings in `fluent_manager.cr`, `image.tag`/`image.digest` blocks in `embedded_files/*-values.yml`, `.crystal-version`, and Dockerfile `ARG`s. Stock `github-actions` and `dockerfile` managers cover `uses:` and `FROM`.
- **`# renovate: datasource=… depName=…` annotations** above every pin (17 sites). A local simulation of the managers matches all of them (+ `.crystal-version`); `GATEKEEPER_VERSION` matches once #2464 replaces its `TODO` placeholder.
- **Policy** (`packageRules`), weekly on Monday:
  | class | behaviour |
  |---|---|
  | kind, helm, sonobuoy, clusterctl, cluster-tools/fluent images, GitHub Actions, runner base image | grouped, **automerge once the CI matrix is green** |
  | kubescape+regolibrary (grouped), kyverno, LitmusChaos, gatekeeper | one PR each, `needs-review`, never automerge |
  | Crystal | one grouped PR for every pinned place, review |
  | majors | held on the dependency dashboard until approved |
  `rangeStrategy: pin`, `separateMultipleMinor` so a 1.8 → 1.19 jump arrives in steps.
- `CONTRIBUTING.md`: the annotation convention and the policy, so new pins stay watched.

## Enabling
Renovate isn't active until an org admin installs the [Renovate GitHub App](https://github.com/apps/renovate) on `lfn-cnti/testsuite`. Its first run opens a "Dependency Dashboard" issue listing everything it detected — that's the moment to confirm all pins were found. Automerge requires the CI matrix to be a required check (or Renovate's `automergeType: branch` will merge when the branch's checks are green, which is what's configured).

## Notes
- Based on `main`; the open refresh PRs (#2464–#2471) touch the same lines, so whichever merges second gets a one-line conflict per pin (comment line added above). Trivial to resolve.
- `renovate-config-validator` (run in `node:22`) reports the config valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)