### PR TITLE
CI: fail on HTTP errors and retry transient ones in every raw curl

### DIFF
--- a/.github/actions/install-kind/action.yml
+++ b/.github/actions/install-kind/action.yml
@@ -20,7 +20,7 @@ runs:
         esac
         url="https://kind.sigs.k8s.io/dl/${{ inputs.version }}/kind-linux-${arch}"
         if command -v curl >/dev/null 2>&1; then
-          curl -fsSLo ./kind "$url"
+          curl -fsSLo ./kind --retry 3 --retry-delay 2 "$url"
         else
           wget -qO ./kind "$url"
         fi

--- a/.github/workflows/arm64.yml
+++ b/.github/workflows/arm64.yml
@@ -46,9 +46,9 @@ jobs:
         with:
           crystal: 1.19.1
       - run: |
-          curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
+          curl -fsSLO --retry 3 --retry-delay 2 "https://dl.k8s.io/release/$(curl -fsSL --retry 3 --retry-delay 2 https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl"
           sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
-          curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash
+          curl -fsSL --retry 3 --retry-delay 2 -o get-helm-4.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 && bash get-helm-4.sh
       - run: |
           shards install
           crystal build src/cnf-testsuite.cr
@@ -95,16 +95,16 @@ jobs:
           kind create cluster --name qemu-arm64 --config=/tmp/cluster.yml
           rm /tmp/cluster.yml
       - run: |
-            sudo apt update && sudo DEBIAN_FRONTEND=noninteractive apt install qemu-user-static -y
+            sudo apt -o Acquire::Retries=3 update && sudo DEBIAN_FRONTEND=noninteractive apt -o Acquire::Retries=3 install qemu-user-static -y
             DOCKER_DEFAULT_PLATFORM=linux/arm64 docker run --network host --name debian-arm64 \
               -v $(pwd):/testsuite -v ~/.kube/config:/root/.kube/config debian:latest /bin/bash -c "\
-            apt update && DEBIAN_FRONTEND=noninteractive apt install git curl gcc pkg-config libpcre2-dev libxml2-dev libyaml-dev zlib1g-dev libssl-dev -y && \
-            curl -LO https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-1-linux-aarch64.tar.gz && \
+            apt -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt -o Acquire::Retries=3 install git curl gcc pkg-config libpcre2-dev libxml2-dev libyaml-dev zlib1g-dev libssl-dev -y && \
+            curl -fsSLO --retry 3 --retry-delay 2 https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-1-linux-aarch64.tar.gz && \
             tar zxf crystal-1.19.1-1-linux-aarch64.tar.gz && \
             export PATH=/crystal-1.19.1-1/bin:$PATH && \
-            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl" && \
+            curl -fsSLO --retry 3 --retry-delay 2 "https://dl.k8s.io/release/$(curl -fsSL --retry 3 --retry-delay 2 https://dl.k8s.io/release/stable.txt)/bin/linux/arm64/kubectl" && \
             install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-            curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash && \
+            curl -fsSL --retry 3 --retry-delay 2 -o get-helm-4.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 && bash get-helm-4.sh && \
             git config --global --add safe.directory /testsuite && \
             (cd testsuite && shards install && crystal build src/cnf-testsuite.cr && \
             ./cnf-testsuite setup && ./cnf-testsuite cnf_install cnf-config=example-cnfs/coredns && ./cnf-testsuite cert && ./cnf-testsuite uninstall_all)"

--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -13,6 +13,8 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     strategy:
+      # one release's transient failure must not cancel the other four
+      fail-fast: false
       matrix:
         release:
           - bullseye
