### PR TITLE
Process tests: say what was checked when they pass

### DIFF
--- a/spec/workload/microservice_spec.cr
+++ b/spec/workload/microservice_spec.cr
@@ -97,6 +97,7 @@ describe "Microservice" do
       result = ShellCmd.run_testsuite("single_process_type")
       result[:status].success?.should be_true
       (/(PASSED).*(Only one process type used)/ =~ result[:output]).should_not be_nil
+      (/> [A-Za-z]+\/.* container .*: (process type |no application process)/ =~ result[:output]).should_not be_nil
       verify_task_result("single_process_type", "passed")
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -219,6 +220,7 @@ describe "Microservice" do
     result = ShellCmd.run_testsuite("specialized_init_system")
     result[:status].success?.should be_true
     (/Containers use specialized init systems/ =~ result[:output]).should_not be_nil
+    (/> Pod\/.* container .*: init '/ =~ result[:output]).should_not be_nil
   ensure
     result = ShellCmd.cnf_uninstall()
   end
@@ -283,6 +285,7 @@ describe "Microservice" do
       result = ShellCmd.run_testsuite("sig_term_handled")
       result[:status].success?.should be_true
       (/(PASSED).*(Sig Term handled)/ =~ result[:output]).should_not be_nil
+      (/> Checked .*: PID 1 \d+.*judged pid\(s\) \d+/ =~ result[:output]).should_not be_nil
       verify_task_result("sig_term_handled", "passed")
     ensure
       result = ShellCmd.cnf_uninstall()
@@ -366,6 +369,7 @@ describe "Microservice" do
       result = ShellCmd.run_testsuite("zombie_handled")
       result[:status].success?.should be_true
       (/(PASSED).*(Zombie handled)/ =~ result[:output]).should_not be_nil
+      (/> Zombie probe injected into \d+ container\(s\)/ =~ result[:output]).should_not be_nil
       verify_task_result("zombie_handled", "passed")
     ensure
       result = ShellCmd.cnf_uninstall()

--- a/spec/workload/observability_spec.cr
+++ b/spec/workload/observability_spec.cr
@@ -17,6 +17,7 @@ describe "Observability" do
       result = ShellCmd.run_testsuite("log_output")
       result[:status].success?.should be_true
       (/(PASSED).*(Resources output logs to stdout and stderr)/ =~ result[:output]).should_not be_nil
+      (/> [A-Za-z]+\/.* in .*: logs from / =~ result[:output]).should_not be_nil
     ensure
       result = ShellCmd.cnf_uninstall()
     end

--- a/src/tasks/utils/init_systems.cr
+++ b/src/tasks/utils/init_systems.cr
@@ -6,13 +6,15 @@ module InitSystems
     property name
     property container
     property init_cmd
-  
+    property specialized : Bool
+
     def initialize(
       @kind : String,
       @namespace : String,
       @name : String,
       @container : String,
-      @init_cmd : String
+      @init_cmd : String,
+      @specialized : Bool = false
     )
     end
   end
@@ -22,8 +24,10 @@ module InitSystems
     SPECIALIZED_INIT_SYSTEMS.includes?(File.basename(cmd))
   end
 
+  # Every container's PID 1 with whether it is a specialized init system;
+  # nil when a container could not be inspected.
   def self.scan(pod : JSON::Any) : Array(InitSystemInfo) | Nil
-    failed_resources = [] of InitSystemInfo
+    inspected = [] of InitSystemInfo
     error_occurred = false
 
     nodes = KubectlClient::Get.nodes_by_pod(pod)
@@ -35,7 +39,7 @@ module InitSystems
 
     if nodes.size == 0
       Log.for("InitSystems.scan").info { "No nodes found for pod '#{pod_name}' in #{resource_namespace} namespace" }
-      return failed_resources
+      return inspected
     end
 
     pod_node = nodes[0]
@@ -51,19 +55,17 @@ module InitSystems
           resource_namespace,
           pod_name.as_s,
           container_name.as_s,
-          container_init_cmd
+          container_init_cmd,
+          InitSystems.is_specialized_init_system?(container_init_cmd)
         )
         Log.for("InitSystems.scan").info { "#{init_info.kind}/#{init_info.name} has container '#{init_info.container}' with #{init_info.init_cmd} as init process" }
