### PR TITLE
points.cr requires the CLIInvocation it reads

### DIFF
--- a/src/tasks/utils/cli_args_validation.cr
+++ b/src/tasks/utils/cli_args_validation.cr
@@ -1,6 +1,7 @@
 require "sam"
 require "./cli_options"
 require "./cli_parser"
+require "./cli_invocation"
 
 # Exit code for CLI usage errors (sysexits EX_USAGE).
 USAGE_EXIT_CODE = 64

--- a/src/tasks/utils/cnf_manager/points.cr
+++ b/src/tasks/utils/cnf_manager/points.cr
@@ -1,4 +1,5 @@
 require "totem"
+require "../cli_invocation"
 require "colorize"
 require "../../../modules/helm"
 require "uuid"


### PR DESCRIPTION
`Results.dir` reads `CLIInvocation` (since #2479) but `points.cr` never required `cli_invocation.cr`; the constant resolved only because `logging.cr` or the CLI specs happened to be in the same program. Running a single spec file — `crystal spec spec/workload/security_spec.cr` — failed to compile with `undefined constant CLIInvocation`. CI never noticed because `crystal spec --tag X` compiles every spec file together.

Require what is used, in `points.cr` and in `cli_args_validation.cr` (whose `invoked_task?` reads it too). Verified: the single-file spec compiles again; binary builds with Crystal 1.19.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)