@@ -54,27 +56,27 @@ jobs:
             docker run --network host --name debian-${{ matrix.release }} \
               -v ~/.docker/config.json:/root/.docker/config.json -v $(pwd):/testsuite \
               -v ~/.kube/config:/root/.kube/config debian:${{ matrix.release }} /bin/bash -c "\
-            apt update && DEBIAN_FRONTEND=noninteractive apt install git curl \
+            apt -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt -o Acquire::Retries=3 install git curl \
               gcc pkg-config libpcre2-dev libxml2-dev libyaml-dev zlib1g-dev libssl-dev -y && \
             case ${{ matrix.release }} in \
             bullseye) \
-              curl -LO https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-1-linux-x86_64.tar.gz && \
+              curl -fsSLO --retry 3 --retry-delay 2 https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-1-linux-x86_64.tar.gz && \
               tar zxf crystal-1.19.1-1-linux-x86_64.tar.gz && \
               export PATH=/crystal-1.19.1-1/bin:$PATH && \
               rm -rf crystal-1.19.1-1-linux-x86_64.tar.gz ;; \
             bookworm | forky) \
-              DEBIAN_FRONTEND=noninteractive apt install crystal -y && \
-              curl -LO https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-1-linux-x86_64.tar.gz && \
+              DEBIAN_FRONTEND=noninteractive apt -o Acquire::Retries=3 install crystal -y && \
+              curl -fsSLO --retry 3 --retry-delay 2 https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-1-linux-x86_64.tar.gz && \
               tar zxf crystal-1.19.1-1-linux-x86_64.tar.gz && \
               mv crystal-1.19.1-1/bin/shards /usr/local/bin && \
               rm -rf crystal-1.19.1-1 crystal-1.19.1-1-linux-x86_64.tar.gz ;; \
             *) \
-                DEBIAN_FRONTEND=noninteractive apt install crystal shards -y ;; \
+                DEBIAN_FRONTEND=noninteractive apt -o Acquire::Retries=3 install crystal shards -y ;; \
             esac && \
-            curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+            curl -fsSLO --retry 3 --retry-delay 2 "https://dl.k8s.io/release/$(curl -fsSL --retry 3 --retry-delay 2 https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
             install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-            curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash && \
-            git config --global --add safe.directory /testsuite
+            curl -fsSL --retry 3 --retry-delay 2 -o get-helm-4.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 && bash get-helm-4.sh && \
+            git config --global --add safe.directory /testsuite && \
             (cd testsuite && shards install && crystal build src/cnf-testsuite.cr && \
             ./cnf-testsuite setup && ./cnf-testsuite cnf_install cnf-config=example-cnfs/coredns && ./cnf-testsuite cert && ./cnf-testsuite uninstall_all)"
       - run: |


### PR DESCRIPTION
The `debian`/`arm64` workflows fetch the Crystal tarball, kubectl, and the helm install script with bare `curl -LO` — no `-f`, no `--retry`. Yesterday that cost a red **main**: GitHub's release CDN answered a **54 KB error page** instead of the ~50 MB Crystal tarball, curl saved it happily, `tar` failed on "not in gzip format", and the job died two commands later with the misleading `shards: command not found` ([run 32955880246](https://github.com/lfn-cnti/testsuite/actions/runs/32955880246), `debian (forky)` — the identical leg passed six minutes earlier).

#2456 gave the *suite's* fetches transient-aware retries; these raw workflow curls are the same class one layer up.

## What changes

Every raw curl (9 call sites: `debian.yml` ×4, `arm64.yml` ×5 incl. the nested `stable.txt` lookups) now runs with:

```
curl -fsSL(-O) --retry 3 --retry-delay 2
```

- `-f`: an HTTP error fails the step **at the curl**, with an honest message — never blessing an error page as an artifact
- `--retry`: retries what curl classifies as transient (408/429/5xx, timeouts) — a hard 404 still fails immediately (verified: exit 22 in 0.3s, no retry), so genuine errors aren't slowed down

**`curl | bash` → download-then-execute** for the helm installs: with a pipe, a failed curl feeds bash an empty script, which exits 0 and lets the chain continue as if helm had installed — the same silent-blessing bug in a different costume.

The `install-kind` action already had `-fsSL` and gains the retry for consistency.

## Verification

- YAML parse on all three files
- Flag-combo smoke tests: real fetch works; 404 → exit 22 in 0.3s with no retry; tarball URL answers 200 with the full content-length
- The workflows themselves run on this PR (`debian`/`arm64` trigger on `pull_request`), which is the real test
**Amended after the bullseye failure on [run 32972360467](https://github.com/lfn-cnti/testsuite/actions/runs/32972360467):** a Debian mirror reset mid-`apt install` — a different transient, same misleading `shards: command not found` symptom. Three additions:

- `-o Acquire::Retries=3` on every `apt` call in both workflows
- debian.yml's `&&` chain ended at `git config … safe.directory`, so the final `(cd testsuite && shards install …)` group ran after *any* setup failure and masked the real cause with exit 127; the chain now covers the whole script, as arm64.yml's already did
- `fail-fast: false` on the debian matrix — one release's transient failure no longer cancels the other four

🤖 Generated with [Claude Code](https://claude.com/claude-code)