### PR TITLE
setup: install nothing a test does not need

### DIFF
--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -8,7 +8,8 @@ alias_task "clusterapi_enabled", "platform:clusterapi_enabled"
 
 namespace "platform" do
   desc "Does the platform pass the K8s conformance tests?"
-  scored_task "k8s_conformance" do |t, args|
+  scored_task "k8s_conformance",
+    deps: ["setup:install_sonobuoy"] do |t, args|
     CNFManager::Task.task_runner(args, task: t, check_cnf_installed: false) do |args, config, result|
       current_dir = FileUtils.pwd
       Log.for(t.name).debug { "current dir: #{current_dir}" }

--- a/src/tasks/setup/kind_setup.cr
+++ b/src/tasks/setup/kind_setup.cr
@@ -9,26 +9,7 @@ require "retriable"
 desc "Install Kind"
 task "install_kind" do |_, args|
   Log.info {"install_kind"}
-  current_dir = FileUtils.pwd 
-  ToolInstall.ensure("kind", Setup::KIND_VERSION, Setup::KIND_BINARY) do
-    write_file = Setup::KIND_BINARY
-    Log.info { "write_file: #{write_file}" }
-    Log.info { "install kind" }
-    url = Setup::KIND_DOWNLOAD_URL
-    Log.info { "url: #{url}" }
-    do_this_on_each_retry = ->(ex : Exception, attempt : Int32, elapsed_time : Time::Span, next_interval : Time::Span) do
-        Log.info { "#{ex.class}: '#{ex.message}' - #{attempt} attempt in #{elapsed_time} seconds and #{next_interval} seconds until the next try."}
-    end
-    Retriable.retry(on_retry: do_this_on_each_retry, times: 3, base_interval: 1.second) do
-      download_file("#{url}","#{write_file}")
-      begin
-        File.chmod(write_file, 0o755)
-      rescue
-        raise "Unable to make #{write_file} executable"
-      end
-    end
-    true
-  end
+  KindManager.ensure_installed
 end
 
 desc "Uninstall Kind"
@@ -49,6 +30,27 @@ class KindManager
   # Path to kind
   property kind : String
 
+  # Kind is not part of `setup`: whoever needs a throwaway cluster installs
+  # the binary on first use.
+  def self.ensure_installed
+    ToolInstall.ensure("kind", Setup::KIND_VERSION, Setup::KIND_BINARY) do
+      write_file = Setup::KIND_BINARY
+      Log.info { "install kind: #{write_file}" }
+      do_this_on_each_retry = ->(ex : Exception, attempt : Int32, elapsed_time : Time::Span, next_interval : Time::Span) do
+        Log.info { "#{ex.class}: '#{ex.message}' - #{attempt} attempt in #{elapsed_time} seconds and #{next_interval} seconds until the next try." }
+      end
+      Retriable.retry(on_retry: do_this_on_each_retry, times: 3, base_interval: 1.second) do
+        download_file(Setup::KIND_DOWNLOAD_URL, write_file)
+        begin
+          File.chmod(write_file, 0o755)
+        rescue
+          raise "Unable to make #{write_file} executable"
+        end
+      end
+      true
+    end
+  end
+
   def initialize
     @kind = Setup::KIND_BINARY
   end
@@ -56,6 +58,7 @@ class KindManager
   #totod make a create cluster with flannel
 
   def create_cluster(name : String, kind_config : String?, k8s_version = "1.35.5") : KindManager::Cluster?
+    KindManager.ensure_installed
     Log.info { "Creating Kind Cluster" }
     kubeconfig = "#{Setup::KIND_DIR}/#{name}_admin.conf"
     Log.for("kind_kubeconfig").info { kubeconfig }

--- a/src/tasks/setup/setup.cr
+++ b/src/tasks/setup/setup.cr
@@ -2,8 +2,7 @@ require "sam"
 
 desc "Sets up the CNF test suite, the K8s cluster, and upstream projects"
 task "setup", ["version", "setup:cnf_directory_setup", "setup:install_local_helm", "setup:prereqs",
-               "setup:create_namespace",
-               "setup:install_sonobuoy", "setup:install_kind"] do |_, args|
+               "setup:create_namespace"] do |_, args|
   stdout_success "Dependency installation complete"
 end
 


### PR DESCRIPTION
`setup` downloaded two tools whose consumers no longer exist, and a third that only one platform test uses — on a slow link those downloads made setup look hung (25 MB of sonobuoy at ~100 KB/s, silently).

- **kind: out of setup, self-installing on first use.** It entered setup in 2021 (#1064) for `cni_compatible`'s throwaway clusters; the product code no longer uses it, but the platform-security specs still build kind clusters for the etcd-encryption examples. `KindManager.create_cluster` now ensures the binary itself (`KindManager.ensure_installed`, shared with the kept `setup:install_kind` task), so nothing installs kind unless something actually creates a cluster. (`install_apisnoop` was already removed by #2525.)
- **sonobuoy: deferred.** `setup:install_sonobuoy` is now a dependency of `platform:k8s_conformance` — its only consumer — so it installs on first use instead of for everyone. The task and its uninstall stay.

`setup` is now: directories, helm (only if missing), prerequisite checks, namespace — seconds, no downloads on a system with helm.

### Verification

Built with the CI compiler; the full spec graph compiles (the platform-security specs are kind's remaining consumer). Locally, with `~/.cnf-testsuite/tools/sonobuoy*` deleted first: the `setup` spec example passes and downloads nothing, and `platform:k8s_conformance` auto-installs sonobuoy through its new task dependency and runs to a verdict (the verdict itself was a quick-mode e2e failure specific to the local WSL2 cluster, which this change cannot influence). The `platform` CI shard is the authoritative proof for the conformance path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
