### PR TITLE
sig_term_handled: judge and report every pod and container (#2492, on top of #2495)

### DIFF
--- a/sample-cnfs/sample-sigterm-ignored-twice/cnf-testsuite.yml
+++ b/sample-cnfs/sample-sigterm-ignored-twice/cnf-testsuite.yml
@@ -1,0 +1,6 @@
+---
+config_version: v2
+deployments:
+  manifests:
+  - name: sigterm-ignored-twice
+    manifest_directory: manifests

--- a/sample-cnfs/sample-sigterm-ignored-twice/manifests/manifest.yml
+++ b/sample-cnfs/sample-sigterm-ignored-twice/manifests/manifest.yml
@@ -1,0 +1,35 @@
+# Two containers in one pod, both with a PID 1 (`sleep`) that ignores
+# SIGTERM. Used to verify that sig_term_handled judges and reports every
+# container rather than stopping at the first one that fails (#2492).
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sigterm-ignored-twice
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sigterm-ignored-twice
+  namespace: sigterm-ignored-twice
+  labels:
+    app: sigterm-ignored-twice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sigterm-ignored-twice
+  template:
+    metadata:
+      labels:
+        app: sigterm-ignored-twice
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: first
+        image: busybox:1.33.1
+        command: ["/bin/sleep", "2147483647"]
+      - name: second
+        image: busybox:1.33.1
+        command: ["/bin/sleep", "2147483647"]

--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -320,6 +320,21 @@ describe "Microservice" do
     end
   end
 
+  it "'sig_term_handled' should report every container that fails, not just the first", tags: ["sig_term"] do
+    begin
+      ShellCmd.cnf_install("--cnf-config ./sample-cnfs/sample-sigterm-ignored-twice/")
+      result = ShellCmd.run_testsuite("sig_term_handled")
+      result[:status].exit_code.should eq(1)
+      (/(FAILED).*(Sig Term not handled)/ =~ result[:output]).should_not be_nil
+      (/impacted: .*\(container first\)/ =~ result[:output]).should_not be_nil
+      (/impacted: .*\(container second\)/ =~ result[:output]).should_not be_nil
+      verify_task_result("sig_term_handled", "failed")
+    ensure
+      result = ShellCmd.cnf_uninstall()
+      result[:status].success?.should be_true
+    end
+  end
+
   it "'sig_term_handled' should pass if SIGTERM is passed through to child processes by a supervisor (tini)", tags: ["sig_term"]  do
     begin
       #todo 1. Watch for signals for the containers pid one process, and the tree of all child processes ity manages

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -647,8 +647,9 @@ scored_task "sig_term_handled",
         next false
       end
 
-      # For each pod, do the main SIGTERM check
-      pods.all? do |pod|
+      # Every pod and every container is judged and reported; the verdicts are
+      # combined afterwards, so one run shows the whole picture.
+      pods.map do |pod|
         pod_name      = pod.dig("metadata", "name").as_s
         pod_namespace = pod.dig("metadata", "namespace").as_s
 
@@ -669,7 +670,7 @@ scored_task "sig_term_handled",
         grace_seconds = pod.dig?("spec", "terminationGracePeriodSeconds").try(&.as_i) || 30
         grace_seconds = {grace_seconds, GENERIC_OPERATION_TIMEOUT}.min
 
-        pod_passed = status["containerStatuses"].as_a.all? do |c_stat|
+        pod_passed = status["containerStatuses"].as_a.map do |c_stat|
           c_name = c_stat["name"].as_s
           skip = ->(reason : String) do
             logger.info { "Skipping #{pod_name}/#{c_name}: #{reason}" }
@@ -747,14 +748,14 @@ scored_task "sig_term_handled",
             }
             false
           end
-        end
+        end.all?
 
         #put tested pod ID into checking list
         tested_pods << pod_unique_id
 
         #return bool
         pod_passed
-      end
+      end.all?
     end
 
     skipped_containers.each do |info|


### PR DESCRIPTION
Completes #2492 (the `sig_term_handled` half; #2503 did `specialized_init_system`). **Stacked on #2495** — merge that first.

`sig_term_handled` iterated pods with `pods.all?` and containers with `containerStatuses.all?`. Both stop at the first `false`, so once one container failed, the remaining containers of that pod and the remaining pods of the resource were neither judged nor reported: `impacted_resources` named a single offender and a CNF with several non-handling containers discovered them one fix at a time — and, since every judged container gets a SIGTERM, the untested ones also escaped the probe entirely.

Every pod and every container is now judged (`map`, then `all?`), so one run reports the whole picture. The per-container verdict, the skip semantics and the SIGKILL-after-grace behavior from #2495 are unchanged.

The full `sig_term` shard run locally with the CI compiler: 

```
'sig_term_handled' should pass if SIGTERM are handeled by child processes                               ✓
'sig_term_handled' should fail if SIGTERM isn't handled by child processes                              ✓
'sig_term_handled' should fail if PID 1 ignores SIGTERM and keeps running                               ✓
'sig_term_handled' should report every container that fails, not just the first     (new)              ✓
'sig_term_handled' should pass if SIGTERM is passed through to child processes by a supervisor (tini)   ✓
5 examples, 0 failures
```

The new fixture `sample-sigterm-ignored-twice` runs two SIGTERM-ignoring containers in one pod; the example asserts both `first` and `second` appear in `impacted_resources` — before this change only `first` did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
