### PR TITLE
Composite manifest: discover CRDs backing the CNF's custom resources

### DIFF
--- a/sample-cnfs/sample-cr-no-crd/cnf-testsuite.yml
+++ b/sample-cnfs/sample-cr-no-crd/cnf-testsuite.yml
@@ -1,0 +1,6 @@
+---
+config_version: v2
+deployments:
+  manifests:
+  - name: cr-no-crd
+    manifest_directory: manifests

--- a/sample-cnfs/sample-cr-no-crd/manifests/manifest.yml
+++ b/sample-cnfs/sample-cr-no-crd/manifests/manifest.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cr-no-crd
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+
+---
+# A custom resource whose CRD is NOT part of this CNF: the spec pre-installs
+# the CRD on the cluster, the way an operator would at runtime.
+apiVersion: example.com/v1
+kind: Widget
+metadata:
+  name: widget-sample
+  namespace: cr-no-crd
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cr-no-crd
+  namespace: cr-no-crd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cr-no-crd
+  template:
+    metadata:
+      labels:
+        app: cr-no-crd
+    spec:
+      containers:
+      - name: main
+        # renovate: datasource=docker depName=busybox
+        image: busybox:1.33.1@sha256:f7ca5a32c10d51aeda3b4d01c61c6061f497893d7f6628b92f822f7117182a57
+        command: ["sh", "-c", "sleep 2147483647"]

--- a/spec/fixtures/widgets-crd.yml
+++ b/spec/fixtures/widgets-crd.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  scope: Namespaced
+  names:
+    plural: widgets
+    singular: widget
+    kind: Widget
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true

--- a/spec/setup_spec.cr
+++ b/spec/setup_spec.cr
@@ -178,6 +178,23 @@ describe "Installation" do
     end
   end
 
