### PR TITLE
Batch the per-pid /proc reads into one exec per node

### DIFF
--- a/src/modules/k8s_kernel_introspection/k8s_kernel_introspection.cr
+++ b/src/modules/k8s_kernel_introspection/k8s_kernel_introspection.cr
@@ -47,14 +47,31 @@ module KernelIntrospection
         result[:output].strip.split("\n").reject(&.empty?)
       end
 
+      # Marker printed after every /proc/<pid>/status so one exec can carry
+      # all of them; it cannot occur inside a status file.
+      STATUS_SEPARATOR = "__CNTI_STATUS_END__"
+      # Pids per exec: keeps the command line far below ARG_MAX on any node.
+      STATUS_BATCH_SIZE = 400
+
+      # Reads /proc/<pid>/status for every pid with one exec per batch instead
+      # of one exec per pid: a node with a few hundred processes used to cost a
+      # few hundred kubectl round trips before a single process tree was known.
+      # Pids whose process has gone by the time the batch runs are skipped.
       def self.all_statuses_by_pids(pids : Array(String), node) : Array(String)
-        Log.info { "all_statuses_by_pids" }
-        proc_statuses = pids.map do |pid|
-          Log.info { "all_statuses_by_pids pid: #{pid}" }
-          proc_status = ClusterTools.exec_by_node("cat /proc/#{pid}/status", node)
-          # if /proc/#{pid}/status cannot be read it means that the process is no longer available
-          proc_status[:output] if proc_status[:status].success?
-        end.compact
+        Log.info { "all_statuses_by_pids: #{pids.size} pid(s)" }
+        proc_statuses = [] of String
+        pids.each_slice(STATUS_BATCH_SIZE) do |batch|
+          command = "/bin/sh -c 'for p in #{batch.join(" ")}; do cat /proc/$p/status 2>/dev/null && echo #{STATUS_SEPARATOR}; done; true'"
+          result = ClusterTools.exec_by_node(command, node)
+          unless result[:status].success?
+            Log.warn { "all_statuses_by_pids: batch of #{batch.size} pid(s) failed on #{node.dig?("metadata", "name")}: #{result[:error]}" }
+            next
+          end
+          result[:output].split(STATUS_SEPARATOR).each do |status|
+            status = status.strip
+            proc_statuses << status unless status.empty?
+          end
+        end
 
         Log.debug { "proc process_statuses_by_node count: #{proc_statuses.size}" }
         proc_statuses


### PR DESCRIPTION
Section 6/T1 of the image plan, and a step toward #2042's spirit: `KernelIntrospection::K8s::Node.all_statuses_by_pids` issued one `kubectl exec` per pid, so building one container's process tree cost as many round trips as the node has processes — on a real node, minutes. One exec now returns a whole batch of `/proc/<pid>/status` files separated by a marker (`400` pids per exec keeps well under ARG_MAX); unreadable pids (process gone) are skipped exactly as before, and a failed batch is logged and skipped rather than raised. No behaviour change for callers.

### Verification

Shards on a local kind cluster (CI compiler), before → after: `process_check` 5:52 → 4:29, `sig_term` 6:52 → 6:22, `zombie` 3:21 → 3:20 (zombie enumerates only the container's few pids, so no gain expected) — 12 examples, 0 failures. A kind node exposes only ~50 pids; on production nodes with thousands of processes the saving is minutes per traced container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)