### PR TITLE
log_output: read every pod, and report what cannot be read instead of crashing

### DIFF
--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -813,7 +813,7 @@ All observability: `./cnf-testsuite observability`
 
 #### Overview
 
-This checks and verifies that STDOUT/STDERR logging is configured for the CNF.
+This checks and verifies that STDOUT/STDERR logging is configured for the CNF. The last log lines of every pod of each workload resource are read; a resource passes when any of its pods has written to stdout/stderr. Pods whose logs cannot be read yet (not scheduled, container still starting) are reported and left out of the verdict; the test is skipped when no pod could be read.
 Expectation: Resource output logs should be sent to STDOUT/STDERR
 
 #### Rationale

--- a/sample-cnfs/sample-unpullable-image/cnf-testsuite.yml
+++ b/sample-cnfs/sample-unpullable-image/cnf-testsuite.yml
@@ -1,0 +1,6 @@
+---
+config_version: v2
+deployments:
+  manifests:
+  - name: unpullable-image
+    manifest_directory: manifests

--- a/sample-cnfs/sample-unpullable-image/manifests/manifest.yml
+++ b/sample-cnfs/sample-unpullable-image/manifests/manifest.yml
@@ -1,0 +1,33 @@
+# A Deployment whose image can never be pulled: the pod is scheduled and
+# Running-phase-bound but its container waits forever, so `kubectl logs`
+# errors ("is waiting to start"). Install it with skip-wait-for-install;
+# used to verify that tests reading pod logs report the pod instead of
+# crashing on the error (#2488).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: unpullable-image
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unpullable-image
+  namespace: unpullable-image
+  labels:
+    app: unpullable-image
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: unpullable-image
+  template:
+    metadata:
+      labels:
+        app: unpullable-image
+    spec:
+      containers:
+      - name: app
+        image: busybox:no-such-tag-cnti-testsuite
+        command: ["/bin/sleep", "2147483647"]

--- a/sample-cnfs/sample-unschedulable/cnf-testsuite.yml
+++ b/sample-cnfs/sample-unschedulable/cnf-testsuite.yml
@@ -1,0 +1,6 @@
+---
+config_version: v2
+deployments:
+  manifests:
+  - name: unschedulable
+    manifest_directory: manifests

--- a/sample-cnfs/sample-unschedulable/manifests/manifest.yml
+++ b/sample-cnfs/sample-unschedulable/manifests/manifest.yml
@@ -1,0 +1,34 @@
+# A Deployment whose pod can never be scheduled (no node carries the
+# selector label), so its logs can never be read. Install it with
+# skip-wait-for-install; used to verify that tests reading pod logs report
+# an unreadable pod instead of crashing (#2488).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: unschedulable
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: unschedulable
+  namespace: unschedulable
+  labels:
+    app: unschedulable
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: unschedulable
+  template:
+    metadata:
+      labels:
+        app: unschedulable
+    spec:
+      nodeSelector:
+        cnti.testsuite/no-such-node: "true"
+      containers:
+      - name: app
+        image: busybox:1.33.1
+        command: ["/bin/sleep", "2147483647"]

--- a/spec/workload/observability_spec.cr
+++ b/spec/workload/observability_spec.cr
@@ -33,6 +33,39 @@ describe "Observability" do
     end
   end
 
+  it "'log_output' should be skipped when no pod is running yet", tags: ["observability_log_output"] do
+    begin
+      # A pod that never schedules has nothing to log; kubectl returns no
+      # output and no error for it, which used to count as "quiet" (#2488).
+      ShellCmd.cnf_install("--cnf-config sample-cnfs/sample-unschedulable --skip-wait-for-install")
+      result = ShellCmd.run_testsuite("log_output")
+      result[:status].success?.should be_true
+      (/(SKIPPED).*(Log output not checked)/ =~ result[:output]).should_not be_nil
+      result[:output].should contain("Logs could not be read: Deployment/unschedulable")
+      result[:output].should contain("pod is Pending")
+      verify_task_result("log_output", "skipped")
+    ensure
+      result = ShellCmd.cnf_uninstall()
+      result[:status].success?.should be_true
+    end
+  end
+
+  it "'log_output' should be skipped, not crash, when a pod's logs cannot be read", tags: ["observability_log_output"] do
+    begin
+      # The image can never be pulled, so `kubectl logs` errors; that used to
+      # be an unhandled exception (exit 2) rather than a verdict (#2488).
+      ShellCmd.cnf_install("--cnf-config sample-cnfs/sample-unpullable-image --skip-wait-for-install")
+      result = ShellCmd.run_testsuite("log_output")
+      result[:status].success?.should be_true
+      (/(SKIPPED).*(Log output not checked)/ =~ result[:output]).should_not be_nil
+      result[:output].should contain("Logs could not be read: Deployment/unpullable-image")
+      verify_task_result("log_output", "skipped")
+    ensure
+      result = ShellCmd.cnf_uninstall()
+      result[:status].success?.should be_true
+    end
+  end
+
   it "'prometheus_traffic' should pass if there is prometheus traffic", tags: ["observability_prometheus_traffic"] do
     ShellCmd.cnf_install("--cnf-config sample-cnfs/sample-prom-pod-discovery/cnf-testsuite.yml")
     helm = Helm::Binary.get

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -16,18 +16,55 @@ scored_task "log_output",
   type: CNFManager::TestType::Essential,
   emoji: "📶☠️" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
