### PR TITLE
container_sock_mounts: judge the CNF's resources, not the cluster's

### DIFF
--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -287,6 +287,55 @@ describe "Security" do
     end
   end
 
+  it "'container_sock_mounts' should ignore socket mounts that belong to other workloads in the cluster", tags: ["container_sock_mounts"] do
+    bystander = "sock-bystander.yml"
+    begin
+      # A pod outside the CNF (and outside EXCLUDE_NAMESPACES) that mounts a
+      # container runtime socket must not fail the CNF's test (#2483). Its
+      # namespace opts out of the restricted Pod Security profile CI enforces,
+      # so the hostPath mount is admitted.
+      File.write(bystander, <<-YAML)
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: sock-bystander
+          labels:
+            pod-security.kubernetes.io/enforce: privileged
+        ---
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: sock-bystander
+          namespace: sock-bystander
+        spec:
+          containers:
+          - name: bystander
+            image: busybox:1.33.1
+            command: ["/bin/sleep", "2147483647"]
+            volumeMounts:
+            - name: sock
+              mountPath: /var/run/docker.sock
+          volumes:
+          - name: sock
+            hostPath:
+              path: /var/run/docker.sock
+              type: FileOrCreate
+        YAML
+      KubectlClient::Apply.file(bystander)
+
+      ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_coredns/cnf-testsuite.yml")
+      result = ShellCmd.run_testsuite("container_sock_mounts")
+      result[:status].success?.should be_true
+      (/(PASSED).*(Container engine daemon sockets are not mounted as volumes)/ =~ result[:output]).should_not be_nil
+      verify_task_result("container_sock_mounts", "passed")
+    ensure
+      result = ShellCmd.cnf_uninstall()
+      result[:status].success?.should be_true
+      KubectlClient::Delete.file(bystander) rescue nil
+      File.delete?(bystander)
+    end
+  end
+
   it "'external_ips' should pass if a cnf has no services with external IPs", tags: ["external_ips"] do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_coredns/cnf-testsuite.yml")

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -125,6 +125,10 @@ scored_task "container_sock_mounts",
     policy_path = Kyverno.best_practice_policy("disallow-cri-sock-mount/disallow-cri-sock-mount.yaml")
     failures = Kyverno::PolicyAudit.run(policy_path, EXCLUDE_NAMESPACES)
 
+    # The audit covers the cluster; only the CNF's own resources are judged.
+    resource_keys = CNFManager.workload_resource_keys(args, config)
+    failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, failures)
+
     if failures.size == 0
       result.passed("Container engine daemon sockets are not mounted as volumes")
     else


### PR DESCRIPTION
Fixes #2483.

`container_sock_mounts` (essential) ran the Kyverno `disallow-cri-sock-mount` audit against the whole cluster and reported every failure outside `EXCLUDE_NAMESPACES` — the only Kyverno-based test that never narrowed the result to the CNF. A log shipper, a node agent or a CI runner in any other namespace that mounts a runtime socket failed the CNF's certification test and was named as its impacted resource.

The audit result now goes through `Kyverno.filter_failures_for_cnf_resources` with the CNF's workload resource keys, exactly as `latest_tag` and `selinux_options` already do. Four lines.

### Verification

New spec example for the bug: a bystander pod in its own namespace mounting `/var/run/docker.sock`, then the coredns CNF — the test must pass. Plus the two existing examples (CNF without a socket mount → passed; `sample_container_sock_mount` → failed). Run locally against a kind cluster with the CI compiler:

```
'container_sock_mounts' should pass if a cnf has no pods that mount container engine socket        ✓
'container_sock_mounts' should fail if the CNF has pods with container engine sockets mounted       ✓
'container_sock_mounts' should ignore socket mounts that belong to other workloads in the cluster   ✓  (new; failed before)
3 examples, 0 failures  (7:53)
```

The bystander's namespace carries `pod-security.kubernetes.io/enforce: privileged` so the hostPath mount is admitted under the restricted profile CI enforces cluster-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