+  it "'cnf_install' should add cluster CRDs backing the cnf's custom resources to the composite manifest", tags: ["cnf_installation1"] do
+    begin
+      # The CRD exists only on the cluster (as if an operator had installed it);
+      # the fixture declares a Widget custom resource but not the CRD.
+      result = ShellCmd.run("kubectl apply -f spec/fixtures/widgets-crd.yml", "apply_widgets_crd")
+      result[:status].success?.should be_true
+      result = ShellCmd.cnf_install("--cnf-config sample-cnfs/sample-cr-no-crd/cnf-testsuite.yml")
+      (/Added 1 CRD\(s\) backing the CNF's custom resources/ =~ result[:output]).should_not be_nil
+      composite = File.read("cnti/installed-cnf/common_manifest.yml")
+      (/# Source: crd_group_filter \(example.com\) \(CustomResourceDefinition\/widgets.example.com\)/ =~ composite).should_not be_nil
+    ensure
+      result = ShellCmd.cnf_uninstall()
+      result[:status].success?.should be_true
+      ShellCmd.run("kubectl delete -f spec/fixtures/widgets-crd.yml --ignore-not-found", "delete_widgets_crd")
+    end
+  end
+
   it "'cnf_install/cnf_uninstall' should install/uninstall a cnf with multiple deployments", tags: ["cnf_installation1"] do
     begin
       result = ShellCmd.cnf_install("--cnf-config sample-cnfs/sample_multiple_deployments/cnf-testsuite.yml")

--- a/src/tasks/utils/cnf_installation/install_common.cr
+++ b/src/tasks/utils/cnf_installation/install_common.cr
@@ -158,6 +158,7 @@ module CNFInstall
     # After all deployments are installed, fetch and add label-identified resources to the composite manifest
     if !parsed_args[:skip_wait_for_install]
       add_label_resources_to_manifest(config, parsed_args[:timeout])
+      add_crds_for_custom_resources_to_manifest
     end
   end
 
@@ -479,6 +480,54 @@ module CNFInstall
       logger.info { "Added #{new_owned_resources.size} owner-reference resources to composite manifest" }
       stdout_success "Added #{new_owned_resources.size} resources via ownerReferences to composite manifest."
     end
+
+  end
+
+  # CRDs behind the CNF's custom resources are part of the CNF's API surface
+  # but are often installed at runtime (by an operator or OLM) rather than
+  # declared in the CNF's own manifests, so they never reached the composite
+  # manifest. Fetch every cluster CRD whose spec.group backs one of the CNF's
+  # custom resources, skipping CRDs the CNF already declares itself.
+  private def self.add_crds_for_custom_resources_to_manifest
+    logger = Log.for("add_crds_for_custom_resources_to_manifest")
+    manifest_resources = Manifest.manifest_path_to_ymls(COMMON_MANIFEST_FILE_PATH)
+
+    cr_groups = manifest_resources.select { |resource| is_custom_resource?(resource) }.compact_map do |resource|
+      api_version = resource.dig?("apiVersion").try(&.as_s)
+      next unless api_version && api_version.includes?("/")
+      resource.dig?("kind").try(&.as_s) == "CustomResourceDefinition" ? nil : api_version.split("/").first
+    end.to_set
+    return if cr_groups.empty?
+
+    declared_crd_names = manifest_resources.compact_map do |resource|
+      next unless resource.dig?("kind").try(&.as_s) == "CustomResourceDefinition"
+      resource.dig?("metadata", "name").try(&.as_s)
+    end.to_set
+
+    discovered_crds = [] of YAML::Any
+    begin
+      json = KubectlClient::Get.resource("customresourcedefinitions")
+      items = (json.dig?("items").try &.as_a?) || [] of JSON::Any
+      items.each do |item|
+        group = item.dig?("spec", "group").try(&.as_s)
+        name = item.dig?("metadata", "name").try(&.as_s)
+        next unless group && name
+        next unless cr_groups.includes?(group)
+        next if declared_crd_names.includes?(name)
+        item.as_h.delete("status") if item.as_h?
+        discovered_crds << YAML.parse(item.to_json)
+        logger.debug { "Discovered CRD #{name} for custom resource group #{group}" }
+      end
+    rescue ex : KubectlClient::ShellCMD::K8sClientCMDException
+      logger.warn { "Could not list CRDs for custom resource groups #{cr_groups.join(", ")}: #{ex.message}" }
+      return
+    end
+    return if discovered_crds.empty?
+
+    crd_manifest = Manifest.combine_ymls_with_crd_source(discovered_crds)
+    Manifest.add_manifest_to_file("custom-resource-definitions", crd_manifest, COMMON_MANIFEST_FILE_PATH)
+    logger.info { "Added #{discovered_crds.size} CRD(s) backing the CNF's custom resources to composite manifest" }
+    stdout_success "Added #{discovered_crds.size} CRD(s) backing the CNF's custom resources to composite manifest."
   end
 
   private def self.fetch_workload_resources_by_labels(config, default_namespace : String = CLUSTER_DEFAULT_NAMESPACE) : Array(YAML::Any)

--- a/src/tasks/utils/cnf_installation/manifest.cr
+++ b/src/tasks/utils/cnf_installation/manifest.cr
@@ -60,6 +60,17 @@ module CNFInstall
       manifest
     end
 
+    # Combine YAMLs with source comments for CRDs discovered through the
+    # API groups of the CNF's custom resources
+    def self.combine_ymls_with_crd_source(ymls : Array(YAML::Any)) : String
+      ymls.map do |yaml_object|
+        name = yaml_object.dig?("metadata", "name").try(&.as_s) || "unknown"
+        group = yaml_object.dig?("spec", "group").try(&.as_s) || "unknown"
+        yaml_str = yaml_object.to_yaml
+        yaml_str.sub(/^---\n/, "---\n# Source: crd_group_filter (#{group}) (CustomResourceDefinition/#{name})\n")
+      end.join
+    end
+
     # Combine YAMLs with source comments for owned resources
     def self.combine_ymls_with_owner_source(ymls : Array(YAML::Any), owner_map : Hash(String, String)) : String
       manifest = ymls.map do |yaml_object|


### PR DESCRIPTION
Follow-up to #2523/#2525: the composite manifest's post-install discovery captured operator-created *workloads* (label- and ownerReference-identified) but never the **CRDs** the operator or OLM installs at runtime — so any test reading `cnf_resources` was blind to the CNF's own API definitions unless the CNF shipped them in its manifests.

After the label and owner passes, install now collects the API groups of the CNF's custom resources from the composite, fetches every cluster CRD whose `spec.group` backs one of them, and appends the ones the CNF did not already declare (deduped by name, `status` stripped, tagged with a `# Source: crd_group_filter (<group>)` comment like the other discovered resources). A CRD-list failure is logged and skipped — discovery never fails an install.

Every manifest-driven test benefits; the immediate consumer is `alpha_k8s_apis` (#2525), whose "CRD serves only alpha versions" check now also sees runtime-installed CRDs.

### Verification

New spec example (`cnf_installation1` shard): the spec pre-installs `widgets.example.com` on the cluster the way an operator would, installs a fixture that declares a `Widget` CR but no CRD, and asserts the CRD lands in the composite with its source comment. Shard run locally on kind with the CI compiler: the full `cnf_installation1` shard (19 examples) ran once and caught a real bug — the CRD pass sat inside `add_label_resources_to_manifest`, which returns early for CNFs without `workload_resource_labels`, so it never fired for the fixture. After moving the call to the install flow itself, the new example passes (the other 18 were already green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
