### PR TITLE
selinux_options: a CNF that sets no seLinuxOptions passes

### DIFF
--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -369,12 +369,12 @@ describe "Security" do
     end
   end
 
-  it "'selinux_options' should be skipped if containers do not use custom selinux options", tags: ["selinux_options"] do
+  it "'selinux_options' should pass if containers do not set selinux options at all", tags: ["selinux_options"] do
     begin
       ShellCmd.cnf_install("cnf-config=./sample-cnfs/sample_nonroot")
       result = ShellCmd.run_testsuite("selinux_options")
       result[:status].success?.should be_true
-      (/(N\/A).*(Pods are not using SELinux)/ =~ result[:output]).should_not be_nil
+      (/(PASSED).*(Pods do not set seLinuxOptions)/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
     end

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -98,7 +98,9 @@ scored_task "selinux_options",
     check_failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, check_failures)
 
     if check_failures.size == 0
-      result.na("Pods are not using SELinux")
+      # No seLinuxOptions at all: nothing escalatory is configured, which is
+      # exactly what certification asks for.
+      result.passed("Pods do not set seLinuxOptions")
     else
       failures = Kyverno.filter_failures_for_cnf_resources(resource_keys, disallow_failures)
 


### PR DESCRIPTION
Fixes #2491.

`selinux_options` is an *essential* test that returned `na` whenever no pod set `seLinuxOptions` — nearly every CNF — so it contributed a pass to almost no certification run, and the 15-of-19 threshold was quietly absorbing a test that is usually not applicable.

The certification claim is "no escalatory SELinux options". A CNF that sets no `seLinuxOptions` at all satisfies it and now **passes** ("Pods do not set seLinuxOptions"); a CNF that sets them is judged by the `disallow-selinux` policy exactly as before (safe options → passed, escalatory ones → failed). The test stays essential and stops being N/A by default.

If the maintainers would rather demote the test to normal than make absence a pass, that is the alternative from #2491 — this PR takes the reading that keeps the check in certification.

The three `selinux_options` spec examples (escalatory → failed; none set → now **passed**; safe options → passed) run locally with the CI compiler: 3 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
