### PR TITLE
zombie_handled: never pass vacuously

### DIFF
--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -445,6 +445,7 @@ Make the PID 1 container process to handle SIGTERM; enable process namespace sha
 #### Overview
 
 This tests if the PID 1 process of containers handles/reaps zombie processes.
+The test injects a probe into every container that creates an orphaned child process; the test is skipped when the probe cannot be injected (for example into a read-only root filesystem).
 Expectation: Zombie processes are handled/reaped by PID 1 process of containers.
 
 #### Rationale

--- a/sample-cnfs/sample-zombie-non-injectable/README.md
+++ b/sample-cnfs/sample-zombie-non-injectable/README.md
@@ -1,0 +1,5 @@
+# sample-zombie-non-injectable
+
+A CNF whose container has `readOnlyRootFilesystem: true`, so the `zombie_handled`
+probe binaries cannot be copied into it. Used to verify that a failed probe
+injection is reported as `skipped` instead of a vacuous `passed` (issue #2474).

--- a/sample-cnfs/sample-zombie-non-injectable/cnf-testsuite.yml
+++ b/sample-cnfs/sample-zombie-non-injectable/cnf-testsuite.yml
@@ -1,0 +1,6 @@
+---
+config_version: v2
+deployments:
+  manifests:
+  - name: zombie-non-injectable
+    manifest_directory: manifests

--- a/sample-cnfs/sample-zombie-non-injectable/manifests/manifest.yml
+++ b/sample-cnfs/sample-zombie-non-injectable/manifests/manifest.yml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: zombie-non-injectable
+  name: zombie-non-injectable
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zombie-non-injectable
+  template:
+    metadata:
+      labels:
+        app: zombie-non-injectable
+    spec:
+      containers:
+      - image: busybox:1.36
+        command: ["/bin/sleep", "infinity"]
+        name: zombie-non-injectable
+        securityContext:
+          # A read-only root filesystem makes `nerdctl cp` unable to place the
+          # zombie probe into the container, which must surface as a skipped
+          # test, never as a pass (see issue #2474).
+          readOnlyRootFilesystem: true
+        resources: {}

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -356,6 +356,20 @@ describe "Microservice" do
     end
   end
 
+  it "'zombie_handled' should be skipped if the zombie probe cannot be injected", tags: ["zombie"] do
+    begin
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample-zombie-non-injectable/")
+      result = ShellCmd.run_testsuite("zombie_handled")
+      # a skipped test does not fail the run
+      result[:status].success?.should be_true
+      (/(SKIPPED).*(Zombie reaping not checked)/ =~ result[:output]).should_not be_nil
+      verify_task_result("zombie_handled", "skipped")
+    ensure
+      result = ShellCmd.cnf_uninstall()
+      result[:status].success?.should be_true
+    end
+  end
+
   after_all do
     result = ShellCmd.run_testsuite("uninstall_all")
   end

--- a/src/modules/cluster_tools/cluster_tools.cr
+++ b/src/modules/cluster_tools/cluster_tools.cr
@@ -133,8 +133,28 @@ module ClusterTools
     Log.info {"node_pid_by_container_id pid: #{pid}" }
     pid 
   end
+  # Zombies are invisible to cgroup-based enumeration on cgroup v1 nodes
+  # (the kernel detaches exiting tasks from every v1 hierarchy), so they are
+  # collected by state and matched to the container through their PPid: an
+  # orphaned child is reparented to the container's init, so every zombie
+  # belonging to the container has a parent among the container's pids.
+  # On cgroup v2 nodes zombies are already in container_pids; the subtraction
+  # keeps the result free of duplicates.
+  def self.container_zombie_pids(container_pids : Array(String), node) : Array(String)
+    zombie_pids = KernelIntrospection::K8s::Node.zombie_pids(node) - container_pids
+    return zombie_pids if zombie_pids.empty?
+
+    zombie_statuses = KernelIntrospection::K8s::Node.all_statuses_by_pids(zombie_pids, node)
+    zombie_statuses.compact_map do |status|
+      parsed = KernelIntrospection.parse_status(status)
+      next unless parsed
+      next unless container_pids.includes?(parsed["PPid"]?.try(&.strip))
+      parsed["Pid"]?.try(&.strip)
+    end
+  end
+
   #each_container_by_resource(resource, namespace) do | container_id, container_pid_on_node, node, container_proctree_statuses, container_status|
-  def self.all_containers_by_resource?(resource, namespace, only_container_pids : Bool = false, include_proctree : Bool = true, &block) 
+  def self.all_containers_by_resource?(resource, namespace, only_container_pids : Bool = false, include_proctree : Bool = true, include_zombies : Bool = false, &block) 
 		kind = resource["kind"].downcase
 		case kind
 		when  "deployment","statefulset","pod","replicaset", "daemonset"
@@ -184,6 +204,9 @@ module ClusterTools
             if include_proctree
               if only_container_pids 
                 pids = KernelIntrospection::K8s::Node.pids_by_container(container_id, node)
+                if include_zombies
+                  pids = pids + container_zombie_pids(pids + [container_pid_on_node], node)
+                end
               else
                 pids = KernelIntrospection::K8s::Node.pids(node)
               end

--- a/src/modules/k8s_kernel_introspection/k8s_kernel_introspection.cr
+++ b/src/modules/k8s_kernel_introspection/k8s_kernel_introspection.cr
@@ -33,6 +33,20 @@ module KernelIntrospection
         pids
       end
 
+      # A task that exits is detached from every cgroup v1 hierarchy, so a
+      # zombie's /proc/<pid>/cgroup resets to "/" on all v1 controller lines
+      # and pids_by_container cannot see it on cgroup v1 nodes (only the v2
+      # "0::" line keeps its path). Zombies are therefore enumerated by
+      # state; their PPid stays valid and attributes them to a container.
+      def self.zombie_pids(node) : Array(String)
+        command = "/bin/sh -c \"grep -l '^State:.*Z (zombie)' /proc/[0-9]*/status 2>/dev/null | sed -e 's,/proc/\\([0-9]*\\)/status,\\1,'\""
+        result = ClusterTools.exec_by_node(command, node)
+        unless result[:status].success?
+          return [] of String
+        end
+        result[:output].strip.split("\n").reject(&.empty?)
+      end
+
       def self.all_statuses_by_pids(pids : Array(String), node) : Array(String)
         Log.info { "all_statuses_by_pids" }
         proc_statuses = pids.map do |pid|

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -451,12 +451,28 @@ scored_task "zombie_handled",
   type: CNFManager::TestType::Essential,
   emoji: "⚖👀" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
+    injection_failures = [] of String
     CNFManager.resource_refs(args, config, WORKLOAD_RESOURCE_KIND_NAMES) do |resource|
       ClusterTools.all_containers_by_resource?(resource, resource[:namespace], include_proctree: false) do |container_id, container_pid_on_node, node|
-        ClusterTools.exec_by_node("nerdctl --namespace=k8s.io cp /zombie #{container_id}:/zombie", node)
-        ClusterTools.exec_by_node("nerdctl --namespace=k8s.io cp /sleep #{container_id}:/sleep", node)
-        ClusterTools.exec_by_node("nerdctl --namespace=k8s.io exec #{container_id} /zombie", node)
+        probe_commands = [
+          "nerdctl --namespace=k8s.io cp /zombie #{container_id}:/zombie",
+          "nerdctl --namespace=k8s.io cp /sleep #{container_id}:/sleep",
+          "nerdctl --namespace=k8s.io exec #{container_id} /zombie",
+        ]
+        probe_commands.each do |probe_command|
+          cmd_result = ClusterTools.exec_by_node(probe_command, node)
+          next if cmd_result[:status].success?
+          Log.for(t.name).error { "zombie probe injection failed for container #{container_id} (#{resource[:kind]}/#{resource[:name]}): #{probe_command}: #{cmd_result[:error]}" }
+          injection_failures << "#{resource[:kind]}/#{resource[:name]} container #{container_id}: `#{probe_command}` failed"
+          break
+        end
       end
+    end
+
+    unless injection_failures.empty?
+      injection_failures.each { |failure| result.append_description(failure) }
+      result.skipped("Zombie reaping not checked: the zombie probe could not be injected into every container")
+      next
     end
 
     sleep(Time::Span.new(seconds: 10))
@@ -464,7 +480,7 @@ scored_task "zombie_handled",
     pods_to_restart = Set(Tuple(String, String)).new
     containers_to_restart = Set(Tuple(String, JSON::Any)).new
     task_response = CNFManager.workload_resource_test(args, config, check_containers:false ) do |resource, _, _|
-      ClusterTools.all_containers_by_resource?(resource, resource[:namespace], only_container_pids:true) do | container_id, container_pid_on_node, node, container_proctree_statuses, container_status, pod_name| 
+      ClusterTools.all_containers_by_resource?(resource, resource[:namespace], only_container_pids: true, include_zombies: true) do | container_id, container_pid_on_node, node, container_proctree_statuses, container_status, pod_name| 
 
         zombies = container_proctree_statuses.map do |status|
           Log.for(t.name).debug { "status: #{status}" }


### PR DESCRIPTION
Fixes #2474.

`zombie_handled` could report PASSED without having tested anything. Two defects, one fix each:

**Zombie enumeration no longer depends on cgroup topology.** The kernel detaches an exiting task from every cgroup v1 hierarchy: a zombie's `/proc/<pid>/cgroup` resets to `/` on all v1 controller lines, so the container-id grep that `only_container_pids` enumeration relies on cannot see zombies on legacy-v1 nodes (only a cgroup v2 `0::` line, where one exists, keeps the path — verified on a live node: the injected zombie's 15 v1 lines all read `/`). A zombie's `PPid` stays valid, however, and every zombie belonging to a container has its parent among the container's processes (orphans are reparented to the container's init). The new `zombie_pids` (one `grep -l` over `/proc/*/status` per node) collects zombies by state, and `ClusterTools.container_zombie_pids` attributes them via `PPid`; `all_containers_by_resource?` merges them into the enumerated set behind a new `include_zombies` flag, used only by `zombie_handled` — `single_process_type` behavior is unchanged, and on v2 nodes the subtraction step keeps the set duplicate-free.

**Probe injection failures now surface instead of passing.** The results of the three injection commands (`nerdctl cp` ×2, `nerdctl exec`) were discarded; a read-only root filesystem (or any other injection failure) meant no zombie was ever created and the test passed vacuously. Each command is now checked: on failure the test reports `skipped` with the failing command in the result details and an error-level log line.

Verified on a live kind cluster (hybrid cgroup v1 host, containerd):

- `sample-bad-zombie` → FAILED, both zombies attributed via `impacted_resources`, container cleanup still runs
- `sample_good_zombie_handling` → PASSED (no false positives from the state-based enumeration); `single_process_type` → PASSED
- new `sample-cnfs/sample-zombie-non-injectable` (busybox with `readOnlyRootFilesystem: true`) → SKIPPED with the failing `nerdctl cp` named in details, exit 0

Spec: new `zombie`-tagged example covering the skipped path (all three now pass locally end-to-end); docs note the skip behavior. Built and spec suite compile-checked with Crystal 1.19.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
