### PR TITLE
Every failed test carries a remediation: the documented one by default

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -242,7 +242,7 @@ Certification: PASSED (17 of 19 essential tests passed, threshold 15)
 | `start_time` / `end_time` | RFC 3339 timestamps for the test's start and end. |
 | `task_runtime` | Test duration in seconds (number). |
 | `details` | *(optional)* Free-form reason/evidence strings; omitted when empty. |
-| `remediation` | *(optional)* Guidance on how to fix the failure; omitted when empty. |
+| `remediation` | *(optional)* Guidance on how to fix the failure; omitted when empty. A failed test that provides none of its own carries the *Remediation* section of its entry in [TEST_DOCUMENTATION](docs/TEST_DOCUMENTATION.md). |
 | `impacted_resources` | *(optional)* Structured list of offending resources; omitted when empty. |
 
 Each `impacted_resources` entry has `kind` and `name`, plus optional `namespace`, `container`, `pod`, and `reason` (present only when known).

--- a/spec/utils/doc_remediation_spec.cr
+++ b/spec/utils/doc_remediation_spec.cr
@@ -1,0 +1,19 @@
+require "../spec_helper"
+require "../../src/tasks/**"
+
+# In-process: the documentation's Remediation sections are the fallback for
+# every failed test, so every essential test must have one, and the lookup
+# must resolve namespaced usage lines to bare task names.
+describe "DocRemediation" do
+  it "documents a remediation for every essential test", tags: ["points"] do
+    essentials = CNFManager::TestRegistry.all.select { |_, m| m.type.essential? }.keys
+    essentials.size.should be >= 19
+    missing = essentials.reject { |name| DocRemediation.for(name) }
+    missing.should eq([] of String)
+
+    DocRemediation.for("liveness").not_nil!.should contain("Liveness Probe")
+    # Usage lines are namespaced for platform tests; the lookup is by task name.
+    DocRemediation.for("platform:node_drain").should eq(DocRemediation.for("node_drain"))
+    DocRemediation.for("no_such_test").should be_nil
+  end
+end

--- a/src/tasks/utils/cnf_manager/task.cr
+++ b/src/tasks/utils/cnf_manager/task.cr
@@ -93,6 +93,13 @@ module CNFManager
         end
       ensure
         result.set_end_time()
+        # A failure that brought no remediation of its own gets the one the
+        # test documentation gives, so every failed item says what to do.
+        if result.status.failed? && result.result_remediation.empty?
+          if remedy = DocRemediation.for(result.testcase)
+            result.append_remediation(remedy)
+          end
+        end
         # Recording the result is what drives the run's exit code: the summary
         # (recomputed on every upsert) derives it from the item outcomes.
         upsert_decorated_task(result)

--- a/src/tasks/utils/doc_remediation.cr
+++ b/src/tasks/utils/doc_remediation.cr
@@ -1,0 +1,37 @@
+require "./embedded_file_manager"
+
+EmbeddedFileManager.test_documentation
+
+# The Remediation sections of docs/TEST_DOCUMENTATION.md, keyed by test name,
+# read from the copy of the document built into the binary. A test that fails
+# without appending a remediation of its own is given this one by the task
+# runner, so the results file always says what to do about a failure - and
+# the documentation stays the single place that says it.
+module DocRemediation
+  @@by_test : Hash(String, String)? = nil
+
+  # The documented remediation for `task_name` (a bare task name; namespaced
+  # usage lines like `platform:cluster_admin` are keyed by their last segment),
+  # or nil when the documentation has none.
+  def self.for(task_name : String) : String?
+    by_test[task_name.rpartition(":")[2]]?
+  end
+
+  def self.by_test : Hash(String, String)
+    @@by_test ||= parse(TEST_DOCUMENTATION_MD)
+  end
+
+  # Each "### Test" section carries "#### Remediation" (one paragraph) and
+  # "#### Usage" with the `./cnf-testsuite <task>` line(s) that name the test.
+  def self.parse(markdown : String) : Hash(String, String)
+    mapping = {} of String => String
+    markdown.split(/\n(?=### )/).each do |section|
+      remedy = section.match(/#### Remediation\n\n(.+?)\n\n#### /m).try(&.[1].strip)
+      next unless remedy
+      section.scan(/`\.\/cnf-testsuite ([a-z0-9_:]+)`/) do |usage|
+        mapping[usage[1].rpartition(":")[2]] = remedy
+      end
+    end
+    mapping
+  end
+end

--- a/src/tasks/utils/embedded_file_manager.cr
+++ b/src/tasks/utils/embedded_file_manager.cr
@@ -28,6 +28,9 @@ module EmbeddedFileManager
   macro disable_cni
     DISABLE_CNI = Base64.decode_string("{{ `cat ./embedded_files/kind-disable-cni.yaml  | base64`}}")
   end
+  macro test_documentation
+    TEST_DOCUMENTATION_MD = Base64.decode_string("{{ `cat ./docs/TEST_DOCUMENTATION.md | base64`}}")
+  end
   macro fluentd_values
     FLUENTD_VALUES = Base64.decode_string("{{ `cat ./embedded_files/fluentd-values.yml  | base64`}}")
   end


### PR DESCRIPTION
First item of the diagnostics plan for the essential tests (X1).

Only five of the nineteen essential tests append any remediation to their result — the four Kubescape-based ones (from the control's text) and `increase_decrease_capacity`. Yet `docs/TEST_DOCUMENTATION.md` already has a *Remediation* section for every one of them (75 tests in all). The two were never connected.

Now they are: the documentation is built into the binary (the same `EmbeddedFileManager` mechanism as the chaos and policy manifests), `DocRemediation` parses its Remediation sections once, keyed by the test named in each section's `./cnf-testsuite <task>` usage line, and the task runner attaches the documented remediation to any test that **fails without appending one of its own**. Tests that do append their own (Kubescape's per-control text, the capacity test's) keep theirs. Passes, skips and errors are untouched.

So a failing `liveness`, `sig_term_handled`, `latest_tag`, … now carries `remediation` in the results file and prints `> remediation: …` on stdout — fourteen essential tests improve without touching any of them, and the documentation stays the single place that says what to do.

### Verification

- Guard spec (in-process): every essential test in the registry has a documented remediation; namespaced usage lines (`platform:…`) resolve by task name; unknown names give nil.
- Live, on a kind cluster with the CI compiler: coredns installed, `specialized_init_system` run (it fails on coredns and appends no remediation of its own):

```
FAILED: [specialized_init_system] Containers do not use specialized init systems
   > remediation: Use init systems that are purpose-built for containers like tini, dumb-init, s6-overlay.
```
and in `cnti/results/latest.yml` the item carries `remediation: ['Use init systems that are purpose-built for containers like tini, dumb-init, s6-overlay.']`.

USAGE's results-file contract notes the fallback. The results schema is unchanged (`remediation` was already an optional list of strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
