### PR TITLE
Kubescape findings name the field and the container

### DIFF
--- a/spec/utils/kubescape_report_spec.cr
+++ b/spec/utils/kubescape_report_spec.cr
@@ -1,0 +1,62 @@
+require "../spec_helper"
+require "../../src/tasks/utils/kubescape.cr"
+
+# In-process, no cluster: the parser keeps the fields kubescape names and the
+# reasons built from them.
+private RESPONSE = <<-JSON
+{
+  "name": "Ensure CPU limits are set",
+  "remediation": "Set resources.limits.cpu for every container.",
+  "ruleReports": [{
+    "name": "resources-cpu-limits",
+    "ruleResponses": [{
+      "alertMessage": "",
+      "alertObject": {"k8sApiObjects": [{"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"name": "web", "namespace": "shop"}}]},
+      "failedPaths": null,
+      "reviewPaths": null,
+      "fixPaths": [
+        {"path": "spec.template.spec.containers[0].resources.limits.cpu", "value": "YOUR_VALUE"},
+        {"path": "spec.template.spec.securityContext.runAsNonRoot", "value": "true"}
+      ]
+    }, {
+      "alertMessage": "hostPath volume is mounted",
+      "alertObject": {"k8sApiObjects": [{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "tool", "namespace": "shop"}}]},
+      "failedPaths": ["spec.volumes[0].hostPath"],
+      "reviewPaths": null,
+      "fixPaths": null
+    }]
+  }]
+}
+JSON
+
+describe "Kubescape report parsing" do
+  it "keeps the failed fields and suggested values, and phrases them", tags: ["points"] do
+    report = Kubescape.parse_test_report(JSON.parse(RESPONSE))
+    report.remediation.should eq("Set resources.limits.cpu for every container.")
+    report.failed_resources.size.should eq(2)
+
+    web = report.failed_resources[0]
+    web.kind.should eq("Deployment")
+    web.paths.should eq(["spec.template.spec.containers[0].resources.limits.cpu", "spec.template.spec.securityContext.runAsNonRoot"])
+    web.reason_for("spec.template.spec.containers[0].resources.limits.cpu").should eq("spec.template.spec.containers[0].resources.limits.cpu is not set")
+    web.reason_for("spec.template.spec.securityContext.runAsNonRoot").should eq("spec.template.spec.securityContext.runAsNonRoot should be true")
+
+    tool = report.failed_resources[1]
+    tool.paths.should eq(["spec.volumes[0].hostPath"])
+    tool.reason_for("spec.volumes[0].hostPath").should eq("spec.volumes[0].hostPath")
+    tool.alert_message.should eq("hostPath volume is mounted")
+  end
+
+  it "records one impacted entry per failed field", tags: ["points"] do
+    report = Kubescape.parse_test_report(JSON.parse(RESPONSE))
+    result = CNFManager::TestCaseResult.empty
+    Kubescape.report_failed_resources(report, result)
+    reasons = result.result_impacted_resources.map { |e| e["reason"] }
+    reasons.should eq([
+      "spec.template.spec.containers[0].resources.limits.cpu is not set",
+      "spec.template.spec.securityContext.runAsNonRoot should be true",
+      "spec.volumes[0].hostPath",
+    ])
+    result.result_impacted_resources.map { |e| e["name"] }.should eq(["web", "web", "tool"])
+  end
+end

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -153,8 +153,14 @@ describe "Security" do
       ShellCmd.cnf_install("--cnf-config ./sample-cnfs/sample-operator/cnf-testsuite.yml")
       result = ShellCmd.run_testsuite("cpu_limits")
       result[:status].exit_code.should eq(1)
-      (result[:output].scan(/Failed resource: Deployment demo-labeled in cnf-default namespace/).size > 0).should be_true
-      (result[:output].scan(/Failed resource: Deployment demo-owned in cnf-default namespace/).size > 0).should be_true
+      # Kubescape findings name the field and the container (#2508). The
+      # operator creates these Deployments, so on a miss show what was reported.
+      ["demo-labeled", "demo-owned"].each do |name|
+        expected = /impacted: Deployment\/#{name} in cnf-default \(container .+\): spec\.template\.spec\.containers\[\d+\]\.resources\.limits\.cpu is not set/
+        unless expected =~ result[:output]
+          fail "no per-field finding for Deployment/#{name}; impacted lines were:\n#{result[:output].lines.select(&.includes?("impacted:")).join}"
+        end
+      end
       (/remediation: Set the CPU limits or use exception mechanism to avoid unnecessary notifications\./ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()

--- a/src/tasks/utils/kubescape.cr
+++ b/src/tasks/utils/kubescape.cr
@@ -108,8 +108,23 @@ module Kubescape
       return if k8s_objects == nil
   
       alert_message = rule_response.dig?("alertMessage")
+      # Where in the object the rule failed: failedPaths/reviewPaths name the
+      # field, fixPaths name it with the value to set. Any of the three may be
+      # null in a given response, so they are merged.
+      paths = [] of String
+      fixes = {} of String => String
+      ["failedPaths", "reviewPaths"].each do |key|
+        rule_response.dig?(key).try(&.as_a?).try &.each { |path| paths << path.as_s }
+      end
+      rule_response.dig?("fixPaths").try(&.as_a?).try &.each do |fix|
+        path = fix.dig?("path").try(&.as_s?) || next
+        paths << path
+        fixes[path] = fix.dig?("value").try(&.as_s?) || ""
+      end
       k8s_objects.as_a.map do |k8s_obj|
         test_resource = parse_rule_response_k8s_object(k8s_obj, rule_name: rule_name, response_alert: alert_message)
+        test_resource.paths = paths.uniq
+        test_resource.fixes = fixes
         @test_resources.push(test_resource)
       end
     end
@@ -190,8 +205,53 @@ module Kubescape
     property name
     property namespace
     property alert_message
+    # Fields the rule failed on (kubescape failedPaths/reviewPaths/fixPaths),
+    # and the value fixPaths suggests for each, when it does.
+    property paths : Array(String) = [] of String
+    property fixes : Hash(String, String) = {} of String => String
 
     def initialize(@rule_name : String, @kind : String, @name : String, @namespace : String | Nil, @alert_message : String | Nil)
+    end
+
+    # One line per failed field: "<path>" plus the suggested value when
+    # kubescape gives a real one ("YOUR_VALUE" is its placeholder for "set it").
+    def reason_for(path : String) : String
+      value = fixes[path]?
+      if value && !value.empty? && value != "YOUR_VALUE"
+        "#{path} should be #{value}"
+      elsif fixes.has_key?(path)
+        "#{path} is not set"
+      else
+        path
+      end
+    end
+
+    # The container a path like spec.template.spec.containers[1].x refers to,
+    # by name, looked up in the live object; nil when the path is not
+    # container-scoped or the object cannot be read.
+    def container_for(path : String) : String?
+      match = path.match(/^spec\.(?:template\.spec\.)?(containers|initContainers|ephemeralContainers)\[(\d+)\]/)
+      return nil unless match
+      spec = KubectlClient::Get.resource(kind, name, namespace)
+      pod_spec = spec.dig?("spec", "template", "spec") || spec.dig?("spec")
+      pod_spec.try(&.dig?(match[1])).try(&.as_a?).try(&.[match[2].to_i]?).try(&.dig?("name")).try(&.as_s?)
+    rescue
+      nil
+    end
+  end
+
+  # Records every failed resource of a report into `result`: one entry per
+  # failed field when kubescape names the fields (with the container, when
+  # the field is a container's), otherwise one entry with the alert message.
+  def self.report_failed_resources(test_report : TestReport, result)
+    test_report.failed_resources.each do |r|
+      if r.paths.empty?
+        result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message)
+      else
+        r.paths.each do |path|
+          result.add_impacted_resource(r.kind, r.name, r.namespace, container: r.container_for(path), reason: r.reason_for(path))
+        end
+      end
     end
   end
 

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -191,7 +191,7 @@ scored_task "privilege_escalation",
     if test_report.failed_resources.size == 0
       result.passed("No containers that allow privilege escalation were found")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found containers that allow privilege escalation")
     end
@@ -212,7 +212,7 @@ scored_task "symlink_file_system",
     if test_report.failed_resources.size == 0
       result.passed("No containers allow a symlink attack")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found containers that allow a symlink attack")
     end
@@ -233,7 +233,7 @@ scored_task "application_credentials",
     if test_report.failed_resources.size == 0
       result.passed("No applications credentials in configuration files")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found applications credentials in configuration files")
     end
@@ -254,7 +254,7 @@ scored_task "host_network",
     if test_report.failed_resources.size == 0
       result.passed("No host network attached to pod")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found host network attached to pod")
     end
@@ -278,7 +278,7 @@ scored_task "service_account_mapping",
     if test_report.failed_resources.size == 0
       result.passed("No service accounts automatically mapped")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Service accounts automatically mapped")
     end
@@ -300,7 +300,7 @@ scored_task "linux_hardening",
     if test_report.failed_resources.size == 0
       result.passed("Security services are being used to harden applications")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found resources that do not use security services")
     end
@@ -321,7 +321,7 @@ scored_task "insecure_capabilities",
     if test_report.failed_resources.size == 0
       result.passed("Containers with insecure capabilities were not found")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found containers with insecure capabilities")
     end
@@ -343,7 +343,7 @@ scored_task "cpu_limits",
     if test_report.failed_resources.size == 0
       result.passed("Containers have CPU limits set")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found containers without CPU limits set")
     end
@@ -365,7 +365,7 @@ scored_task "memory_limits",
     if test_report.failed_resources.size == 0
       result.passed("Containers have memory limits set")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found containers without memory limits set")
     end
@@ -387,7 +387,7 @@ scored_task "ingress_egress_blocked",
     if test_report.failed_resources.size == 0
       result.passed("Ingress and Egress traffic blocked on pods")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Ingress and Egress traffic not blocked on pods")
     end
@@ -408,7 +408,7 @@ scored_task "host_pid_ipc_privileges",
     if test_report.failed_resources.size == 0
       result.passed("No containers with hostPID and hostIPC privileges")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found containers with hostPID and hostIPC privileges")
     end
@@ -430,7 +430,7 @@ scored_task "non_root_containers",
     if test_report.failed_resources.size == 0
       result.passed("Containers are running with non-root user with non-root group membership")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found containers running with root user or user with root group membership")
     end
@@ -452,7 +452,7 @@ scored_task "immutable_file_systems",
     if test_report.failed_resources.size == 0
       result.passed("Containers have immutable file systems")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found containers with mutable file systems")
     end
@@ -477,7 +477,7 @@ scored_task "hostpath_mounts",
     if test_report.failed_resources.size == 0
       result.passed("Containers do not have hostPath mounts")
     else
-      test_report.failed_resources.each { |r| result.add_impacted_resource(r.kind, r.name, r.namespace, reason: r.alert_message) }
+      Kubescape.report_failed_resources(test_report, result)
       result.append_remediation(test_report.remediation.to_s) if test_report.remediation
       result.failed("Found containers with hostPath mounts")
     end


### PR DESCRIPTION
Second item of the diagnostics plan for the essential tests (X2).

The Kubescape-based tests — the essential `cpu_limits`, `memory_limits`, `non_root_containers`, `hostpath_mounts`, and ten more — reported a failed **workload** with kubescape's `alertMessage`, which on current controls is empty, so what the user saw was the fallback "Failed resource: Deployment x in ns". Kubescape's rule responses say much more: `failedPaths`/`reviewPaths` name the field the rule failed on and `fixPaths` names it with the value to set (confirmed on a live 4.0.12 / NSA 2.0.33 scan: `alertMessage: ''`, `fixPaths: [{path: "spec.template.spec.containers[0].resources.limits.cpu", value: "YOUR_VALUE"}]`). The parser dropped all three.

### Now

`TestResource` keeps the paths (all three sources merged, any of which may be null) and the suggested values. `Kubescape.report_failed_resources(test_report, result)` records **one `impacted_resources` entry per failed field**, with the container name resolved from the live object when the path is container-scoped (`…containers[1]…`, init and ephemeral included), and a reason phrased from the fix: `…resources.limits.cpu is not set`, `…runAsNonRoot should be true`, or the bare path when kubescape offers no value. Resources for which kubescape names no field keep the previous alert-message entry. All 14 kubescape-based tests use the helper, replacing 14 identical lines; the control's own remediation text is appended as before.

### Verification

- In-process unit spec (no cluster): a two-response control report parses into paths + fixes, reasons phrase correctly, and the helper records one entry per field with the right resource names.
- Live, on a kind cluster with the CI compiler: the `sample-hostpath` fixture (a bare Pod with a hostPath mount, running as root):

```
FAILED: [hostpath_mounts] Found containers with hostPath mounts
   > impacted: Pod/nginx in cnfspace: spec.volumes[0]
   > impacted: Pod/nginx in cnfspace (container nginx): spec.containers[0].volumeMounts[0]
   > remediation: Remove hostPath mounts unless they are absolutely necessary …
FAILED: [non_root_containers] Found containers running with root user or user with root group membership
   > impacted: Pod/nginx in cnfspace (container nginx): spec.containers[0].securityContext.runAsNonRoot should be true
   > impacted: Pod/nginx in cnfspace (container nginx): spec.containers[0].securityContext.runAsGroup should be 1000
```

Before this change both tests reported a single line: `Pod/nginx in cnfspace: Failed resource: Pod nginx in cnfspace namespace`. The `non_root_containers`/`hostpath_mounts` failing spec examples keep passing. The `labels` shard's `cpu_limits` example asserted the old generic sentence (the only place in `spec/` that did) and now asserts the per-field line; rebased onto main after #2480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)