+    # Pods whose logs could not be read (not scheduled, container still
+    # creating, ...) are reported, never judged.
+    unreadable = [] of String
+    judged_any = false
+
     task_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, _, _|
-      test_passed = false
+      resource_yaml = KubectlClient::Get.resource(resource[:kind], resource[:name], resource[:namespace])
+      pods = KubectlClient::Get.pods_by_resource_labels(resource_yaml, resource[:namespace])
 
-      log_result = KubectlClient::Utils.logs("#{resource["kind"]}/#{resource["name"]}", namespace: resource[:namespace], options: "--all-containers --tail=5 --prefix=true")
-      Log.for("Log lines").info { log_result[:output] }
-      if log_result[:output].size > 0
-        test_passed = true
-       end
+      # Every pod of the resource is read - `kubectl logs <kind>/<name>` would
+      # sample just one - and the resource logs if any of them does.
+      logging = [] of String
+      quiet = [] of String
+      pods.each do |pod|
+        pod_name = pod.dig("metadata", "name").as_s
+        # A pod that is not running has nothing to say yet; kubectl prints no
+        # logs and no error for one that was never scheduled.
+        phase = pod.dig?("status", "phase").try(&.as_s) || "Unknown"
+        unless phase == "Running"
+          unreadable << "#{resource[:kind]}/#{resource[:name]} pod #{pod_name}: pod is #{phase}"
+          next
+        end
+        begin
+          log_result = KubectlClient::Utils.logs("pod/#{pod_name}", namespace: resource[:namespace], options: "--all-containers --tail=5 --prefix=true")
+          Log.for(t.name).info { "#{pod_name} log lines: #{log_result[:output]}" }
+          (log_result[:output].strip.empty? ? quiet : logging) << pod_name
+        rescue ex : KubectlClient::ShellCMD::NetworkError
+          raise ex
+        rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
+          unreadable << "#{resource[:kind]}/#{resource[:name]} pod #{pod_name}: #{ex.message.to_s.lines.first?.to_s.strip}"
+        end
+      end
 
-      test_passed
+      # Nothing readable: this resource is not judged.
+      next true if logging.empty? && quiet.empty?
+      judged_any = true
+
+      if logging.empty?
+        quiet.each { |pod_name| result.add_impacted_resource("Pod", pod_name, resource[:namespace], reason: "no log output on stdout/stderr") }
+        false
+      else
+        true
+      end
     end
-    if task_response 
+
+    unreadable.each { |line| result.append_description("Logs could not be read: #{line}") }
+    if !judged_any
+      result.skipped("Log output not checked: no pod's logs could be read")
+    elsif task_response
       result.passed("Resources output logs to stdout and stderr")
     else
       result.failed("Resources do not output logs to stdout and stderr")


### PR DESCRIPTION
Fixes #2488.

`log_output` (essential) ran `kubectl logs <kind>/<name> --all-containers --tail=5` once per workload resource and passed on any output. Two problems:

- `kubectl logs deployment/x` reads **one** pod (kubectl picks the first), so a resource whose first pod was quiet failed even if its other pods logged, and vice versa.
- The call went through `raise_exc_on_error`, so a pod that was `Pending`, `ContainerCreating` or gone made the test **crash** (unhandled exception, exit 2) instead of reaching a verdict.

### Now

Every pod of each resource (via `pods_by_resource_labels`) is read with `kubectl logs pod/<name> --all-containers --tail=5`; a resource logs when **any** of its pods has written to stdout/stderr, and the quiet pods of a failing resource are named in `impacted_resources`. A pod that is not `Running` (never scheduled, still creating, pulling an image) has nothing to say yet — kubectl returns empty output and *no error* for an unscheduled pod, which would otherwise read as "quiet" — and a pod whose logs `kubectl` cannot read are both reported in the result details ("Logs could not be read: …") and left out of the verdict; a resource with nothing readable is not judged, and a CNF where no pod at all could be read is `skipped`, not failed and not crashed. Network errors still propagate — those are the suite's problem, not the CNF's.

### Verification

Two new fixtures, each installed with `skip_wait_for_install`, each with a spec example expecting **skipped** with the pod named: `sample-unschedulable` (a nodeSelector no node carries → `Pending` forever; previously judged *quiet* and failed) and `sample-unpullable-image` (an image tag that does not exist → the container waits forever and `kubectl logs` errors; previously exit 2). Plus the two existing examples (coredns logs → passed; `sample_no_logs` → failed).

Run locally against a kind cluster with the CI compiler:

```
'log_output' should pass with a cnf that outputs logs to stdout                    ✓
'log_output' should fail with a cnf that does not output logs to stdout            ✓
'log_output' should be skipped when no pod is running yet                          ✓  (new; was judged quiet → failed)
'log_output' should be skipped, not crash, when a pod's logs cannot be read        ✓  (new; was exit 2)
4 examples, 0 failures
```

Both fixtures declare their own namespace, labelled `pod-security.kubernetes.io/enforce: privileged` like the other manifest fixtures, so CI's cluster-wide restricted profile admits them.

`docs/TEST_DOCUMENTATION.md` describes the per-pod rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
