### PR TITLE
Kyverno-based tests name what the policy matched

### DIFF
--- a/spec/workload/configuration_spec.cr
+++ b/spec/workload/configuration_spec.cr
@@ -367,6 +367,7 @@ describe CnfTestSuite do
       result = ShellCmd.run_testsuite("latest_tag")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(Container images are using the latest tag)/ =~ result[:output]).should_not be_nil
+      (/impacted: Pod\/nginx in .* \(container nginx\): image bitnamilegacy\/nginx:latest uses the latest tag/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
     end

--- a/spec/workload/security_spec.cr
+++ b/spec/workload/security_spec.cr
@@ -302,7 +302,8 @@ describe "Security" do
       result = ShellCmd.run_testsuite("container_sock_mounts")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(Container engine daemon sockets are mounted as volumes)/ =~ result[:output]).should_not be_nil
-      (/Unix socket is not allowed/ =~ result[:output]).should_not be_nil
+      (/impacted: .*: volume docker-engine-socket mounts host path \/var\/run\/docker\.sock/ =~ result[:output]).should_not be_nil
+      (/impacted: .*: volume containerd-engine-socket mounts host path \/var\/run\/containerd\.sock/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
     end
@@ -385,6 +386,7 @@ describe "Security" do
       result = ShellCmd.run_testsuite("selinux_options")
       result[:status].exit_code.should eq(1)
       (/(FAILED).*(Pods are using custom SELinux options that can be used for privilege escalations)/ =~ result[:output]).should_not be_nil
+      (/impacted: Pod\/nginx in .*: seLinuxOptions type=spc_t/ =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
     end

--- a/src/tasks/utils/kyverno.cr
+++ b/src/tasks/utils/kyverno.cr
@@ -150,6 +150,67 @@ module Kyverno
     end
   end
 
+  # What a policy matched, read back from the live resource: Kyverno's report
+  # names the resource and the rule, not the image, volume or securityContext
+  # that tripped it. Each helper returns nothing (never raises) when the
+  # resource cannot be read, so callers fall back to the policy message.
+  module Findings
+    def self.pod_spec(kind : String, name : String, namespace : String) : JSON::Any?
+      resource = KubectlClient::Get.resource(kind, name, namespace)
+      resource.dig?("spec", "template", "spec") || resource.dig?("spec")
+    rescue
+      nil
+    end
+
+    def self.containers(pod_spec : JSON::Any) : Array(JSON::Any)
+      ["containers", "initContainers", "ephemeralContainers"].flat_map do |list|
+        pod_spec.dig?(list).try(&.as_a?) || [] of JSON::Any
+      end
+    end
+
+    # Containers whose image has no tag or the `latest` tag (a digest counts as pinned).
+    def self.latest_tag_images(kind, name, namespace) : Array(NamedTuple(container: String, image: String))
+      spec = pod_spec(kind, name, namespace) || return [] of NamedTuple(container: String, image: String)
+      containers(spec).compact_map do |c|
+        image = c.dig?("image").try(&.as_s?) || next
+        next if image.includes?("@")
+        tag = image.rpartition("/")[2].partition(":")[2]
+        next unless tag.empty? || tag == "latest"
+        {container: c.dig?("name").try(&.as_s?) || "", image: image}
+      end
+    end
+
+    # hostPath volumes that mount a socket, with the containers mounting them.
+    def self.socket_mounts(kind, name, namespace) : Array(NamedTuple(volume: String, path: String, containers: Array(String)))
+      spec = pod_spec(kind, name, namespace) || return [] of NamedTuple(volume: String, path: String, containers: Array(String))
+      (spec.dig?("volumes").try(&.as_a?) || [] of JSON::Any).compact_map do |v|
+        path = v.dig?("hostPath", "path").try(&.as_s?) || next
+        next unless path.ends_with?(".sock")
+        volume = v.dig?("name").try(&.as_s?) || ""
+        mounting = containers(spec).select do |c|
+          (c.dig?("volumeMounts").try(&.as_a?) || [] of JSON::Any).any? { |m| m.dig?("name").try(&.as_s?) == volume }
+        end.map { |c| c.dig?("name").try(&.as_s?) || "" }
+        {volume: volume, path: path, containers: mounting}
+      end
+    end
+
+    # seLinuxOptions set at pod level ("pod") or on a container, rendered as k=v.
+    def self.selinux_options(kind, name, namespace) : Array(NamedTuple(scope: String, options: String))
+      spec = pod_spec(kind, name, namespace) || return [] of NamedTuple(scope: String, options: String)
+      found = [] of NamedTuple(scope: String, options: String)
+      render = ->(o : JSON::Any) { o.as_h.map { |k, v| "#{k}=#{v}" }.join(", ") }
+      if o = spec.dig?("securityContext", "seLinuxOptions")
+        found << {scope: "pod", options: render.call(o)}
+      end
+      containers(spec).each do |c|
+        if o = c.dig?("securityContext", "seLinuxOptions")
+          found << {scope: c.dig?("name").try(&.as_s?) || "", options: render.call(o)}
+        end
+      end
+      found
+    end
+  end
+
   def self.filter_failures_for_cnf_resources(resource_keys, failures)
     filtered = failures.map do |failure|
       failed_resources = failure.resources.select do |resource|

--- a/src/tasks/workload/configuration.cr
+++ b/src/tasks/workload/configuration.cr
@@ -90,7 +90,14 @@ scored_task "latest_tag",
     else
       failures.each do |failure|
         failure.resources.each do |resource|
-          result.add_impacted_resource(resource.kind, resource.name, reason: "using the latest tag. #{failure.message}")
+          images = Kyverno::Findings.latest_tag_images(resource.kind, resource.name, resource.namespace)
+          if images.empty?
+            result.add_impacted_resource(resource.kind, resource.name, resource.namespace, reason: "using the latest tag. #{failure.message}")
+          else
+            images.each do |i|
+              result.add_impacted_resource(resource.kind, resource.name, resource.namespace, container: i[:container], reason: "image #{i[:image]} uses the latest tag")
+            end
+          end
         end
       end
       result.failed("Container images are using the latest tag")

--- a/src/tasks/workload/security.cr
+++ b/src/tasks/workload/security.cr
@@ -109,7 +109,16 @@ scored_task "selinux_options",
       else
         failures.each do |failure|
           failure.resources.each do |resource|
-            result.add_impacted_resource(resource.kind, resource.name, resource.namespace, reason: failure.message)
+            options = Kyverno::Findings.selinux_options(resource.kind, resource.name, resource.namespace)
+            if options.empty?
+              result.add_impacted_resource(resource.kind, resource.name, resource.namespace, reason: failure.message)
+            else
+              options.each do |o|
+                reason = "seLinuxOptions #{o[:options]}"
+                container = o[:scope] == "pod" ? nil : o[:scope]
+                result.add_impacted_resource(resource.kind, resource.name, resource.namespace, container: container, reason: reason)
+              end
+            end
           end
         end
         result.failed("Pods are using custom SELinux options that can be used for privilege escalations")
@@ -136,7 +145,19 @@ scored_task "container_sock_mounts",
     else
       failures.each do |failure|
         failure.resources.each do |resource|
-          result.add_impacted_resource(resource.kind, resource.name, resource.namespace, reason: failure.message)
+          mounts = Kyverno::Findings.socket_mounts(resource.kind, resource.name, resource.namespace)
+          if mounts.empty?
+            result.add_impacted_resource(resource.kind, resource.name, resource.namespace, reason: failure.message)
+          else
+            mounts.each do |m|
+              reason = "volume #{m[:volume]} mounts host path #{m[:path]}"
+              if m[:containers].empty?
+                result.add_impacted_resource(resource.kind, resource.name, resource.namespace, reason: reason)
+              else
+                m[:containers].each { |c| result.add_impacted_resource(resource.kind, resource.name, resource.namespace, container: c, reason: reason) }
+              end
+            end
+          end
         end
       end
       result.failed("Container engine daemon sockets are mounted as volumes")


### PR DESCRIPTION
Diagnostics plan item X3.

The three Kyverno-based essential tests reported the policy's generic message and nothing about what was matched: `latest_tag` never named the image, `container_sock_mounts` never named the volume or the socket, `selinux_options` never named the options. Kyverno's policy report identifies the resource and the rule; the specifics are in the resource itself.

`Kyverno::Findings` reads the failed resource's live pod spec (own spec for a Pod, the template's otherwise; containers, initContainers and ephemeralContainers alike) and extracts exactly what each policy is about:

- `latest_tag` → one entry per container: `image bitnamilegacy/nginx:latest uses the latest tag` (a missing tag counts; a digest counts as pinned); the entry now also carries the namespace, which was missing.
- `container_sock_mounts` → one entry per socket hostPath volume, per mounting container: `volume docker-engine-socket mounts host path /var/run/docker.sock`.
- `selinux_options` → the options as set, per container or at pod level: `seLinuxOptions type=spc_t`.

If the resource cannot be read back, the previous policy-message entry is kept. Nothing about the verdicts changes.

### Verification

Assertions on the enriched lines added to each test's failing example; the three shards run locally against a kind cluster with the CI compiler: `latest_tag` 3/3, `container_sock_mounts` 3/3, `selinux_options` 3/3. The lines the fixtures now produce:

```
impacted: Pod/nginx in cnf-default (container nginx): image bitnamilegacy/nginx:latest uses the latest tag
impacted: Pod/... in ...: volume docker-engine-socket mounts host path /var/run/docker.sock
impacted: Pod/... in ...: volume containerd-engine-socket mounts host path /var/run/containerd.sock
impacted: Pod/nginx in cnf-default: seLinuxOptions type=spc_t
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
