### PR TITLE
One container enumeration for hostport_not_used and privileged_containers

### DIFF
--- a/sample-cnfs/sample-hostport-pod/cnf-testsuite.yml
+++ b/sample-cnfs/sample-hostport-pod/cnf-testsuite.yml
@@ -1,0 +1,6 @@
+---
+config_version: v2
+deployments:
+  manifests:
+  - name: hostport-pod
+    manifest_directory: manifests

--- a/sample-cnfs/sample-hostport-pod/manifests/manifest.yml
+++ b/sample-cnfs/sample-hostport-pod/manifests/manifest.yml
@@ -1,0 +1,24 @@
+# A bare Pod - no spec.template - whose container exposes a hostPort. Used to
+# verify hostport_not_used inspects every workload kind (#2486).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hostport-pod
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostport-pod
+  namespace: hostport-pod
+  labels:
+    app: hostport-pod
+spec:
+  containers:
+  - name: hostport-pod
+    image: busybox:1.33.1
+    command: ["/bin/sleep", "2147483647"]
+    ports:
+    - containerPort: 8080
+      hostPort: 18080

--- a/sample-cnfs/sample-privileged-initcontainer/cnf-testsuite.yml
+++ b/sample-cnfs/sample-privileged-initcontainer/cnf-testsuite.yml
@@ -1,0 +1,6 @@
+---
+config_version: v2
+deployments:
+  manifests:
+  - name: privileged-init
+    manifest_directory: manifests

--- a/sample-cnfs/sample-privileged-initcontainer/manifests/manifest.yml
+++ b/sample-cnfs/sample-privileged-initcontainer/manifests/manifest.yml
@@ -1,0 +1,36 @@
+# A Deployment whose only privileged container is an initContainer. Used to
+# verify privileged_containers inspects init containers (#2486).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: privileged-init
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: privileged-init
+  namespace: privileged-init
+  labels:
+    app: privileged-init
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: privileged-init
+  template:
+    metadata:
+      labels:
+        app: privileged-init
+    spec:
+      initContainers:
+      - name: privileged-setup
+        image: busybox:1.33.1
+        command: ["/bin/true"]
+        securityContext:
+          privileged: true
+      containers:
+      - name: app
+        image: busybox:1.33.1
+        command: ["/bin/sleep", "2147483647"]

--- a/spec/utils/utils_spec.cr
+++ b/spec/utils/utils_spec.cr
@@ -84,19 +84,14 @@ describe "Utils" do
         white_list_container_names = config.common.white_list_container_names
         Log.info { "white_list_container_names #{white_list_container_names.inspect}" }
         violation_list = [] of String
-        resource_response = CNFManager.workload_resource_test(args, config) do |resource, container, initialized|
-          privileged_list = KubectlClient::Get.privileged_containers(all_namespaces: true).map { |container| container.dig("name") }.uniq
-          resource_containers = KubectlClient::Get.resource_containers(resource["kind"],resource["name"],resource["namespace"])
-          resource_containers_list = (JSON.parse(resource_containers.to_json).as_a).map { |element| element["name"] }
-          # Only check the containers that are in the deployed helm chart or manifest
-          (privileged_list & (resource_containers_list - white_list_container_names)).each do |x|
-            violation_list << x.as_s
+        resource_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, _, _|
+          # The resource's own containers, judged by their own securityContext.
+          KubectlClient::Get.resource_all_containers(resource["kind"], resource["name"], resource["namespace"]).each do |container|
+            container_name = container.dig?("name").try(&.as_s) || ""
+            next if white_list_container_names.includes?(container_name)
+            violation_list << container_name if container.dig?("securityContext", "privileged") == true
           end
-          if violation_list.size > 0
-            false
-          else
-            true
-          end
+          violation_list.empty?
         end
         Log.debug { "violator list: #{violation_list.flatten}" }
         emoji_security=""

--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -184,6 +184,21 @@ describe CnfTestSuite do
     end
   end
 
+  it "'hostport_not_used' should fail when a bare Pod uses a host port", tags: ["hostport_not_used"] do
+    begin
+      # A Pod has no spec.template; the check must still see its containers (#2486).
+      ShellCmd.cnf_install("--cnf-config sample-cnfs/sample-hostport-pod")
+      result = ShellCmd.run_testsuite("hostport_not_used")
+      result[:status].exit_code.should eq(1)
+      (/(FAILED).*(HostPort is being used)/ =~ result[:output]).should_not be_nil
+      (/impacted: Pod\/hostport-pod.*\(container hostport-pod\): using a HostPort/ =~ result[:output]).should_not be_nil
+      verify_task_result("hostport_not_used", "failed")
+    ensure
+      result = ShellCmd.cnf_uninstall()
+      result[:status].success?.should be_true
+    end
+  end
+
   it "'hostport_not_used' should pass when a node port is not being used", tags: ["hostport_not_used"] do
     begin
       ShellCmd.cnf_install("--cnf-config ./sample-cnfs/sample_coredns/cnf-testsuite.yml --skip-wait-for-install")

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -27,6 +27,21 @@ describe "Security" do
     end
   end
 
