### PR TITLE
github-runner image: OCI labels, Renovate annotations, overridable image

### DIFF
--- a/tools/github-runner/Dockerfile
+++ b/tools/github-runner/Dockerfile
@@ -1,10 +1,21 @@
+# Self-hosted CI runner with the toolchain baked in, so that no shard pays
+# for installing Crystal, kind or kustomize. Published by the images workflow
+# as ghcr.io/lfn-cnti/github-runner:<runner version>-crystal<Crystal version>.
+
+# renovate: datasource=docker depName=myoung34/github-runner
 FROM myoung34/github-runner:2.336.0-ubuntu-noble
 
 # renovate: datasource=github-releases depName=crystal-lang/crystal
 ARG CRYSTAL_VERSION=1.19.1
 ARG CRYSTAL_URL=https://github.com/crystal-lang/crystal/releases/download
+# renovate: datasource=github-releases depName=kubernetes-sigs/kind
 ARG KIND_VERSION=v0.32.0
+# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=regex:^kustomize/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
 ARG KUSTOMIZE_VERSION=v5.8.1
+
+LABEL org.opencontainers.image.source="https://github.com/lfn-cnti/testsuite" \
+      org.opencontainers.image.description="CNTi Test Suite self-hosted CI runner: GitHub runner + Crystal, kind, kubectl, helm, kustomize, gh" \
+      org.opencontainers.image.licenses="Apache-2.0"
 
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg --output /usr/share/keyrings/githubcli-archive-keyring.gpg && \
     chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg && \

--- a/tools/github-runner/create_runners.sh
+++ b/tools/github-runner/create_runners.sh
@@ -20,7 +20,8 @@ fi
 
 RUNNER_COUNT=0
 for node in "${!RUNNERS[@]}"; do
-    export RUNNER_IMAGE="conformance/github-runner:v2.336.0" # don't forget the v
+    # Override with RUNNER_IMAGE=... to deploy another build.
+    export RUNNER_IMAGE="${RUNNER_IMAGE:-conformance/github-runner:v2.336.0}"
     ssh root@${RUNNERS[$node]} "docker pull $RUNNER_IMAGE"
     RUNNERS_PER_NODE=4
     until [ $RUNNERS_PER_NODE -eq 0 ]; do


### PR DESCRIPTION
Phase 1, step 4 of the container-image plan. The runner image stays (installing Crystal/kind/kustomize per shard would cost ~30 s × ~50 shards per run); this only prepares it for the images workflow.

- OCI labels (`source` links the future GHCR package to this repo).
- `# renovate:` annotations for the `myoung34/github-runner` base image, kind and kustomize (`kustomize/vX.Y.Z` tags need a regex versioning); Crystal already had one.
- `create_runners.sh` honours `RUNNER_IMAGE` from the environment, default unchanged.

### Verification

Built locally and smoke-tested: Crystal 1.19.1, Shards 0.20.0, kind 0.32.0, kustomize v5.8.1, kubectl v1.36.4, helm v4.2.4, gh 2.98.0. Not deployed — the redeploy from GHCR is phase 3 and closes #2511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)