### PR TITLE
node_drain: target the workload by its whole selector

### DIFF
--- a/src/tasks/utils/chaos_templates.cr
+++ b/src/tasks/utils/chaos_templates.cr
@@ -112,8 +112,7 @@ class ChaosTemplates
       @test_name : String,
       @chaos_experiment_name : String,
       @app_namespace : String,
-      @deployment_label : String,
-      @deployment_label_value : String,
+      @app_label : String,
       @app_nodename : String,
       @total_chaos_duration : String = "#{NODE_DRAIN_TOTAL_CHAOS_DURATION}"
     )

--- a/src/tasks/utils/litmus_manager.cr
+++ b/src/tasks/utils/litmus_manager.cr
@@ -32,8 +32,9 @@ module LitmusManager
 
   # Node the workload identified by `deployment_label=deployment_value` sits on,
   # or nil when it has no pod scheduled anywhere.
-  def self.get_workload_node_name(deployment_label, deployment_value, namespace) : String?
-    scheduled_pod_node_name(namespace, "#{deployment_label}=#{deployment_value}")
+  # Node of the workload matching `selector` (a `k=v[,k=v...]` label selector).
+  def self.get_workload_node_name(selector : String, namespace) : String?
+    scheduled_pod_node_name(namespace, selector)
   end
 
   # Node the Litmus operator sits on, or nil when it is not scheduled anywhere.

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -228,8 +228,9 @@ scored_task "node_drain",
         test_passed = false
       else
         schedulable_nodes = KubectlClient::Get.schedulable_nodes_list
-        deployment_label = "#{spec_labels.as_h.first_key}"
-        deployment_label_value = "#{spec_labels.as_h.first_value}"
+        # The whole selector: one label of a multi-label selector (every Helm
+        # chart's) also matches other releases of the same chart.
+        app_label = spec_labels.as_h.map { |key, value| "#{key}=#{value}" }.join(",")
 
         # Declare this outside the block so that the name of the node can be used to uncordon later.
         cordon_target_node_name = nil
@@ -241,14 +242,14 @@ scored_task "node_drain",
           # test are still listed by kubectl, so the first answer could name a node the
           # workload had already left, and the run would cordon one node while draining
           # another.
-          app_node_name = LitmusManager.get_workload_node_name(deployment_label, deployment_label_value, namespace: app_namespace)
+          app_node_name = LitmusManager.get_workload_node_name(app_label, namespace: app_namespace)
 
           if schedulable_nodes.size <= 1
             skip_reason = "node_drain chaos test requires the cluster to have atleast two schedulable nodes"
           elsif app_node_name.nil?
-            skip_reason = "node_drain chaos test found no scheduled pod for #{deployment_label}=#{deployment_label_value} in the #{app_namespace} namespace"
+            skip_reason = "node_drain chaos test found no scheduled pod for #{app_label} in the #{app_namespace} namespace"
           else
-            Log.info { "Found node to cordon #{app_node_name} using label #{deployment_label}='#{deployment_label_value}' in #{app_namespace} namespace." }
+            Log.info { "Found node to cordon #{app_node_name} using selector #{app_label} in #{app_namespace} namespace." }
 
             # Record the cordon target before cordoning, so the ensure block below
             # releases the node even if the cordon only partly took effect.
@@ -306,11 +307,10 @@ scored_task "node_drain",
               test_name,
               "#{chaos_experiment_name}",
               app_namespace,
-              "#{deployment_label}",
-              "#{deployment_label_value}",
+              app_label,
               app_node_name
             ).to_s
-            Log.for("node_drain").info { "Chaos test name: #{test_name}; Experiment name: #{chaos_experiment_name}; Label #{deployment_label}=#{deployment_label_value}; namespace: #{app_namespace}" }
+            Log.for("node_drain").info { "Chaos test name: #{test_name}; Experiment name: #{chaos_experiment_name}; Selector #{app_label}; namespace: #{app_namespace}" }
             chaos_template_path = File.join(CNF_TEMP_FILES_DIR, "#{chaos_experiment_name}-chaosengine.yml")
             File.write(chaos_template_path, template)
             KubectlClient::Apply.file(chaos_template_path)

--- a/src/templates/chaos_templates/node_drain.yml.ecr
+++ b/src/templates/chaos_templates/node_drain.yml.ecr
@@ -6,7 +6,7 @@ metadata:
 spec:
   appinfo:
     appns: '<%= @app_namespace %>'
-    applabel: '<%= @deployment_label %>=<%= @deployment_label_value %>'
+    applabel: '<%= @app_label %>'
     appkind: 'deployment'
   # It can be delete/retain
   jobCleanUpPolicy: 'delete'


### PR DESCRIPTION
Fixes #2489.

`node_drain` picked **one** label out of the resource's `spec.selector.matchLabels` — whichever the map yielded first — and used it both to find the workload's node and as the Litmus `applabel`. Every Helm-generated workload selects on several labels (`app.kubernetes.io/name` plus `app.kubernetes.io/instance` at least), so one label alone can match other releases of the same chart in the namespace: the node to drain could come from a pod that is not this resource's, and the chaos experiment could observe pods that are not either.

The whole selector is now used, as the `k=v,k=v` label selector both `kubectl` and Litmus's `appinfo.applabel` accept: `get_workload_node_name` takes the selector string, and `ChaosTemplates::NodeDrain` renders it into the ChaosEngine unchanged.

The `node_drain` spec (coredns drained and rescheduled on a three-node kind cluster) run locally with the CI compiler: 1 example, 0 failures — the coredns chart's selector has several labels, and Litmus's `appinfo.applabel` accepted the comma-joined form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