+  it "'privileged_containers' should fail on a privileged init container", tags: ["privileges"] do
+    begin
+      # Only the initContainer is privileged; the check must see it (#2486).
+      ShellCmd.cnf_install("--cnf-config ./sample-cnfs/sample-privileged-initcontainer/cnf-testsuite.yml")
+      result = ShellCmd.run_testsuite("privileged_containers")
+      result[:status].exit_code.should eq(1)
+      (/Found 1 privileged containers/ =~ result[:output]).should_not be_nil
+      (/impacted: .*\(container privileged-setup\): privileged container/ =~ result[:output]).should_not be_nil
+      verify_task_result("privileged_containers", "failed")
+    ensure
+      result = ShellCmd.cnf_uninstall()
+      result[:status].success?.should be_true
+    end
+  end
+
   it "'privileged_containers' should pass on a whitelisted, privileged cnf", tags: ["privileges"] do
     begin
       ShellCmd.cnf_install("--cnf-config ./sample-cnfs/sample_whitelisted_privileged_cnf/cnf-testsuite.yml --skip-wait-for-install")

--- a/src/modules/kubectl_client/modules/get.cr
+++ b/src/modules/kubectl_client/modules/get.cr
@@ -81,25 +81,6 @@ module KubectlClient
       "#{cmd} -o json"
     end
 
-    def self.privileged_containers(namespace : String? = nil, all_namespaces : Bool? = true) : Array(JSON::Any)
-      logger = @@logger.for("privileged_containers")
-      logger.debug { "Get privileged containers" }
-
-      pods = resource("pods", namespace: namespace, all_namespaces: all_namespaces).dig("items").as_a
-      privileged_containers = pods.map do |pod|
-        pod.dig("spec", "containers").as_a.map do |container|
-          if container.dig?("securityContext", "privileged") == true
-            container
-          else
-            nil
-          end
-        end.compact
-      end.flatten
-      logger.info { "Found #{privileged_containers.size} privileged containers" }
-
-      privileged_containers
-    end
-
     def self.resource_map(k8s_manifest, &)
       nodes = resource("nodes")
       if nodes["items"]?
@@ -379,6 +360,27 @@ module KubectlClient
       logger.info { "Matched #{matched_pods.size} pods: #{KubectlClient.names_from_json_array_to_s(matched_pods)}" }
 
       matched_pods
+    end
+
+    # Every container a workload resource declares - containers, initContainers
+    # and ephemeralContainers - from its pod spec (a Pod's own spec, or the
+    # template's for the kinds that carry one). Tests that judge containers
+    # read this so that none of them forgets a list.
+    def self.resource_all_containers(kind : String, resource_name : String, namespace : String? = nil) : Array(JSON::Any)
+      logger = @@logger.for("resource_all_containers")
+      logger.debug { "Get every container of #{kind}/#{resource_name}" }
+
+      pod_spec = case kind.downcase
+                 when "pod"
+                   resource(kind, resource_name, namespace).dig?("spec")
+                 when "deployment", "statefulset", "replicaset", "daemonset", "job"
+                   resource(kind, resource_name, namespace).dig?("spec", "template", "spec")
+                 end
+      return [] of JSON::Any if pod_spec.nil?
+
+      ["containers", "initContainers", "ephemeralContainers"].flat_map do |list|
+        pod_spec.dig?(list).try(&.as_a?) || [] of JSON::Any
+      end
     end
 
     def self.resource_containers(kind : String, resource_name : String, namespace : String? = nil) : JSON::Any

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -174,31 +174,19 @@ scored_task "hostport_not_used",
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     task_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, _, _|
       Log.for(t.name).info { "hostport_not_used resource: #{resource}" }
-      test_passed=true
-      Log.for(t.name).info { "resource kind: #{resource}" }
-      k8s_resource = KubectlClient::Get.resource(resource[:kind], resource[:name], resource[:namespace])
-      Log.for(t.name).debug { "resource: #{k8s_resource}" }
+      test_passed = true
 
-      # per examaple https://github.com/lfn-cnti/testsuite/issues/164#issuecomment-904890977
-      containers = k8s_resource.dig?("spec", "template", "spec", "containers")
-      Log.for(t.name).debug { "containers: #{containers}" }
-
-      containers && containers.as_a.each do |single_container|
-        ports = single_container.dig?("ports")
-
-        ports && ports.as_a.each do |single_port|
-          Log.for(t.name).debug { "single_port: #{single_port}" }
-          
+      # per example https://github.com/lfn-cnti/testsuite/issues/164#issuecomment-904890977
+      KubectlClient::Get.resource_all_containers(resource[:kind], resource[:name], resource[:namespace]).each do |single_container|
+        container_name = single_container.dig?("name").try(&.as_s) || ""
+        single_container.dig?("ports").try(&.as_a?).try &.each do |single_port|
           hostport = single_port.dig?("hostPort")
-
-          Log.for(t.name).debug { "DAS hostPort: #{hostport}" }
-
+          Log.for(t.name).debug { "container #{container_name} port #{single_port}: hostPort #{hostport}" }
           if hostport
