### PR TITLE
install_opa: wait for gatekeeper to create the constraint CRD

### DIFF
--- a/src/tasks/setup/opa_setup.cr
+++ b/src/tasks/setup/opa_setup.cr
@@ -32,7 +32,12 @@ task "install_opa", ["setup:install_local_helm", "setup:create_namespace"] do |_
   File.write(enforce_manifest, ENFORCE_IMAGE_TAG)
   File.write(template_manifest, CONSTRAINT_TEMPLATE)
   KubectlClient::Wait.wait_for_install_by_apply(template_manifest)
-  KubectlClient::Wait.wait_for_condition("crd", "requiretags.constraints.gatekeeper.sh", "condition=established", 300)
+  # Gatekeeper generates the constraint CRD from the template asynchronously.
+  # `kubectl wait` fails at once when the resource does not exist yet, so poll
+  # until the CRD appears and is Established before creating a constraint.
+  unless KubectlClient::Wait.wait_for_resource_availability("customresourcedefinition", "requiretags.constraints.gatekeeper.sh", nil, 300)
+    raise "Gatekeeper did not create the requiretags constraint CRD within 300 seconds"
+  end
   KubectlClient::Apply.file(enforce_manifest)
 end
 


### PR DESCRIPTION
Fixes a start-up race that crashes a whole run when gatekeeper is a beat slow, seen on [`Test Binary Without Source(microservice)`](https://github.com/lfn-cnti/testsuite/actions/runs/33052547823/job/98451320679):

```
kubectl wait crd/requiretags.constraints.gatekeeper.sh --for=condition=established
Error from server (NotFound) … → unhandled exception → exit 2
```

`install_opa` applies the ConstraintTemplate and immediately runs `kubectl wait` on the constraint CRD — but that CRD is **generated asynchronously by gatekeeper's controller**, and `kubectl wait` does not wait for a resource to come into existence: if it isn't there yet it fails at once, and `raise_exc_on_error` turns that into a crash. Whether a run survives depends on which of the two wins a race that is usually, not always, won by gatekeeper.

The fix uses the polling primitive the module already has: `wait_for_resource_availability("customresourcedefinition", …)` checks every 3 s through `crd_ready?`, which treats NotFound as *not yet* and returns only on `Established=True`; a CRD that never appears within the timeout now fails with a plain message rather than a backtrace.

Verified on a live kind cluster with no gatekeeper installed (the real race path): the poller logs its wait, the CRD reaches Established, the `block-latest-tag` constraint is applied, exit 0. Built with Crystal 1.19.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)