### PR TITLE
cni_compatible: static coupling check instead of the disabled cluster test

### DIFF
--- a/docs/TEST_DOCUMENTATION.md
+++ b/docs/TEST_DOCUMENTATION.md
@@ -236,16 +236,16 @@ Ensure that you can successfully change the software version of your CNF back to
 
 #### Overview
 
-This installs temporary kind clusters and will test the CNF against both Calico and Cilium CNIs.
-Expectation: CNF should be compatible with multiple and different CNIs
+This statically inspects the CNF's rendered manifests for features that couple it to one specific CNI plugin: Multus `NetworkAttachmentDefinition` objects, `k8s.v1.cni.cncf.io/networks` annotations requesting extra networks, Calico- or Cilium-specific APIs and annotations, and SR-IOV device resource requests.
+Expectation: the CNF requests nothing that only one specific CNI plugin can provide
 
 #### Rationale
 
-A CNF should be runnable by any CNI that adheres to the [CNI specification](https://github.com/containernetworking/cni/blob/master/SPEC.md)
+A CNF should be runnable by any CNI that adheres to the [CNI specification](https://github.com/containernetworking/cni/blob/master/SPEC.md); manifests that hardwire vendor-specific network features only run on matching clusters.
 
 #### Remediation
 
-Ensure that your CNF is compatible with Calico, Cilium and other available CNIs.
+Avoid vendor-specific network APIs, annotations and device resources in the CNF's manifests, or isolate them behind optional, documented configuration.
 
 #### Usage
 

--- a/sample-cnfs/sample-cni-coupled/cnf-testsuite.yml
+++ b/sample-cnfs/sample-cni-coupled/cnf-testsuite.yml
@@ -1,0 +1,6 @@
+---
+config_version: v2
+deployments:
+  manifests:
+  - name: cni-coupled
+    manifest_directory: manifests

--- a/sample-cnfs/sample-cni-coupled/manifests/manifest.yml
+++ b/sample-cnfs/sample-cni-coupled/manifests/manifest.yml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cni-coupled
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+
+---
+# The Multus networks annotation couples this workload to a meta-CNI; without
+# Multus it is ignored, so the fixture installs on any cluster.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cni-coupled
+  namespace: cni-coupled
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cni-coupled
+  template:
+    metadata:
+      labels:
+        app: cni-coupled
+      annotations:
+        k8s.v1.cni.cncf.io/networks: macvlan-conf
+    spec:
+      containers:
+      - name: main
+        # renovate: datasource=docker depName=busybox
+        image: busybox:1.33.1@sha256:f7ca5a32c10d51aeda3b4d01c61c6061f497893d7f6628b92f822f7117182a57
+        command: ["sh", "-c", "sleep 2147483647"]

--- a/spec/workload/compatibility_spec.cr
+++ b/spec/workload/compatibility_spec.cr
@@ -12,20 +12,27 @@ describe "Compatibility" do
   end
 
 
-  it "'cni_compatible' should pass if the cnf works with calico and flannel", tags: ["compatibility"] do
+  it "'cni_compatible' should pass when nothing couples the cnf to one CNI plugin", tags: ["compatibility"] do
     begin
       ShellCmd.cnf_install("--cnf-config sample-cnfs/sample-coredns-cnf/cnf-testsuite.yml")
-      retry_limit = 5
-      retries = 1
       result = ShellCmd.run_testsuite("cni_compatible")
-      until (/PASSED/ =~ result[:output]) || retries > retry_limit
-        Log.info { "cni_compatible spec retry: #{retries}" }
-        sleep 1.0
-        result = ShellCmd.run_testsuite("cni_compatible")
-        retries = retries + 1
-      end
-      Log.info { "Status:  #{result[:output]}" }
-      (/(SKIPPED).*(cni_compatible test was temporarily disabled)/ =~ result[:output]).should_not be_nil
+      result[:status].success?.should be_true
+      (/(PASSED).*(No coupling to a specific CNI plugin detected)/ =~ result[:output]).should_not be_nil
+      verify_task_result("cni_compatible", "passed")
+    ensure
+      result = ShellCmd.cnf_uninstall
+      result[:status].success?.should be_true
+    end
+  end
+
+  it "'cni_compatible' should fail when the cnf requests CNI-specific features", tags: ["compatibility"] do
+    begin
+      ShellCmd.cnf_install("--cnf-config sample-cnfs/sample-cni-coupled/cnf-testsuite.yml")
+      result = ShellCmd.run_testsuite("cni_compatible")
+      result[:status].exit_code.should eq(1)
+      (/(FAILED).*(CNF is coupled to specific CNI plugins or features)/ =~ result[:output]).should_not be_nil
+      (/impacted: Deployment\/cni-coupled in cni-coupled: requests additional CNI networks: k8s.v1.cni.cncf.io\/networks/ =~ result[:output]).should_not be_nil
+      verify_task_result("cni_compatible", "failed")
     ensure
       result = ShellCmd.cnf_uninstall
       result[:status].success?.should be_true

--- a/src/tasks/workload/compatibility.cr
+++ b/src/tasks/workload/compatibility.cr
@@ -512,75 +512,69 @@ scored_task "helm_chart_valid",
 end
 
 
-def setup_calico_cluster(cluster_name : String) : KindManager::Cluster
-  Log.info { "Running cni_compatible(Cluster Creation)" }
-  Helm.helm_repo_add("projectcalico","https://docs.projectcalico.org/charts")
-  calico_cluster = KindManager.create_cluster_with_chart_and_wait(
-    cluster_name,
-    KindManager.disable_cni_config,
-    "projectcalico/tigera-operator --version v3.32.1"
-  )
-
-  return calico_cluster
-end
-
-def setup_cilium_cluster(cluster_name : String) : KindManager::Cluster
-  chart_opts = [
-    "--set operator.replicas=1",
-    "--set image.repository=cilium/cilium",
-    "--set image.useDigest=false",
-    "--set operator.image.useDigest=false",
-    "--set operator.image.repository=cilium/operator"
-  ]
-
-  kind_manager = KindManager.new
-  cluster = kind_manager.create_cluster(cluster_name, KindManager.disable_cni_config)
-  Helm.helm_repo_add("cilium","https://helm.cilium.io/")
-  chart = "cilium/cilium"
-  chart_opts.push("--version 1.20.1")
-  with_kubeconfig(cluster.kubeconfig) { Helm.install("#{cluster_name}-plugin", "#{chart}", namespace: "kube-system", values: "#{chart_opts.join(" ")}") }
-
-  cluster.wait_until_pods_ready()
-  Log.info { "cilium kubeconfig: #{cluster.kubeconfig}" }
-  return cluster
-end
+# Annotation Multus and other meta-CNIs use to request extra networks.
+CNI_NETWORKS_ANNOTATION = "k8s.v1.cni.cncf.io/networks"
+# Vendor-specific API groups / annotation prefixes that tie a CNF to one CNI plugin.
+CNI_VENDOR_MARKERS = ["projectcalico.org", "cilium.io", "k8s.cni.cncf.io"]
 
 desc "CNFs should work with any Certified Kubernetes product and any CNI-compatible network that meet their functionality requirements."
 scored_task "cni_compatible",
   emoji: "🔓🔑" do |t, args|
   CNFManager::Task.task_runner(args, task: t) do |args, config, result|
-     # TODO (kosstennbl) adapt cnf_to_new_cluster metod to new installation process. Until then - test is disabled. More info: #2153
-    result.skipped("cni_compatible test was temporarily disabled, check #2153")
-    next
-    docker_version = DockerClient.version_info()
-    if docker_version.installed?
-      ensure_kubeconfig!
-      kubeconfig_orig = ENV["KUBECONFIG"]
-      begin
-        calico_cluster = setup_calico_cluster("calico-test")
-        Log.info { "calico kubeconfig: #{calico_cluster.kubeconfig}" }
-        calico_cnf_passed = CNFManager.cnf_to_new_cluster(config, calico_cluster.kubeconfig)
-        Log.info { "calico_cnf_passed: #{calico_cnf_passed}" }
-        result.append_description("CNF failed to install on Calico CNI cluster") unless calico_cnf_passed
+    coupled = 0
+    CNFManager.cnf_resources(args, config) do |resource|
+      api_version = resource.dig?("apiVersion").try(&.as_s?) || ""
+      kind = resource.dig?("kind").try(&.as_s?)
+      name = resource.dig?("metadata", "name").try(&.as_s?)
+      namespace = resource.dig?("metadata", "namespace").try(&.as_s?)
+      next unless kind && name
 
-        cilium_cluster = setup_cilium_cluster("cilium-test")
-        cilium_cnf_passed = CNFManager.cnf_to_new_cluster(config, cilium_cluster.kubeconfig)
-        Log.info { "cilium_cnf_passed: #{cilium_cnf_passed}" }
-        result.append_description("CNF failed to install on Cilium CNI cluster") unless cilium_cnf_passed
-
-        if calico_cnf_passed && cilium_cnf_passed
-          result.passed("CNF compatible with both Calico and Cilium")
-        else
-          result.failed("CNF not compatible with either Calico or Cilium")
-        end
-      ensure
-        kind_manager = KindManager.new
-        kind_manager.delete_cluster("calico-test")
-        kind_manager.delete_cluster("cilium-test")
-        ENV["KUBECONFIG"]="#{kubeconfig_orig}"
+      flag = ->(reason : String) do
+        coupled += 1
+        result.add_impacted_resource(kind, name, namespace, reason: reason)
+        Log.for(t.name).info { "#{kind}/#{name}: #{reason}" }
       end
+
+      if kind == "NetworkAttachmentDefinition"
+        flag.call("requires a Multus NetworkAttachmentDefinition (#{api_version})")
+      elsif (vendor = CNI_VENDOR_MARKERS.find { |m| api_version.includes?(m) })
+        flag.call("uses the CNI-specific API #{api_version}")
+      end
+
+      # Pod-level annotations: on the pod itself or in a workload's pod template.
+      [resource.dig?("metadata", "annotations"),
+       resource.dig?("spec", "template", "metadata", "annotations")].each do |annotations|
+        annotations.try(&.as_h?).try(&.each do |key, value|
+          key = key.as_s? || next
+          if key == CNI_NETWORKS_ANNOTATION
+            flag.call("requests additional CNI networks: #{CNI_NETWORKS_ANNOTATION}=#{value}")
+          elsif (vendor = CNI_VENDOR_MARKERS.find { |m| key.includes?(m) })
+            flag.call("carries the CNI-specific annotation #{key}")
+          end
+        end)
+      end
+
+      # SR-IOV device resources requested by any container.
+      [resource.dig?("spec", "containers"),
+       resource.dig?("spec", "template", "spec", "containers")].each do |containers|
+        containers.try(&.as_a?).try(&.each do |container|
+          container_name = container.dig?("name").try(&.as_s?)
+          ["requests", "limits"].each do |section|
+            container.dig?("resources", section).try(&.as_h?).try(&.each_key do |key|
+              key = key.as_s? || next
+              if key.downcase.includes?("sriov")
+                flag.call("container #{container_name} requests the SR-IOV device resource #{key}")
+              end
+            end)
+          end
+        end)
+      end
+    end
+
+    if coupled.zero?
+      result.passed("No coupling to a specific CNI plugin detected")
     else
-      result.skipped("Docker not installed")
+      result.failed("CNF is coupled to specific CNI plugins or features")
     end
   end
 end


### PR DESCRIPTION
First half of the #2178 replacement (split from the original single PR for reviewability; the `alpha_k8s_apis` half is stacked on this one). `cni_compatible` had skipped unconditionally since the v2 install rework ("temporarily disabled, check #2153").

It now answers the question it was always about — *is this CNF coupled to one specific CNI plugin?* — by inspecting the rendered composite manifest for coupling markers: Multus `NetworkAttachmentDefinition`s, `k8s.v1.cni.cncf.io/networks` annotations, Calico/Cilium-specific APIs and annotations, and SR-IOV device resource requests. Each finding is an impacted-resource entry naming the resource and the marker. No throwaway Calico/Cilium kind clusters, no docker-in-docker; the dead `setup_calico_cluster`/`setup_cilium_cluster` helpers and the spec's retry-around-a-permanent-skip (part of #1946) go with it.

New fixture `sample-cni-coupled`: a Deployment with a Multus networks annotation — inert without Multus, so it installs on any cluster and fails only this test.

The dynamic variant (install on another-CNI cluster via the v2 installer with a kubeconfig override) remains possible future work on #2178.

### Verification

`compatibility` shard on a local kind cluster with the CI compiler: 2 examples (coupled fixture fails with the impacted entry, clean CNF passes), 0 failures. `mdl` with the repo's style/rules passes on the docs. The intermediate state (this PR without the stacked one) builds and compiles the full spec suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
