### PR TITLE
specialized_init_system: match the init binary by name, and know docker-init

### DIFF
--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -402,7 +402,7 @@ Make sure that your CNFs containers are not sharing the same [database](https://
 
 #### Overview
 
-This tests if containers in pods have dumb-init, tini or s6-overlay as init processes.
+This tests if containers in pods use a specialized init system as their PID 1 process: tini (including tini-static and docker-init), dumb-init, or s6-overlay (whose PID 1 is s6-svscan). The check is on the executable's name, not on any part of its path.
 Expectation: Container images should use specialized init systems for containers.
 
 #### Rationale

--- a/src/tasks/constants.cr
+++ b/src/tasks/constants.cr
@@ -21,7 +21,10 @@ SONOBUOY_K8S_VERSION = "0.57.5"
 IGNORED_SECRET_TYPES = ["kubernetes.io/service-account-token", "kubernetes.io/dockercfg", "kubernetes.io/dockerconfigjson", "helm.sh/release.v1"]
 EMPTY_JSON = JSON.parse(%({}))
 EMPTY_JSON_ARRAY = JSON.parse(%([]))
-SPECIALIZED_INIT_SYSTEMS = ["tini", "dumb-init", "s6-svscan"]
+# Matched against the basename of a container's PID 1 executable: tini (also
+# as tini-static, and as docker-init, the copy Docker ships), dumb-init, and
+# s6-svscan (PID 1 once s6-overlay's /init has handed over).
+SPECIALIZED_INIT_SYSTEMS = ["tini", "tini-static", "docker-init", "dumb-init", "s6-svscan"]
 ROLLING_VERSION_CHANGE_TEST_NAMES = ["rolling_update", "rolling_downgrade", "rolling_version_change"]
 WORKLOAD_RESOURCE_KIND_NAMES = ["replicaset", "deployment", "statefulset", "pod", "daemonset"]
 

--- a/src/tasks/utils/init_systems.cr
+++ b/src/tasks/utils/init_systems.cr
@@ -17,12 +17,9 @@ module InitSystems
     end
   end
   
+  # By the executable's basename: a path that merely contains "tini" is not tini.
   def self.is_specialized_init_system?(cmd : String) : Bool
-    SPECIALIZED_INIT_SYSTEMS.each do |init_system|
-      return true if cmd.includes?(init_system)
-    end
-    # No specialized init system found
-    return false
+    SPECIALIZED_INIT_SYSTEMS.includes?(File.basename(cmd))
   end
 
   def self.scan(pod : JSON::Any) : Array(InitSystemInfo) | Nil


### PR DESCRIPTION
Fixes #2493.

`InitSystems.is_specialized_init_system?` decided by substring — `cmd.includes?("tini")` — so any PID 1 whose *path* merely contained `tini` passed, and the list (`tini`, `dumb-init`, `s6-svscan`) missed the entrypoints in real use: `docker-init` (the tini copy Docker ships and that many images exec) and `tini-static`. The match is now on the executable's basename against an explicit list — `tini`, `tini-static`, `docker-init`, `dumb-init`, `s6-svscan` (what s6-overlay's `/init` hands over to as PID 1). `single_process_type`, which already compared process names against the same list, benefits from the two additions unchanged.

`docs/TEST_DOCUMENTATION.md` names the list and the rule. Both `specialized_init_system` spec examples (coredns → failed; `sample-init-systems` → passed) run locally with the CI compiler: 2 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