-  
-        if !InitSystems.is_specialized_init_system?(container_init_cmd)
-          failed_resources << init_info
-        end
+        inspected << init_info
       else
         error_occurred = true
       end
     end
 
-    return error_occurred ? nil : failed_resources
+    return error_occurred ? nil : inspected
   end
 
   def self.get_container_init_cmd(node, container_id) : String?

--- a/src/tasks/workload/microservice.cr
+++ b/src/tasks/workload/microservice.cr
@@ -346,6 +346,7 @@ scored_task "single_process_type",
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     fail_msgs = Set(String).new
     ignored_init_msgs = Set(String).new
+    checked_process_types = [] of String
     resources_checked = false
     test_passed = true
 
@@ -385,6 +386,9 @@ scored_task "single_process_type",
         end.map { |status| status["Name"].strip }.uniq
 
         Log.for(t.name).info { "container '#{container_name}' application process types: #{app_process_types}" }
+        if app_process_types.size <= 1
+          checked_process_types << "#{kind}/#{name} container #{container_name}: #{app_process_types.empty? ? "no application process besides PID 1" : "process type #{app_process_types.first}"}"
+        end
 
         # When the container's init process (PID 1) is a real init/supervisor that is
         # NOT one of the recommended specialized init systems, record that we saw it and
@@ -436,6 +440,7 @@ scored_task "single_process_type",
 
     if resources_checked
       if test_passed
+        checked_process_types.each { |line| result.append_description(line) }
         result.passed("Only one process type used")
       else
         fail_msgs.each { |msg| result.append_description(msg) }
@@ -454,6 +459,7 @@ scored_task "zombie_handled",
   emoji: "⚖👀" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     injection_failures = [] of String
+    probed_containers = [] of String
     CNFManager.resource_refs(args, config, WORKLOAD_RESOURCE_KIND_NAMES) do |resource|
       ClusterTools.all_containers_by_resource?(resource, resource[:namespace], include_proctree: false) do |container_id, container_pid_on_node, node|
         probe_commands = [
@@ -461,13 +467,16 @@ scored_task "zombie_handled",
           "nerdctl --namespace=k8s.io cp /sleep #{container_id}:/sleep",
           "nerdctl --namespace=k8s.io exec #{container_id} /zombie",
         ]
+        injected = true
         probe_commands.each do |probe_command|
           cmd_result = ClusterTools.exec_by_node(probe_command, node)
           next if cmd_result[:status].success?
           Log.for(t.name).error { "zombie probe injection failed for container #{container_id} (#{resource[:kind]}/#{resource[:name]}): #{probe_command}: #{cmd_result[:error]}" }
           injection_failures << "#{resource[:kind]}/#{resource[:name]} container #{container_id}: `#{probe_command}` failed"
+          injected = false
           break
         end
+        probed_containers << "#{resource[:kind]}/#{resource[:name]} container #{container_id.to_s[0, 12]}" if injected
       end
     end
 
@@ -525,6 +534,7 @@ scored_task "zombie_handled",
     end
 
     if task_response
+      result.append_description("Zombie probe injected into #{probed_containers.size} container(s): #{probed_containers.join("; ")}")
       result.passed("Zombie handled")
     else
       result.failed("Zombie not handled")
@@ -623,6 +633,7 @@ scored_task "sig_term_handled",
     # Containers that could not be judged, with the reason; they never count
     # against the CNF.
     skipped_containers = [] of NamedTuple(pod: String, container: String, reason: String)
+    checked_containers = [] of String
     judged_any = false
 
     #Track already tested pods
@@ -727,6 +738,7 @@ scored_task "sig_term_handled",
           sleep(Time::Span.new(seconds: STRACE_WAIT_BUFFER)) unless traced.empty?
 
           judged_any = true
+          checked_containers << "#{pod_name}/#{c_name}: PID 1 #{pid}#{supervised ? " (supervisor)" : ""}, judged pid(s) #{judged.join(", ")}, grace #{grace_seconds}s"
           ClusterTools.exec_by_node("kill -TERM #{pid} || true", node)
           survivors = wait_for_processes_to_exit(judged, node, grace_seconds)
           # Whatever is still alive did not act on SIGTERM; end it the way the
