### PR TITLE
operator_test: retry the namespace finalize on a 409 instead of erroring

### DIFF
--- a/spec/workload/operator_spec.cr
+++ b/spec/workload/operator_spec.cr
@@ -51,7 +51,13 @@ describe "Operator" do
         json.as_h.delete("spec")
         File.write("operator.json", "#{json.to_json}")
         Log.info { "Uninstall Namespace Finalizer" }
-        KubectlClient::Utils.replace_raw("'/api/v1/namespaces/operators/finalize'", "./operator.json")[:status].success?
+        begin
+          KubectlClient::Utils.replace_raw("'/api/v1/namespaces/operators/finalize'", "./operator.json")[:status].success?
+        rescue KubectlClient::ShellCMD::ConflictError
+          # The terminating namespace's resourceVersion moved between the read
+          # above and this write; refetch and try again.
+          false
+        end
       end
 
       repeat_with_timeout(timeout: GENERIC_OPERATION_TIMEOUT, errormsg: "Namespace uninstallation has timed-out") do
@@ -62,7 +68,13 @@ describe "Operator" do
         json.as_h.delete("spec")
         File.write("manager.json", "#{json.to_json}")
         Log.info { "Uninstall Namespace Finalizer" }
-        KubectlClient::Utils.replace_raw("'/api/v1/namespaces/operator-lifecycle-manager/finalize'", "./manager.json")[:status].success?
+        begin
+          KubectlClient::Utils.replace_raw("'/api/v1/namespaces/operator-lifecycle-manager/finalize'", "./manager.json")[:status].success?
+        rescue KubectlClient::ShellCMD::ConflictError
+          # The terminating namespace's resourceVersion moved between the read
+          # above and this write; refetch and try again.
+          false
+        end
       end
     end
   end

--- a/src/modules/kubectl_client/constants.cr
+++ b/src/modules/kubectl_client/constants.cr
@@ -10,4 +10,5 @@ module KubectlClient
   ALREADY_EXISTS_ERR_MATCH = "AlreadyExists"
   NOT_FOUND_ERR_MATCH      = "NotFound|does not exist"
   NETWORK_ERR_MATCH        = "Unable to connect to the server|connection refused|request timed out"
+  CONFLICT_ERR_MATCH       = "Conflict|the object has been modified"
 end

--- a/src/modules/kubectl_client/kubectl_client.cr
+++ b/src/modules/kubectl_client/kubectl_client.cr
@@ -74,6 +74,8 @@ module KubectlClient
           raise NotFoundError.new(result[:error], result[:status].exit_code)
         when /#{NETWORK_ERR_MATCH}/i.match(result[:error])
           raise NetworkError.new(result[:error], result[:status].exit_code)
+        when /#{CONFLICT_ERR_MATCH}/.match(result[:error])
+          raise ConflictError.new(result[:error], result[:status].exit_code)
         else
           raise UnspecifiedError.new(result[:error], result[:status].exit_code)
         end
@@ -96,6 +98,11 @@ module KubectlClient
     end
 
     class NetworkError < K8sClientCMDException
+    end
+
+    # HTTP 409: the object changed between a read and a write (resourceVersion
+    # moved); the operation is retryable after a fresh read.
+    class ConflictError < K8sClientCMDException
     end
 
     class UnspecifiedError < K8sClientCMDException


### PR DESCRIPTION
Fixes the flake seen in [this run](https://github.com/lfn-cnti/testsuite/actions/runs/33378313444/job/99444730563): `operator_test`'s cleanup force-finishes the terminating `operators` / `operator-lifecycle-manager` namespaces inside `repeat_with_timeout`, but when the namespace's `resourceVersion` moved between the GET and the `kubectl replace --raw …/finalize`, the 409 came back as a raised `UnspecifiedError` and escaped the retry loop — erroring an example whose assertions had already passed.

- `kubectl_client`: 409s (`Conflict` / "the object has been modified") now raise a dedicated `ConflictError` (new, subclass of `K8sClientCMDException`), so callers can tell a retryable write race from a real failure.
- `operator_spec`: both finalize calls rescue `ConflictError` and return `false`, which is exactly what `repeat_with_timeout` needs to refetch with the fresh `resourceVersion` and try again.

No behaviour change for any other caller: previously these errors raised `UnspecifiedError`, which nobody rescued specifically; `ConflictError` still inherits from `K8sClientCMDException`.

### Verification

Binary and full spec suite compile with the CI compiler. The race itself is timing-dependent (it needs the namespace object to change mid-cleanup), so the proof is the `operator_test` shard in CI; the failed job on #2522 has also been re-run as-is to confirm the flake passes on retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)