### PR TITLE
GNU-style options: one registry, one parser in front of SAM (RFC #2459, part 1)

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -16,10 +16,21 @@ The CNTI Test Suite can be run in production mode (using an executable) or in de
 
 ```
 # Production mode
-./cnf-testsuite <testname>
+./cnf-testsuite [options] <task> [<task> ...]
 
 # Developer mode
-crystal src/cnf-testsuite.cr <testname>
+crystal src/cnf-testsuite.cr -- [options] <task> [<task> ...]
+```
+
+Options are GNU-style and may appear anywhere on the line, as `--name VALUE`
+or `--name=VALUE`; several task names run in order. `--skip <task>` leaves a
+task out of a suite. `./cnf-testsuite help` lists every option; an unknown
+option or task is a usage error (exit 64) with the closest match suggested.
+
+```
+./cnf-testsuite cnf_install --cnf-config ./cnf-testsuite.yml --timeout 120
+./cnf-testsuite all --skip resilience --strict
+./cnf-testsuite liveness readiness
 ```
 
 :star: \*Note: All usage commands in this document will use the production (binary executable) syntax unless otherwise stated.
@@ -370,9 +381,9 @@ cnf-config=<path_to_your_config_file>/cnf-testsuite.yml
 
 #### Get available options and to see all available tests from command line:
 
-`help` prints a usage page: the typical workflow, the options, the `key=value`
-arguments, the flags, and the `~exclusion` / `@` syntax. `-h` and a bare
-invocation print the same page.
+`help` prints a usage page: the typical workflow, every option with its
+meaning, and how to skip tasks or run several. `-h` and a bare invocation print
+the same page.
 
 ```
 ./cnf-testsuite help

--- a/spec/utils/cli_args_spec.cr
+++ b/spec/utils/cli_args_spec.cr
@@ -1,4 +1,5 @@
 require "./../spec_helper"
+require "../../src/tasks/**"
 require "../../src/tasks/utils/sam_args_patch"
 require "../../src/tasks/utils/cli_args_validation"
 
@@ -22,14 +23,30 @@ describe "CLI argument validation" do
     result[:output].should contain("Unknown argument 'cnf-path='")
   end
 
-  it "warns on unmatched exclusions and task names in argument positions", tags: ["points"] do
+  it "warns on an unmatched legacy exclusion, and runs a second task named after the first", tags: ["points"] do
     result = ShellCmd.run_testsuite("version ~no_such_task")
     result[:status].success?.should be_true
     result[:output].should contain("does not match any task")
 
-    result = ShellCmd.run_testsuite("version delete_results")
+    # A task name in an argument position is another task to run, in order.
+    result = ShellCmd.run_testsuite("version test")
     result[:status].success?.should be_true
-    result[:output].should contain("separate them with")
+    result[:output].should contain("CNF TestSuite version:")
+    result[:output].should contain("ping")
+  end
+
+  it "accepts GNU-style options and rejects unknown ones with a suggestion", tags: ["points"] do
+    result = ShellCmd.run_testsuite("cnf_install --cnf-config /nonexistent/cnf-testsuite.yml")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("CNF configuration file not found")
+
+    result = ShellCmd.run_testsuite("version --cnf-confg x")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("Did you mean '--cnf-config'?")
+
+    result = ShellCmd.run_testsuite("version --timeout abc")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("not a number")
   end
 
   it "exits 64 when a task's own arguments are missing or name no file", tags: ["points"] do
@@ -76,25 +93,17 @@ describe "CLI argument validation" do
     Sam::Args.new(["cnf-config=a=b"]).named["cnf-config"].should eq("a=b")
   end
 
-  it "invoked_task? matches only tokens in task positions", tags: ["points"] do
-    original = ARGV.dup
-    begin
-      ARGV.clear
-      ARGV.concat(["state", "cnf-config=x", "strict", "@", "security"])
-      invoked_task?("state").should be_true
-      invoked_task?("security").should be_true      # after the '@' separator
-      invoked_task?("strict").should be_false       # flag, not a task position
-      invoked_task?("cnf-config=x").should be_false
+  it "invoked_task? matches only tasks named on the command line", tags: ["points"] do
+    CLIParser.parse!(["state", "--cnf-config", "x", "--strict", "security"])
+    invoked_task?("state").should be_true
+    invoked_task?("security").should be_true
+    invoked_task?("strict").should be_false   # option, not a task
+    invoked_task?("x").should be_false
 
-      # The old unanchored regexes matched substrings anywhere on the command
-      # line - /ran/ matched an invocation of rolling_version_change.
-      ARGV.clear
-      ARGV.concat(["rolling_version_change"])
-      invoked_task?("ran").should be_false
-      invoked_task?("rolling_version_change").should be_true
-    ensure
-      ARGV.clear
-      ARGV.concat(original)
-    end
+    # The old unanchored regexes matched substrings anywhere on the command
+    # line - /ran/ matched an invocation of rolling_version_change.
+    CLIParser.parse!(["rolling_version_change"])
+    invoked_task?("ran").should be_false
+    invoked_task?("rolling_version_change").should be_true
   end
 end

--- a/spec/utils/cli_completion_spec.cr
+++ b/spec/utils/cli_completion_spec.cr
@@ -49,23 +49,27 @@ describe "Shell completion" do
     first.size.should eq(first.uniq.size)
   end
 
-  it "completes flags, key= arguments, exclusions and tasks after the separator", tags: ["points"] do
-    after_task = bash_completions("cnf-testsuite all ")
-    after_task.should contain("strict")
-    after_task.should contain("cnf-config=")
-    after_task.should contain("@")
-    after_task.should_not contain("liveness")
+  it "completes options, their values, and further task names", tags: ["points"] do
+    after_task = bash_completions("cnf-testsuite all --")
+    after_task.should contain("--strict")
+    after_task.should contain("--cnf-config")
+    after_task.should contain("--skip")
+    after_task.should_not contain("strict")
 
-    bash_completions("cnf-testsuite all ~readi").should eq(["~readiness"])
-    bash_completions("cnf-testsuite liveness @ readi").should eq(["readiness"])
+    # A task name is a valid next word: several tasks run in order.
+    bash_completions("cnf-testsuite liveness readi").should eq(["readiness"])
+    bash_completions("cnf-testsuite all --skip readi").should eq(["readiness"])
+    bash_completions("cnf-testsuite all --skip=readi").should eq(["readiness"])
     bash_completions("cnf-testsuite -l deb").should eq(["debug"])
     bash_completions("cnf-testsuite -l debug live").should eq(["liveness"])
     bash_completions("cnf-testsuite help tas").should eq(["tasks"])
     bash_completions("cnf-testsuite completion ").should eq(["bash", "zsh"])
   end
 
-  it "completes file names after path-valued arguments", tags: ["points"] do
-    bash_completions("cnf-testsuite cnf_install cnf-config=spec/fixtu").should eq(["spec/fixtures/"])
-    bash_completions("cnf-testsuite cnf_install timeout=").should be_empty
+  it "completes file names after path-valued options", tags: ["points"] do
+    bash_completions("cnf-testsuite cnf_install --cnf-config spec/fixtu").should eq(["spec/fixtures/"])
+    # bash replaces only the text after the "=" it splits on.
+    bash_completions("cnf-testsuite cnf_install --cnf-config=spec/fixtu").should eq(["spec/fixtures/"])
+    bash_completions("cnf-testsuite cnf_install --timeout ").should be_empty
   end
 end

--- a/spec/utils/cli_parser_spec.cr
+++ b/spec/utils/cli_parser_spec.cr
@@ -1,0 +1,99 @@
+require "../spec_helper"
+require "../../src/tasks/**"
+require "../../src/tasks/utils/cli_args_validation"
+
+# In-process: the parser maps a command line onto task paths and the Sam::Args
+# the tasks read, without running anything.
+private def parse(*tokens)
+  CLIParser.parse!(tokens.to_a)
+end
+
+private def usage_error(*tokens) : Array(String)
+  CLIParser.parse!(tokens.to_a)
+  fail "expected a usage error for #{tokens.inspect}"
+rescue e : CLIParser::UsageError
+  e.errors
+end
+
+describe "CLI parser" do
+  it "maps GNU-style options onto the arguments tasks read", tags: ["points"] do
+    segments = parse("cnf_install", "--cnf-config", "x.yml", "--timeout=30", "--skip-wait-for-install")
+    segments.size.should eq(1)
+    segments[0].tasks.should eq(["cnf_install"])
+    segments[0].args.named["cnf-config"].should eq("x.yml")
+    segments[0].args.named["timeout"].should eq("30")
+    # Flags keep the word tasks already read.
+    segments[0].args.raw.should contain("skip_wait_for_install")
+  end
+
+  it "accepts options anywhere on the line and runs several tasks in order", tags: ["points"] do
+    segments = parse("--strict", "liveness", "readiness", "--results-dir", "out")
+    segments.size.should eq(1)
+    segments[0].tasks.should eq(["liveness", "readiness"])
+    segments[0].args.raw.should eq(["strict"])
+    CLIInvocation.tasks.should eq(["liveness", "readiness"])
+    CLIInvocation.option("results-dir").should eq("out")
+    invoked_task?("readiness").should be_true
+    invoked_task?("strict").should be_false
+  end
+
+  it "turns --skip into the exclusion SAM honors, resolving aliases", tags: ["points"] do
+    segments = parse("all", "--skip", "resilience", "--skip=liveness")
+    segments[0].args.raw.should eq(["~resilience", "~liveness"])
+    # A top-level alias names the task it points at.
+    segments = parse("platform", "--skip", "k8s_conformance")
+    segments[0].args.raw.first.to_s.should start_with("~")
+    segments[0].args.raw.first.to_s.should_not eq("~k8s_conformance") if TaskAliases["k8s_conformance"]?
+  end
+
+  it "keeps the legacy spellings working until they are removed", tags: ["points"] do
+    segments = parse("cnf_install", "cnf-config=x.yml", "timeout=30", "skip_wait_for_install", "~liveness", "@", "cert", "exclude=liveness readiness")
+    segments.size.should eq(2)
+    segments[0].tasks.should eq(["cnf_install"])
+    segments[0].args.named["cnf-config"].should eq("x.yml")
+    segments[0].args.raw.should eq(["skip_wait_for_install", "~liveness"])
+    segments[1].tasks.should eq(["cert"])
+    segments[1].args.named["exclude"].should eq("liveness readiness")
+    CLIInvocation.tasks.should eq(["cnf_install", "cert"])
+  end
+
+  it "preserves '=' inside values", tags: ["points"] do
+    parse("cnf_install", "--cnf-config=a=b")[0].args.named["cnf-config"].should eq("a=b")
+    parse("cnf_install", "cnf-config=a=b")[0].args.named["cnf-config"].should eq("a=b")
+  end
+
+  it "leaves help and completion topics alone", tags: ["points"] do
+    parse("help", "tasks")[0].args.raw.should eq(["tasks"])
+    parse("help", "liveness")[0].tasks.should eq(["help"])
+    parse("completion", "zsh")[0].args.raw.should eq(["zsh"])
+  end
+
+  it "reports every usage error at once, with suggestions", tags: ["points"] do
+    errors = usage_error("cnf_install", "--cnf-confg", "x", "--timeout", "abc", "--strict=yes", "--skip", "livenes", "bogus")
+    errors.join("\n").should contain("Unknown option '--cnf-confg'. Did you mean '--cnf-config'?")
+    errors.join("\n").should contain("'abc' is not a number")
+    errors.join("\n").should contain("'--strict' takes no value")
+    errors.join("\n").should contain("Unknown task 'livenes' given to '--skip'. Did you mean 'liveness'?")
+    errors.join("\n").should contain("Unknown flag 'bogus'")
+    errors.size.should eq(5)
+
+    usage_error("cnf_install", "--cnf-config").join.should contain("requires a value")
+    usage_error("cnf_install", "--kubeconfig", "/nonexistent").join.should contain("is not a file")
+    usage_error("version", "cnf-path=x").join.should contain("Unknown argument 'cnf-path='")
+    usage_error("version", "--exclude", "x").join.should contain("Unknown option '--exclude'")
+    usage_error("version", "-x").join.should contain("Unknown option '-x'")
+  end
+
+  it "sets KUBECONFIG from --kubeconfig", tags: ["points"] do
+    original = ENV["KUBECONFIG"]?
+    file = File.tempname("kubeconfig")
+    File.write(file, "")
+    begin
+      parse("version", "--kubeconfig", file)
+      ENV["KUBECONFIG"].should eq(file)
+    ensure
+      File.delete?(file)
+      original ? (ENV["KUBECONFIG"] = original) : ENV.delete("KUBECONFIG")
+    end
+  end
+end

--- a/spec/utils/results_spec.cr
+++ b/spec/utils/results_spec.cr
@@ -38,9 +38,13 @@ describe "Results location" do
     end
   end
 
-  it "rejects an empty results-dir= as a usage error", tags: ["points"] do
-    result = ShellCmd.run_testsuite("version results-dir=")
+  it "rejects an empty --results-dir as a usage error", tags: ["points"] do
+    result = ShellCmd.run_testsuite("version --results-dir ''")
     result[:status].exit_code.should eq(USAGE_EXIT_CODE)
-    result[:output].should contain("results-dir=")
+    result[:output].should contain("Invalid value for '--results-dir'")
+
+    result = ShellCmd.run_testsuite("version --results-dir")
+    result[:status].exit_code.should eq(USAGE_EXIT_CODE)
+    result[:output].should contain("requires a value")
   end
 end

--- a/src/cnf-testsuite.cr
+++ b/src/cnf-testsuite.cr
@@ -64,10 +64,11 @@ begin
     exit 0
   end
 
-  argv = TaskAliases.resolve_exclusions(ARGV.clone)
-  validate_cli_args!(argv)
-  # See issue #426 for exit code requirement
-  Sam.process_tasks(argv)
+  # Every task on the line runs in order with the arguments parsed for it;
+  # SAM only ever sees a task path and a ready-made Sam::Args.
+  CLIParser.parse!(ARGV).each do |segment|
+    segment.tasks.each { |task| Sam.invoke(task, segment.args) }
+  end
 
   if CNFManager::Points::Results.file_exists?
     # One stable line per run for scripts to grep; the pointer is the path
@@ -83,6 +84,9 @@ begin
       exit 2
     end
   end
+rescue e : CLIParser::UsageError
+  e.errors.each { |error| stdout_failure error }
+  exit USAGE_EXIT_CODE
 rescue e : Sam::NotFound
   stdout_failure e.message.to_s
   if suggestion = CLIHelp.suggestion_for(e.task_path)

--- a/src/tasks/utils/cli_args_validation.cr
+++ b/src/tasks/utils/cli_args_validation.cr
@@ -1,4 +1,6 @@
 require "sam"
+require "./cli_options"
+require "./cli_parser"
 
 # Exit code for CLI usage errors (sysexits EX_USAGE).
 USAGE_EXIT_CODE = 64
@@ -11,92 +13,16 @@ def usage_error!(message : String) : NoReturn
   exit USAGE_EXIT_CODE
 end
 
-# Every key=value argument some task actually reads.
-KNOWN_CLI_NAMED_ARGS = [
-  "cnf-config", "timeout", "input-config", "output-config",
-  "exclude", "pod-labels", "baseline-count", "results-dir",
-]
-# Named arguments whose value must be an integer.
-NUMERIC_CLI_NAMED_ARGS = ["timeout", "baseline-count"]
-# Every bare-word flag some task actually reads from the raw arguments.
-KNOWN_CLI_FLAGS = [
-  "strict", "essential", "poc", "wip", "alpha", "beta", "destructive",
-  "skip_wait_for_install", "skip_wait_for_uninstall",
-]
+# The legacy spellings, derived from the option registry: help, completion
+# and validation all read CLIOptions, so these can no longer drift from it.
+KNOWN_CLI_NAMED_ARGS = CLIOptions::ALL.select(&.takes_value?).compact_map(&.legacy)
+NUMERIC_CLI_NAMED_ARGS = CLIOptions::ALL.select(&.numeric).compact_map(&.legacy)
+KNOWN_CLI_FLAGS = CLIOptions.flags.compact_map(&.legacy)
 
-# Validates raw CLI tokens before SAM processes them. Previously every typo was
-# silently ignored: unknown key=value args and flags did nothing, exclusions
-# matching no task were dropped, and a second task name on the command line was
-# swallowed as an argument. Unknown input is now a usage error; the two
-# warn-only cases stay warnings for compatibility.
-def validate_cli_args!(argv : Array(String))
-  task_paths = Sam.root_namespace.all_tasks.map(&.path)
-  errors = [] of String
-  expect_task = true
-  current_task = ""
-
-  argv.each do |token|
-    if token == Sam::TASK_SEPARATOR
-      expect_task = true
-      next
-    end
-    if expect_task
-      # Task names themselves are validated by SAM (Sam::NotFound).
-      current_task = token
-      expect_task = false
-      next
-    end
-    # `help` takes a topic - "tasks" or a task name - and `completion` a shell
-    # name, rather than the flags and key=value arguments every other task takes.
-    next if current_task == "help" || current_task == "completion"
-
-    if token.empty?
-      errors << "Empty argument given."
-    elsif token.starts_with?("~")
-      unless task_paths.includes?(token[1..])
-        stdout_warning "Exclusion '#{token}' does not match any task and will be ignored."
-      end
-    elsif token.includes?("=")
-      key, value = token.split("=", 2)
-      if !KNOWN_CLI_NAMED_ARGS.includes?(key)
-        errors << "Unknown argument '#{key}='. Known arguments: #{KNOWN_CLI_NAMED_ARGS.join(", ")}."
-      elsif NUMERIC_CLI_NAMED_ARGS.includes?(key) && value.to_i?.nil?
-        errors << "Invalid value for '#{key}=': '#{value}' is not a number."
-      elsif key == "results-dir" && value.blank?
-        errors << "Invalid value for 'results-dir=': a directory path is required."
-      end
-    elsif token.starts_with?("-")
-      errors << "Unknown option '#{token}'. Supported options: -l/--loglevel LEVEL, -h/--help, --version."
-    elsif KNOWN_CLI_FLAGS.includes?(token)
-      # valid bare flag
-    elsif task_paths.includes?(token)
-      stdout_warning "'#{token}' is a task name in an argument position and will be ignored. To run multiple tasks, separate them with '#{Sam::TASK_SEPARATOR}': cnf-testsuite <task1> #{Sam::TASK_SEPARATOR} <task2>"
-    else
-      errors << "Unknown flag '#{token}'. Known flags: #{KNOWN_CLI_FLAGS.join(", ")}."
-    end
-  end
-
-  unless errors.empty?
-    errors.each { |error| stdout_failure error }
-    exit USAGE_EXIT_CODE
-  end
-end
-
-# True when `name` was one of the tasks invoked on the command line: the first
-# token, or any token following the '@' task separator. Replaces the old
-# unanchored `case ARGV.join(" ") when /name/` checks, where e.g. /ran/ matched
-# any invocation containing "ran" (rolling_version_change, a fixture path, ...).
+# True when `name` was one of the tasks invoked on the command line, as parsed
+# by CLIParser. Replaces the old unanchored `case ARGV.join(" ") when /name/`
+# checks, where e.g. /ran/ matched any invocation containing "ran"
+# (rolling_version_change, a fixture path, ...).
 def invoked_task?(name : String) : Bool
-  expect_task = true
-  ARGV.each do |token|
-    if token == Sam::TASK_SEPARATOR
-      expect_task = true
-      next
-    end
-    if expect_task
-      return true if token == name
-      expect_task = false
-    end
-  end
-  false
+  CLIInvocation.tasks.includes?(name)
 end

--- a/src/tasks/utils/cli_completion.cr
+++ b/src/tasks/utils/cli_completion.cr
@@ -15,7 +15,7 @@ module CLICompletion
   FUNCTION_NAME = "_cnf_testsuite_completions"
 
   # Named arguments whose value is a path, completed with file names.
-  FILE_VALUED_ARGS = ["cnf-config", "input-config", "output-config"]
+  FILE_VALUED_ARGS = CLIOptions.visible.select(&.file).map(&.name)
 
   def self.script(shell : String, bin_name : String = self.bin_name) : String
     case shell
@@ -59,11 +59,12 @@ module CLICompletion
     # Remove with:  complete -r #{bin_name}
     #{FUNCTION_NAME}() {
       local tasks="#{task_paths.join(" ")}"
-      local flags="#{KNOWN_CLI_FLAGS.join(" ")}"
-      local named="#{KNOWN_CLI_NAMED_ARGS.map { |arg| "#{arg}=" }.join(" ")}"
-      local file_args=" #{FILE_VALUED_ARGS.join(" ")} "
+      local flags="#{CLIOptions.visible.select(&.kind.flag?).map(&.long).join(" ")}"
+      local valued="#{CLIOptions.visible.select(&.takes_value?).map(&.long).join(" ")}"
+      local file_args=" #{FILE_VALUED_ARGS.map { |arg| "--#{arg}" }.join(" ")} "
+      local task_args=" #{CLIOptions.multis.map(&.long).join(" ")} "
       local levels="#{log_levels.join(" ")}"
-      local options="-l --loglevel -h --help --version"
+      local options="-l --loglevel -h --help --version $flags $valued"
 
       # Take the word under the cursor from the raw line rather than COMP_WORDS:
       # bash splits words on ':' and '=' (COMP_WORDBREAKS), which would cut
@@ -73,20 +74,24 @@ module CLICompletion
       local before="${line:0:${#line}-${#cur}}"
 
       # Walk the completed words to learn what the cursor position expects:
-      # a task (at the start, or after the '@' separator), a help topic, a shell
-      # name, a log level, or a task's arguments.
-      local state="task" expect_level=0 w
+      # the value of the option just before it, a help topic, a shell name, or
+      # - the default - a task name or an option.
+      local state="task" expect="" w
       local -a cwords=()
       for w in $before; do cwords+=("$w"); done
       local i=1
       while (( i < ${#cwords[@]} )); do
         w="${cwords[i]}"
-        if (( expect_level )); then
-          expect_level=0
+        if [[ -n "$expect" ]]; then
+          expect=""
         elif [[ "$w" == "-l" || "$w" == "--loglevel" ]]; then
-          expect_level=1
-        elif [[ "$w" == "@" ]]; then
-          state="task"
+          expect="level"
+        elif [[ "$task_args" == *" $w "* ]]; then
+          expect="task"
+        elif [[ "$file_args" == *" $w "* ]]; then
+          expect="file"
+        elif [[ "$w" == --* && "$valued" == *" $w "* ]]; then
+          expect="value"
         elif [[ "$state" == "task" && "$w" != -* ]]; then
           case "$w" in
             help)       state="help" ;;
@@ -98,34 +103,42 @@ module CLICompletion
         fi
         (( i++ ))
       done
-      (( expect_level )) && state="level"
 
       local -a candidates=() reply=()
-      case "$state" in
-        task)
-          if [[ "$cur" == -* ]]; then candidates=($options); else candidates=($tasks); fi ;;
-        help)  candidates=(tasks $tasks) ;;
-        shell) candidates=(#{SHELLS.join(" ")}) ;;
+      local prefix="" value="$cur" f
+      # --option=value completes like the value after `--option `.
+      if [[ -z "$expect" && "$cur" == --*=* ]]; then
+        w="${cur%%=*}"; value="${cur#*=}"; prefix="$w="
+        if [[ "$task_args" == *" $w "* ]]; then expect="task"
+        elif [[ "$file_args" == *" $w "* ]]; then expect="file"
+        elif [[ "$valued" == *" $w "* ]]; then expect="value"; fi
+      fi
+      case "$expect" in
         level) candidates=($levels) ;;
-        args)
-          if [[ "$cur" == *=* ]]; then
-            # key=value: complete file names for path-valued keys, nothing else.
-            local key="${cur%%=*}" value="${cur#*=}" f
-            if [[ "$file_args" == *" $key "* ]]; then
-              # A plain glob rather than compgen -f: under zsh's bashcompinit
-              # compgen ignores its word and globs the completion prefix instead.
-              for f in "$value"*; do
-                [[ -e "$f" ]] || continue
-                [[ -d "$f" ]] && f="$f/"
-                candidates+=("$key=$f")
-              done
-            fi
-          elif [[ "$cur" == "~"* ]]; then
-            for w in $tasks; do candidates+=("~$w"); done
-          else
-            candidates=($flags $named @)
-          fi ;;
+        task)  candidates=($tasks) ;;
+        file)
+          # A plain glob rather than compgen -f: under zsh's bashcompinit
+          # compgen ignores its word and globs the completion prefix instead.
+          for f in "$value"*; do
+            [[ -e "$f" ]] || continue
+            [[ -d "$f" ]] && f="$f/"
+            candidates+=("$f")
+          done ;;
+        value) ;;
+        *)
+          case "$state" in
+            help)  candidates=(tasks $tasks) ;;
+            shell) candidates=(#{SHELLS.join(" ")}) ;;
+            done)  ;;
+            *)
+              if [[ "$cur" == -* ]]; then candidates=($options); else candidates=($tasks); fi ;;
+          esac ;;
       esac
+      if [[ -n "$prefix" ]]; then
+        local -a prefixed=()
+        for w in "${candidates[@]}"; do prefixed+=("$prefix$w"); done
+        candidates=("${prefixed[@]}")
+      fi
 
       # Prefix test by substring rather than a glob pattern: zsh's sh emulation
       # does not always treat a quoted "$cur"* as literal text.
@@ -142,8 +155,8 @@ module CLICompletion
         reply=("${reply[@]#"$head"}")
       fi
 
-      # A lone `key=` or `dir/` completion continues on the same word.
-      if [[ ${#reply[@]} -eq 1 && ( "${reply[0]}" == *= || "${reply[0]}" == */ ) ]]; then
+      # A lone `dir/` completion continues on the same word.
+      if [[ ${#reply[@]} -eq 1 && "${reply[0]}" == */ ]]; then
         type compopt &>/dev/null && compopt -o nospace 2>/dev/null
       fi
       COMPREPLY=("${reply[@]}")

--- a/src/tasks/utils/cli_help.cr
+++ b/src/tasks/utils/cli_help.cr
@@ -150,20 +150,31 @@ module CLIHelp
     result
   end
 
-  def self.main_page : String
-    named_args = KNOWN_CLI_NAMED_ARGS.join(", ")
-    flags = KNOWN_CLI_FLAGS.join(", ")
+  # One row per option, wrapped like the task rows: the three the entry point
+  # handles itself, then everything in the registry.
+  def self.option_rows : String
+    String.build do |io|
+      io << row("-l, --loglevel LEVEL", "trace, debug, info, notice, warn, error, fatal (default: error)")
+      io << row("-h, --help", "show this help and exit")
+      io << row("    --version", "print the version and exit")
+      CLIOptions.visible.each do |option|
+        label = option.takes_value? ? "#{option.long} #{option.value_label}" : option.long
+        io << row("    #{label}", option.description)
+      end
+    end.chomp
+  end
 
+  def self.main_page : String
     <<-HELP
     The CNTi Test Suite validates a Cloud Native Function against cloud native
     best practices by running tests against a live Kubernetes cluster.
 
     USAGE
-      #{BIN_NAME} [options] <task> [arguments] [~exclusions] [#{Sam::TASK_SEPARATOR} <task> ...]
+      #{BIN_NAME} [options] <task> [<task> ...]
 
     TYPICAL WORKFLOW
       #{BIN_NAME} setup                                    install prerequisites (once)
-      #{BIN_NAME} cnf_install cnf-config=./cnf-testsuite.yml
+      #{BIN_NAME} cnf_install --cnf-config ./cnf-testsuite.yml
       #{BIN_NAME} cert                                     run the certification tests
       #{BIN_NAME} cnf_uninstall
 
@@ -173,23 +184,12 @@ module CLIHelp
       platform    tests against the Kubernetes platform itself
       cert        certification run; exits 0 when the CNF is certified
 
-    OPTIONS
-      -l, --loglevel LEVEL   trace, debug, info, notice, warn, error, fatal (default: error)
-      -h, --help             show this help and exit
-          --version          print the version and exit
+    OPTIONS (anywhere on the line; --name VALUE or --name=VALUE)
+    #{option_rows}
 
-    ARGUMENTS (key=value, after the task name)
-      cnf-config=PATH   a cnf-testsuite.yml or the directory holding one
-      timeout=SECONDS   how long to wait for install and uninstall operations
-      results-dir=PATH  where results files go (default: ./cnti/results, or $CNF_TESTSUITE_RESULTS_DIR)
-      All known arguments: #{named_args}
-
-    FLAGS
-      #{flags}
-
-    EXCLUSIONS AND MULTIPLE TASKS
-      ~<task>   skip a task within a suite, e.g. `#{BIN_NAME} all ~resilience`
-      #{Sam::TASK_SEPARATOR}         run several tasks in one invocation, e.g. `#{BIN_NAME} liveness #{Sam::TASK_SEPARATOR} readiness`
+    SKIPPING AND MULTIPLE TASKS
+      --skip <task>   skip a task within a suite, e.g. `#{BIN_NAME} all --skip resilience`
+      Several task names run in order: `#{BIN_NAME} liveness readiness --strict`
 
     EXIT CODES
       0   the run met its objective          2   the suite broke: a test errored, or a crash

--- a/src/tasks/utils/cli_invocation.cr
+++ b/src/tasks/utils/cli_invocation.cr
@@ -1,8 +1,30 @@
-# Flags recognized by the top-level OptionParser in logging.cr. That parser runs
-# at require time, before every task is registered, so it only records what was
-# asked for - the entry point acts on it once the task tree is complete and can
-# therefore render a help page that lists everything.
+# What the command line asked for, as parsed once at the entry point. -h and
+# --version are recorded earlier still, by the OptionParser in logging.cr that
+# runs at require time before any task exists.
 class CLIInvocation
   class_property? help_requested : Bool = false
   class_property? version_requested : Bool = false
+
+  @@tasks = [] of String
+  @@named = {} of String => String
+
+  # Records the parsed segments: every task named on the line, and the named
+  # option values (line-wide; the last occurrence wins).
+  def self.record(segments)
+    @@tasks = segments.flat_map(&.tasks)
+    @@named = {} of String => String
+    segments.each do |segment|
+      segment.args.named.each { |key, value| @@named[key] = value.to_s }
+    end
+  end
+
+  # The tasks named on the command line, in order.
+  def self.tasks : Array(String)
+    @@tasks
+  end
+
+  # A named option's value as given on the command line, or nil.
+  def self.option(name : String) : String?
+    @@named[name]?
+  end
 end

--- a/src/tasks/utils/cli_options.cr
+++ b/src/tasks/utils/cli_options.cr
@@ -1,0 +1,96 @@
+# The one description of every option the CLI accepts. Validation, help and
+# completion all read this list, so they cannot drift from each other or from
+# what the tasks consume. Tasks keep reading `args.named[<name>]` and
+# `args.raw.includes?(<internal name>)`; only the command-line spelling is
+# decided here.
+module CLIOptions
+  enum Kind
+    Value # --name VALUE
+    Flag  # --name
+    Multi # --name VALUE, repeatable
+  end
+
+  record Option,
+    name : String,
+    kind : Kind,
+    description : String,
+    value_label : String = "",
+    # What tasks read: args.named key for values, the raw word for flags.
+    internal : String = "",
+    numeric : Bool = false,
+    file : Bool = false,
+    # Legacy spelling still accepted until the legacy forms are removed:
+    # `key=value` for values, a bare word for flags. Nil for new options.
+    legacy : String? = nil,
+    # Accepted but not advertised.
+    hidden : Bool = false do
+    def long : String
+      "--#{name}"
+    end
+
+    def internal_name : String
+      internal.empty? ? name : internal
+    end
+
+    def takes_value? : Bool
+      !kind.flag?
+    end
+  end
+
+  ALL = [
+    Option.new("cnf-config", Kind::Value, "a cnf-testsuite.yml, or the directory holding one", value_label: "PATH", file: true, legacy: "cnf-config"),
+    Option.new("timeout", Kind::Value, "how long to wait for install and uninstall operations", value_label: "SECONDS", numeric: true, legacy: "timeout"),
+    Option.new("results-dir", Kind::Value, "where results files go (default: ./cnti/results, or $CNF_TESTSUITE_RESULTS_DIR)", value_label: "PATH", legacy: "results-dir"),
+    Option.new("kubeconfig", Kind::Value, "the kubeconfig to use (default: $KUBECONFIG)", value_label: "PATH", file: true),
+    Option.new("skip", Kind::Multi, "skip a task within a suite; repeatable", value_label: "TASK"),
+    Option.new("input-config", Kind::Value, "update_config: the cnf-testsuite.yml to convert", value_label: "PATH", file: true, legacy: "input-config"),
+    Option.new("output-config", Kind::Value, "update_config: where to write the converted file", value_label: "PATH", file: true, legacy: "output-config"),
+    Option.new("pod-labels", Kind::Value, "label selector of the pods a chaos test targets", value_label: "LABELS", legacy: "pod-labels"),
+    Option.new("baseline-count", Kind::Value, "smf_upf_heartbeat: heartbeats to sample for the baseline", value_label: "N", numeric: true, legacy: "baseline-count"),
+    Option.new("strict", Kind::Flag, "stop at the first failed or errored test", legacy: "strict"),
+    Option.new("essential", Kind::Flag, "cert: run only the essential tests", legacy: "essential"),
+    Option.new("poc", Kind::Flag, "include proof-of-concept tests", legacy: "poc"),
+    Option.new("wip", Kind::Flag, "include work-in-progress tests", legacy: "wip"),
+    Option.new("alpha", Kind::Flag, "include alpha tests", legacy: "alpha"),
+    Option.new("beta", Kind::Flag, "include beta tests", legacy: "beta"),
+    Option.new("destructive", Kind::Flag, "allow destructive tests", legacy: "destructive"),
+    Option.new("skip-wait-for-install", Kind::Flag, "do not wait for resources to become ready after install", internal: "skip_wait_for_install", legacy: "skip_wait_for_install"),
+    Option.new("skip-wait-for-uninstall", Kind::Flag, "do not wait for resources to be removed after uninstall", internal: "skip_wait_for_uninstall", legacy: "skip_wait_for_uninstall"),
+    # cert's `exclude="a b"` is superseded by --skip; accepted in its legacy
+    # spelling only, until the legacy forms are removed.
+    Option.new("exclude", Kind::Value, "cert: tests to leave out", value_label: "TESTS", legacy: "exclude", hidden: true),
+  ]
+
+  def self.[]?(name : String) : Option?
+    ALL.find { |option| option.name == name }
+  end
+
+  def self.visible : Array(Option)
+    ALL.reject(&.hidden)
+  end
+
+  def self.values : Array(Option)
+    ALL.select { |option| option.kind.value? }
+  end
+
+  def self.flags : Array(Option)
+    ALL.select { |option| option.kind.flag? }
+  end
+
+  def self.multis : Array(Option)
+    ALL.select { |option| option.kind.multi? }
+  end
+
+  def self.long_names : Array(String)
+    ALL.reject(&.hidden).map(&.long)
+  end
+
+  # Legacy `key=value` keys and bare flag words, by their legacy spelling.
+  def self.legacy_named(name : String) : Option?
+    ALL.find { |option| option.takes_value? && option.legacy == name }
+  end
+
+  def self.legacy_flag(word : String) : Option?
+    ALL.find { |option| option.kind.flag? && option.legacy == word }
+  end
+end

--- a/src/tasks/utils/cli_parser.cr
+++ b/src/tasks/utils/cli_parser.cr
@@ -1,0 +1,164 @@
+require "sam"
+require "levenshtein"
+require "./cli_options"
+require "./cli_invocation"
+require "./cli_help"
+require "./test_metadata"
+
+# Turns the command line into tasks and their arguments before SAM sees it.
+# SAM's own argument parsing is bypassed: it only ever receives a task path
+# and a ready-made Sam::Args, so its historical `-flag`-eats-the-next-token
+# and `=`-truncation behaviors cannot reach a task.
+#
+# Grammar (GNU-style; options may appear anywhere on the line):
+#   cnf-testsuite [--option VALUE|--option=VALUE|--flag]... <task> [<task>...]
+#
+# The legacy forms - `key=value`, bare flag words, `~task` exclusions and the
+# `@` separator - are still accepted here and map onto the same internal
+# representation; they are removed, together with this comment, once every
+# caller has moved.
+module CLIParser
+  class UsageError < Exception
+    getter errors : Array(String)
+
+    def initialize(@errors : Array(String))
+      super(@errors.join("\n"))
+    end
+  end
+
+  # Tasks that take a free-form topic rather than options.
+  POSITIONAL_TASKS = ["help", "completion"]
+
+  record Segment, tasks : Array(String), args : Sam::Args
+
+  # Parses argv, records the invocation for the rest of the run, and returns
+  # the segments to run in order. Raises UsageError with every problem found.
+  def self.parse!(argv : Array(String)) : Array(Segment)
+    segments = [] of Segment
+    errors = [] of String
+    task_paths = Sam.root_namespace.all_tasks.map(&.path)
+
+    tasks = [] of String
+    named = Sam::Args::AllowedHash.new
+    raw = [] of Sam::Args::AllowedTypes
+    close = -> do
+      errors << "Missing task name before '#{Sam::TASK_SEPARATOR}'." if tasks.empty? && !segments.empty?
+      segments << Segment.new(tasks, Sam::Args.new(named, raw)) unless tasks.empty?
+      tasks = [] of String
+      named = Sam::Args::AllowedHash.new
+      raw = [] of Sam::Args::AllowedTypes
+    end
+
+    i = 0
+    while i < argv.size
+      token = argv[i]
+      positional = tasks.first?.try { |first| POSITIONAL_TASKS.includes?(first) } || false
+
+      if token == Sam::TASK_SEPARATOR
+        close.call
+      elsif token.empty?
+        errors << "Empty argument given."
+      elsif token.starts_with?("--")
+        name, has_inline, inline = token[2..].partition("=")
+        option = CLIOptions[name]?
+        if option.nil? || option.hidden
+          errors << "Unknown option '--#{name}'.#{option_suggestion(name)}"
+          # Swallow what was probably its value, so one typo is one error.
+          i += 1 if !has_inline.presence && argv[i + 1]?.try { |v| !v.starts_with?("-") && !task_paths.includes?(v) }
+        elsif option.kind.flag?
+          errors << "Option '#{option.long}' takes no value." unless inline.empty? && !has_inline.presence
+          raw << option.internal_name
+        else
+          value = has_inline.presence ? inline : (argv[i + 1]? if argv[i + 1]?.try { |v| !v.starts_with?("--") })
+          if value.nil?
+            errors << "Option '#{option.long}' requires a value: #{option.long} #{option.value_label}."
+          else
+            i += 1 unless has_inline.presence
+            if option.kind.multi?
+              apply_skip(option, value, task_paths, raw, errors)
+            else
+              apply_value(option, value, named, errors)
+            end
+          end
+        end
+      elsif token.starts_with?("-")
+        errors << "Unknown option '#{token}'. Supported: #{CLIOptions.long_names.join(", ")}, -l/--loglevel LEVEL, -h/--help, --version."
+      elsif tasks.empty?
+        # The first bare word of a segment names a task; SAM validates it.
+        tasks << token
+      elsif positional
+        raw << token
+      elsif token.includes?("=")
+        key, value = token.split("=", 2)
+        if option = CLIOptions.legacy_named(key)
+          apply_value(option, value, named, errors)
+        else
+          errors << "Unknown argument '#{key}='.#{option_suggestion(key)}"
+        end
+      elsif token.starts_with?("~")
+        target = TaskAliases[token[1..]]? || token[1..]
+        if task_paths.includes?(target)
+          raw << "~#{target}"
+        else
+          stdout_warning "Exclusion '#{token}' does not match any task and will be ignored."
+        end
+      elsif option = CLIOptions.legacy_flag(token)
+        raw << option.internal_name
+      elsif task_paths.includes?(token)
+        tasks << token
+      else
+        errors << "Unknown flag '#{token}'.#{word_suggestion(token, task_paths)}"
+      end
+      i += 1
+    end
+    close.call
+
+    raise UsageError.new(errors) unless errors.empty?
+    CLIInvocation.record(segments)
+    segments
+  end
+
+  private def self.apply_value(option, value : String, named, errors)
+    if option.numeric && value.to_i?.nil?
+      errors << "Invalid value for '#{option.long}': '#{value}' is not a number."
+    elsif value.blank?
+      errors << "Invalid value for '#{option.long}': #{option.value_label.downcase.presence || "a value"} is required."
+    elsif option.name == "kubeconfig"
+      if File.file?(value)
+        # Honored by every kubectl/helm call from here on; the env var alone
+        # keeps working when the option is absent.
+        ENV["KUBECONFIG"] = value
+      else
+        errors << "Invalid value for '--kubeconfig': '#{value}' is not a file."
+      end
+    end
+    named[option.internal_name] = value
+  end
+
+  private def self.apply_skip(option, value : String, task_paths, raw, errors)
+    target = TaskAliases[value]? || value
+    if task_paths.includes?(target)
+      raw << "~#{target}"
+    else
+      errors << "Unknown task '#{value}' given to '#{option.long}'.#{word_suggestion(value, task_paths)}"
+    end
+  end
+
+  private def self.option_suggestion(name : String) : String
+    match = Levenshtein.find(name, CLIOptions.visible.map(&.name), tolerance(name))
+    match ? " Did you mean '--#{match}'?" : " Run `#{CLIHelp::BIN_NAME} help` for the options."
+  end
+
+  private def self.word_suggestion(word : String, task_paths : Array(String)) : String
+    candidates = CLIOptions.visible.map(&.long) + task_paths
+    match = Levenshtein.find(word, candidates, tolerance(word))
+    match ? " Did you mean '#{match}'?" : ""
+  end
+
+  # How far a suggestion may be from what was typed: up to three edits, but
+  # never more than half the word, so a one-letter typo is not "corrected" to
+  # an unrelated short name.
+  private def self.tolerance(word : String) : Int32
+    {3, word.size // 2}.min
+  end
+end

--- a/src/tasks/utils/cnf_manager/points.cr
+++ b/src/tasks/utils/cnf_manager/points.cr
@@ -157,13 +157,12 @@ module CNFManager
       RESULTS_DIR_ENV = "CNF_TESTSUITE_RESULTS_DIR"
       LATEST_NAME     = "latest.yml"
 
-      # Directory results are written to: `results-dir=PATH` on the command line,
-      # else CNF_TESTSUITE_RESULTS_DIR, else ./cnti/results. Resolved once
+      # Directory results are written to: `--results-dir PATH` on the command
+      # line, else CNF_TESTSUITE_RESULTS_DIR, else ./cnti/results. Resolved once
       # per process and creates nothing -- delete_results reads it too.
       def self.dir : String
         @@dir ||= begin
-          arg = ARGV.find(&.starts_with?("#{RESULTS_DIR_ARG}="))
-          value = arg ? arg.split("=", 2)[1] : ENV[RESULTS_DIR_ENV]?
+          value = CLIInvocation.option(RESULTS_DIR_ARG) || ENV[RESULTS_DIR_ENV]?
           value.presence || DEFAULT_DIR
         end
       end

--- a/src/tasks/utils/logging.cr
+++ b/src/tasks/utils/logging.cr
@@ -20,9 +20,10 @@ begin
     # the tasks exist, so the entry point is what acts on them.
     parser.on("-h", "--help", "Show usage and exit") { CLIInvocation.help_requested = true }
     parser.on("--version", "Print the version and exit") { CLIInvocation.version_requested = true }
+    # Every other option belongs to CLIParser, which runs once the tasks exist;
+    # leave them in ARGV untouched.
+    parser.invalid_option { }
   end
-rescue ex : OptionParser::InvalidOption
-  puts ex
 end
 
 # First Log.setup is necessary to make sure loglevel


### PR DESCRIPTION
**Draft — part 1 of 2 for RFC #2459 (P3-1).** This PR adds the GNU-style option surface and the parser behind it; part 2 migrates every caller (specs, workflows, docs) and removes the legacy forms. Until then both forms are accepted, so this can merge on its own without breaking anything.

### What the command line looks like now

```
cnf-testsuite [options] <task> [<task> ...]

cnf-testsuite cnf_install --cnf-config ./cnf-testsuite.yml --timeout 120
cnf-testsuite all --skip resilience --strict
cnf-testsuite liveness readiness
```

Options are accepted anywhere on the line, as `--name VALUE` or `--name=VALUE`; several task names run in order; `--skip TASK` (repeatable) replaces both `~task` and cert's `exclude=`; `--kubeconfig PATH` is new. The full mapping is the table in #2459.

### How

- **`CLIOptions`** — one registry describing every option: long name, kind (value / flag / repeatable), value label, description, numeric/file, the name tasks read internally, and the legacy spelling. Validation, help and completion all read it, so they cannot drift from each other — the `KNOWN_CLI_*` constants survive as derived views of it.
- **`CLIParser`** — parses before SAM and hands it only a task path plus a ready-made `Sam::Args`; SAM's own argument parsing (source of the historical `-flag`-eats-next-token and `=`-truncation bugs) is no longer on the path. Tasks are untouched: they still read `args.named["cnf-config"]`, `args.raw.includes?("strict")`, and SAM still honors `~path` in `raw` for `--skip`. All usage errors on a line are reported together, exit 64, with "did you mean" over options and tasks. `--kubeconfig` sets `KUBECONFIG` for the run after checking the file exists.
- **`CLIInvocation`** records the parsed tasks and options for the rest of the run: `invoked_task?` and the results-dir lookup read that instead of scanning `ARGV`.
- The early `OptionParser` in `logging.cr` keeps `-l/-h/--version` (it must run before the tasks exist) and now leaves every other option in `ARGV` for the parser.
- **Help** renders the option table from the registry; **completion** offers `--options`, their values (log levels, task names after `--skip`, file names after path-valued options, in both `--opt VALUE` and `--opt=VALUE` forms) and further task names.

### Behavior change worth knowing

A task name in an argument position used to be warned about and ignored; it now runs, in order, as the RFC proposes (`cnf-testsuite liveness readiness`). `@` still works until part 2 removes it.

### Verification

Built and spec suite compile-checked with Crystal 1.19.1. New in-process `cli_parser_spec` covers the mapping table, legacy passthrough, `=`-in-values, help/completion topics, `--kubeconfig`, and the error cases (each error once, with suggestion); `cli_args_spec`, `cli_help_spec`, `cli_completion_spec` updated for the new surface and green. USAGE's syntax section describes the options; the example commands throughout USAGE migrate in part 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