@@ -769,6 +781,7 @@ scored_task "sig_term_handled",
     if task_response && !judged_any
       result.skipped("Sig Term handling not checked: no container could be traced")
     elsif task_response
+      checked_containers.each { |line| result.append_description("Checked #{line}") }
       result.passed("Sig Term handled")
     else
       failed_containers.each do |info|
@@ -828,6 +841,7 @@ scored_task "specialized_init_system",
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
     error_occurred    = false
     resources_checked = false
+    checked_inits     = [] of String
 
     task_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, _, _|
       Log.for(t.name).info { "Checking #{resource[:kind]}/#{resource[:name]} in #{resource[:namespace]}" }
@@ -858,13 +872,18 @@ scored_task "specialized_init_system",
           next false
         end
 
+        results.select(&.specialized).each do |info|
+          checked_inits << "#{info.kind}/#{info.name} container #{info.container}: init '#{info.init_cmd}'"
+        end
+        failed = results.reject(&.specialized)
+
         # No failures => this pod passes
-        if results.empty?
+        if failed.empty?
           next true
         end
 
         # Report failures
-        results.each do |info|
+        failed.each do |info|
           result.add_impacted_resource(info.kind.to_s, info.name.to_s, info.namespace.to_s, container: info.container.to_s, reason: "'#{info.init_cmd}' as init process")
         end
 
@@ -880,6 +899,7 @@ scored_task "specialized_init_system",
     elsif !task_response
       result.failed("Containers do not use specialized init systems (ভ_ভ) ރ")
     else
+      checked_inits.each { |line| result.append_description(line) }
       result.passed("Containers use specialized init systems 🖥️")
     end
   end

--- a/src/tasks/workload/observability.cr
+++ b/src/tasks/workload/observability.cr
@@ -19,6 +19,7 @@ scored_task "log_output",
     # Pods whose logs could not be read (not scheduled, container still
     # creating, ...) are reported, never judged.
     unreadable = [] of String
+    logged_resources = [] of String
     judged_any = false
 
     task_response = CNFManager.workload_resource_test(args, config, check_containers: false) do |resource, _, _|
@@ -57,6 +58,7 @@ scored_task "log_output",
         quiet.each { |pod_name| result.add_impacted_resource("Pod", pod_name, resource[:namespace], reason: "no log output on stdout/stderr") }
         false
       else
+        logged_resources << "#{resource[:kind]}/#{resource[:name]} in #{resource[:namespace]}: logs from #{logging.join(", ")}"
         true
       end
     end
@@ -65,6 +67,7 @@ scored_task "log_output",
     if !judged_any
       result.skipped("Log output not checked: no pod's logs could be read")
     elsif task_response
+      logged_resources.each { |line| result.append_description(line) }
       result.passed("Resources output logs to stdout and stderr")
     else
       result.failed("Resources do not output logs to stdout and stderr")


### PR DESCRIPTION
Diagnostics plan item X4, for the process tests (the probe tests got theirs in #2509). **Stacked on #2514** — it edits the same `microservice.cr` regions; merge that first.

A skip now always explains itself and a failure names its resources, but a *pass* said nothing — the verdict had to be trusted, not reviewed, which is exactly what certification reviewers cannot do. Each of these tests now leaves one `details` line per thing it checked:

| Test | On pass |
|---|---|
| `sig_term_handled` | `Checked web-5f7/app: PID 1 4711 (supervisor), judged pid(s) 4720, 4721, grace 30s` |
| `zombie_handled` | `Zombie probe injected into 2 container(s): Deployment/web container 3f2a9c1b0d4e; …` |
| `single_process_type` | `Deployment/web container app: process type nginx` |
| `specialized_init_system` | `Pod/web-5f7 container app: init '/sbin/tini'` |
| `log_output` | `Deployment/web in shop: logs from web-5f7, web-9c2` |

`InitSystems.scan` now returns every inspected container with a `specialized` flag rather than only the failing ones, so the test partitions the result; its verdict logic is unchanged. Nothing changes on failure or skip.

### Verification

The pass-side example of each test asserts its new line; shards run locally against a kind cluster with the CI compiler: `process_check` 4, `specialized_init_system` 2, `observability_log_output` 4, `zombie` 3, `sig_term` 5 examples — 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
