### PR TITLE
CI: create kind clusters through one action that retries a missed boot deadline

### DIFF
--- a/.github/actions/create-kind-cluster/action.yml
+++ b/.github/actions/create-kind-cluster/action.yml
@@ -1,0 +1,38 @@
+name: "Create kind cluster"
+description: "Create a kind cluster from a config file, retrying once when the node containers miss kind's fixed boot deadline. This action is the single place that creates kind clusters in actions.yml."
+inputs:
+  name:
+    description: "Cluster name"
+    required: true
+  config:
+    description: "kind config file"
+    required: false
+    default: "/tmp/cluster.yml"
+  kubeconfig:
+    description: "Where to write the kubeconfig"
+    required: true
+  wait:
+    description: "How long kind waits for the control plane to become ready"
+    required: false
+    default: "5m"
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        cat "${{ inputs.config }}"
+        kind --version
+        # kind gives the node containers a fixed 60 s to boot systemd; when several
+        # jobs boot clusters on one host at once that deadline is occasionally
+        # missed, and a host that busy can also leave the control plane too slow
+        # for kubeadm. kind removes its own failed nodes, so retrying is just
+        # trying again -- after a pause long enough for the burst to pass.
+        for attempt in 1 2; do
+          kind create cluster --name "${{ inputs.name }}" --config="${{ inputs.config }}" \
+            --kubeconfig "${{ inputs.kubeconfig }}" --wait "${{ inputs.wait }}" && break
+          if [ "$attempt" = 2 ]; then echo "::error::kind create cluster failed twice"; exit 1; fi
+          echo "::warning::kind create cluster failed (attempt $attempt); retrying in 60 s"
+          sleep 60
+        done
+        KUBECONFIG="${{ inputs.kubeconfig }}" kubectl get nodes

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -123,6 +123,7 @@ jobs:
         export CLUSTER=$(uuidgen)
         echo "export CLUSTER=$CLUSTER"
         echo "export CLUSTER=$CLUSTER" > cluster.env
+        echo "CLUSTER=$CLUSTER" >> "$GITHUB_ENV"
         mkdir -p /shared/pss
         cat <<EOF > /shared/pss/cluster-level-pss.$CLUSTER.yaml
         apiVersion: apiserver.config.k8s.io/v1
@@ -300,15 +301,11 @@ jobs:
         EOF
     - name: Install kind
       uses: ./.github/actions/install-kind
-    - name: Create Kind Cluster 
-      run: |
-        cat /tmp/cluster.yml
-        source cluster.env
-        echo kind create cluster --name $CLUSTER --config=/tmp/cluster.yml --kubeconfig ./$CLUSTER.conf --retain --wait 5m
-        kind --version
-        kind create cluster --name $CLUSTER --config=/tmp/cluster.yml --kubeconfig ./$CLUSTER.conf --retain --wait 5m
-        export KUBECONFIG=$(pwd)/$CLUSTER.conf
-        kubectl get nodes
+    - name: Create Kind Cluster
+      uses: ./.github/actions/create-kind-cluster
+      with:
+        name: ${{ env.CLUSTER }}
+        kubeconfig: ./${{ env.CLUSTER }}.conf
     - name: Configure registry mirror (private_registry)
       if: startsWith(matrix.spec, 'private_registry_')
       run: |
@@ -394,7 +391,7 @@ jobs:
         ls -la
         sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
 
-    - name: Create Kind Cluster 
+    - name: Kind cluster config
       run: |
         cat << EOF > /tmp/cluster.yml
         kind: Cluster
@@ -407,11 +404,12 @@ jobs:
         EOF
         export CLUSTER=$(uuidgen)
         echo "export CLUSTER=$CLUSTER" > cluster.env
-        echo kind create cluster --name $CLUSTER --config=/tmp/cluster.yml --kubeconfig ./$CLUSTER.conf --retain --wait 5m
-        kind --version
-        kind create cluster --name $CLUSTER --config=/tmp/cluster.yml --kubeconfig ./$CLUSTER.conf --retain --wait 5m
-        export KUBECONFIG=$(pwd)/$CLUSTER.conf
-        kubectl get nodes
+        echo "CLUSTER=$CLUSTER" >> "$GITHUB_ENV"
+    - name: Create Kind Cluster
+      uses: ./.github/actions/create-kind-cluster
+      with:
+        name: ${{ env.CLUSTER }}
+        kubeconfig: ./${{ env.CLUSTER }}.conf
     - name: Install Crystal
       uses: crystal-lang/install-crystal@v1
       with:
@@ -502,12 +500,13 @@ jobs:
             hostPath: $HOME/.docker/config.json
         EOF
         export CLUSTER=$(uuidgen)
-        echo "export CLUSTER=$CLUSTER"
         echo "export CLUSTER=$CLUSTER" > cluster.env
-        kind --version
-        kind create cluster --name $CLUSTER --config=/tmp/cluster.yml --kubeconfig /tmp/$CLUSTER.conf --retain --wait 5m
-        export KUBECONFIG=/tmp/$CLUSTER.conf
-        kubectl get nodes
+        echo "CLUSTER=$CLUSTER" >> "$GITHUB_ENV"
+    - name: Create Kind Cluster
+      uses: ./.github/actions/create-kind-cluster
+      with:
+        name: ${{ env.CLUSTER }}
+        kubeconfig: /tmp/${{ env.CLUSTER }}.conf
     - name: Run Test Suite without source(config_lifecycle)
       run: |
         source cluster.env
@@ -597,10 +596,12 @@ jobs:
         EOF
         export CLUSTER=$(uuidgen)
         echo "export CLUSTER=$CLUSTER" > cluster.env
-        kind --version
-        kind create cluster --name $CLUSTER --config=/tmp/cluster.yml --kubeconfig /tmp/$CLUSTER.conf --retain --wait 5m
-        export KUBECONFIG=/tmp/$CLUSTER.conf
-        kubectl get nodes
+        echo "CLUSTER=$CLUSTER" >> "$GITHUB_ENV"
+    - name: Create Kind Cluster
+      uses: ./.github/actions/create-kind-cluster
+      with:
+        name: ${{ env.CLUSTER }}
+        kubeconfig: /tmp/${{ env.CLUSTER }}.conf
     - name: Run Test Suite without source(microservice)
       run: |
         source cluster.env
@@ -689,10 +690,12 @@ jobs:
         EOF
         export CLUSTER=$(uuidgen)
         echo "export CLUSTER=$CLUSTER" > cluster.env
-        kind --version
-        kind create cluster --name $CLUSTER --config=/tmp/cluster.yml --kubeconfig /tmp/$CLUSTER.conf --retain --wait 5m
-        export KUBECONFIG=/tmp/$CLUSTER.conf
-        kubectl get nodes
+        echo "CLUSTER=$CLUSTER" >> "$GITHUB_ENV"
+    - name: Create Kind Cluster
+      uses: ./.github/actions/create-kind-cluster
+      with:
+        name: ${{ env.CLUSTER }}
+        kubeconfig: /tmp/${{ env.CLUSTER }}.conf
     - name: Run Test Suite without source(all)
       run: |
         source cluster.env


### PR DESCRIPTION
kind gives the node containers a fixed 60 s to reach systemd's multi-user target (`could not find a log line that matches "Reached target .*Multi-User System.*"`) — independent of `--wait`, which only governs the later readiness phase. When several jobs of the fan-out boot clusters on the same host at once, that deadline is occasionally missed and the job dies before any test runs. Seen on [run 32971270083](https://github.com/lfn-cnti/testsuite/actions/runs/32971270083): two of four slots on one host timed out at the same second, then booted fine 90 s later.

A new `.github/actions/create-kind-cluster` composite action (sibling of `install-kind`) holds the single create-with-retry sequence: on failure it waits 60 s for the burst to pass, tries once more, and fails with an `::error` if the second attempt also fails. **All five** cluster creations in `actions.yml` now go through it — `spec`, `chaos` and the three `test_binary_*` jobs, the latter of which previously had no retry at all. Each job publishes `CLUSTER` to `$GITHUB_ENV` next to the existing `cluster.env` so the action can be handed the name; `cluster.env` and every later `source cluster.env` are unchanged.

`--retain` is dropped (review feedback): nothing in the workflow inspected retained nodes before the `always()` `Delete Cluster` step removed them, so it only ever served interactive debugging on a runner — and without it kind cleans up its own failed attempt, which removes the need for an explicit delete before the retry. If a boot failure ever needs a post-mortem again, that means re-adding `--retain` *plus* a log-collection step before cleanup.

The action's script was exercised against a fake `kind` for all three paths (fail-then-succeed → 0, fail twice → 1, first-try success → silent). `debian.yml`/`arm64.yml`/`nightly_free5gc.yml` each boot a single cluster on a dedicated runner, so they're deliberately left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)