### PR TITLE
specialized_init_system: inspect and report every pod, not just the first failing one

### DIFF
--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -834,7 +834,8 @@ scored_task "specialized_init_system",
 
       resources_checked = true
 
-      pods.all? do |pod|
+      # Every pod is inspected and reported; the verdict comes afterwards.
+      pods.map do |pod|
         pod_name = pod.dig("metadata", "name").as_s
         Log.for(t.name).info { "Inspecting pod #{pod_name}" }
 
@@ -859,7 +860,7 @@ scored_task "specialized_init_system",
 
         # mark this resource as failing
         next false
-      end
+      end.all?(true)
     end
 
     if error_occurred


### PR DESCRIPTION
Part of #2492 (the `specialized_init_system` half; `sig_term_handled` follows once #2495 has merged, since it rewrites the same block).

`specialized_init_system` iterated pods with `pods.all? do … end`, which stops at the first pod that fails, so the remaining pods were neither inspected nor reported and `impacted_resources` named only the first offender — a CNF with several non-compliant containers found them one fix at a time. Every pod is now inspected and reported, and the verdict is taken afterwards (`map` then `all?`); the skip/error semantics are unchanged.

Both `specialized_init_system` spec examples run locally with the CI compiler: 2 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
