### PR TITLE
hardcoded_ip_addresses: let errors be errors, drop a dead namespace deletion

### DIFF
--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -213,8 +213,7 @@ end
 desc "Does the CNF have hardcoded IPs in the K8s resource configuration"
 scored_task "hardcoded_ip_addresses_in_k8s_runtime_configuration",
   type: CNFManager::TestType::Essential do |t, args|
-  task_response = CNFManager::Task.task_runner(args, task: t) do |args, config, result|
-    current_dir = FileUtils.pwd
+  CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     allowed_ip_addresses = [
       "127.0.0.1",
       "0.0.0.0"
@@ -249,10 +248,6 @@ scored_task "hardcoded_ip_addresses_in_k8s_runtime_configuration",
       end
       result.failed("Hard-coded IP addresses found in the runtime K8s configuration")
     end
-  rescue
-    result.skipped("unknown exception")
-  ensure
-    KubectlClient::Delete.resource("namespace", "hardcoded-ip-test", extra_opts: "--force --grace-period 0")
   end
 end
 


### PR DESCRIPTION
Fixes #2490.

`hardcoded_ip_addresses_in_k8s_runtime_configuration` wrapped its body in a bare `rescue` that reported **any** failure — a missing composite manifest, an encoding error, a bug — as `skipped("unknown exception")`, so breakage of an essential test looked benign. The task runner already records an uncaught exception as `error` with exit 2, which is the honest verdict; the rescue is removed so it gets to.

Its `ensure` force-deleted a namespace `hardcoded-ip-test` that nothing in the repository creates (a leftover from an older design of the test), running a pointless `kubectl delete --force --grace-period 0` on every run; gone as well, along with an unused `current_dir`.

Both `hardcoded_ip_addresses…` spec examples (a CNF with hard-coded IPs → failed, a clean one → passed) run locally against a kind cluster with the CI compiler: 2 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