-            result.add_impacted_resource(resource[:kind], resource[:name], resource[:namespace], reason: "using a HostPort")
-            test_passed=false
+            result.add_impacted_resource(resource[:kind], resource[:name], resource[:namespace], container: container_name, reason: "using a HostPort")
+            test_passed = false
           end
-
-        end 
+        end
       end
       test_passed
     end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -150,19 +150,19 @@ scored_task "privileged_containers",
     white_list_container_names = config.common.white_list_container_names
     Log.debug { "white_list_container_names #{white_list_container_names.inspect}" }
     violation_list = [] of NamedTuple(kind: String, name: String, container: String, namespace: String)
-    task_response = CNFManager.workload_resource_test(args, config) do |resource, container, _|
-      privileged_list = KubectlClient::Get.privileged_containers(all_namespaces: true).map { |container| container.dig("name") }.uniq
-      resource_containers = KubectlClient::Get.resource_containers(resource["kind"],resource["name"],resource["namespace"])
-      resource_containers_list = resource_containers.as_a.map { |element| element["name"] }
-      # Only check the containers that are in the deployed helm chart or manifest
-      (privileged_list & (resource_containers_list - white_list_container_names)).each do |container_name|
-        violation_list << {kind: resource["kind"], name: resource["name"], container: container_name.to_s, namespace: resource["namespace"]}
+    task_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, _, _|
+      # The resource's own containers - init and ephemeral ones included - judged
+      # by their own securityContext, never by a name shared with some privileged
+      # container elsewhere in the cluster.
+      resource_passed = true
+      KubectlClient::Get.resource_all_containers(resource["kind"], resource["name"], resource["namespace"]).each do |container|
+        container_name = container.dig?("name").try(&.as_s) || ""
+        next if white_list_container_names.includes?(container_name)
+        next unless container.dig?("securityContext", "privileged") == true
+        violation_list << {kind: resource["kind"], name: resource["name"], container: container_name, namespace: resource["namespace"]}
+        resource_passed = false
       end
-      if violation_list.size > 0
-        false
-      else
-        true
-      end
+      resource_passed
     end
     Log.debug { "violator list: #{violation_list.flatten}" }
     if task_response


### PR DESCRIPTION
Fixes #2486 and #2487.

Two essential tests enumerated containers their own way, and both ways had holes:

- `hostport_not_used` read `spec.template.spec.containers` only. A bare **Pod** has no `spec.template`, so it passed vacuously; **initContainers** were never looked at.
- `privileged_containers` collected the *names* of every privileged container in every namespace (`EXCLUDE_NAMESPACES` not applied — the suite's own `cluster-tools` DaemonSet is always in that set) and intersected them with the CNF's container names: identity by name, cluster-wide, and `spec.containers` only, so a privileged initContainer was invisible while a CNF container that merely shared a name with some privileged pod elsewhere was a false positive. It also re-listed every pod in the cluster once per CNF container.

### One enumeration for both

`KubectlClient::Get.resource_all_containers(kind, name, namespace)` returns every container a workload resource declares — `containers`, `initContainers`, `ephemeralContainers` — from its pod spec (a Pod's own, or the template's for the kinds that carry one). Both tests read it:

- `hostport_not_used` flags any of those containers with a `ports[].hostPort`, naming the container in `impacted_resources`.
- `privileged_containers` judges each of the resource's own containers by its **own** `securityContext.privileged`; the `white_list_container_names` allowlist keeps its meaning. No cluster-wide listing, no name matching.

### Verification

Two new fixtures with spec examples, each a case the old code passed: `sample-hostport-pod` (a bare Pod with a hostPort → **failed**, container named) and `sample-privileged-initcontainer` (only the initContainer is privileged → **failed**, `privileged-setup` named). The existing pass/fail/allowlist examples of both tests keep passing.

Run locally against a kind cluster with the CI compiler:

```
--tag hostport_not_used
  should fail when a host port is being used                 ✓
  should fail when a bare Pod uses a host port               ✓  (new; passed before)
  should pass when a node port is not being used             ✓
  3 examples, 0 failures

--tag privileges
  privileged_containers should pass with a non-privileged cnf        ✗  local only: the Bitnami wordpress
                                                                        chart's readiness never passes on my
                                                                        WSL cluster even at timeout=900, so
                                                                        cnf_install fails before the test runs;
                                                                        green on every recent main run in CI
  privileged_containers should fail on a non-whitelisted, privileged cnf   ✓
  privileged_containers should fail on a privileged init container         ✓  (new; passed before)
  privileged_containers should pass on a whitelisted, privileged cnf       ✓
  privilege_escalation should fail / should pass                           ✓ ✓
```

The rewritten `privileged_containers` was also run by hand against that wordpress+mariadb CNF (a Deployment plus a StatefulSet) and passed. `KubectlClient::Get.privileged_containers` — the cluster-wide, by-name helper — had no callers left and is removed; the `single_task_runner` spec that exercised it now uses the same enumeration as the test. Whole spec suite compile-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
