### PR TITLE
Spec fixture: give the non-specialized init a long-lived child

### DIFF
--- a/sample-cnfs/sample-nonspecialized-init/manifests/manifest.yml
+++ b/sample-cnfs/sample-nonspecialized-init/manifests/manifest.yml
@@ -33,4 +33,4 @@ spec:
       - name: nonspecialized-init
         image: busybox
         command: ["/bin/sh"]
-        args: ["-c", "while true; do sleep 30; done"]
+        args: ["-c", "while true; do sleep 3600; done"]


### PR DESCRIPTION
Deflakes the `process_check` shard.

`sample-nonspecialized-init` ran `while true; do sleep 30; done`, so its only child died and respawned every 30 s. `single_process_type` enumerates in two phases — pid list, then one `/proc/<pid>/status` read per pid, dropping any pid that vanished in between — so a respawn inside that window collapses the proctree to PID 1 alone. The test still passes ("only one process type"), but the *uses non-specialized init system* description that `microservice_spec.cr:113` asserts on is never emitted. First observed on #2475's run (attempt 1), where the shard is otherwise green across main and every open PR.

`sleep 3600` (the idiom `sample_stuck_finalizer` already uses) makes the child outlive any enumeration; the fixture's shape — `sh` as PID 1 supervising exactly one child — is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)