### PR TITLE
Console feedback for every long silent operation

### DIFF
--- a/src/tasks/platform/platform.cr
+++ b/src/tasks/platform/platform.cr
@@ -28,6 +28,7 @@ namespace "platform" do
       # Run the tests
       testrun_stdout = IO::Memory.new
       Log.debug { "CNF_TESTSUITE_ENV: #{ENV["CNF_TESTSUITE_ENV"]?}" }
+      StatusLine.push "Running the Sonobuoy conformance scan (this takes several minutes)..."
       if ENV["CNF_TESTSUITE_ENV"]? == "TEST"
         Log.info { "Running Sonobuoy using Quick Mode" }
         cmd = "#{sonobuoy} run --wait --mode quick"
@@ -48,6 +49,7 @@ namespace "platform" do
         )
       end
       Log.debug { testrun_stdout.to_s }
+      StatusLine.pop
 
       cmd = "results=$(#{sonobuoy} retrieve #{Setup::SONOBUOY_DIR}); #{sonobuoy} results $results"
       results_stdout = IO::Memory.new

--- a/src/tasks/setup/cluster_api_setup.cr
+++ b/src/tasks/setup/cluster_api_setup.cr
@@ -25,10 +25,12 @@ namespace "setup" do
 
     File.write("#{clusterctl}/clusterctl.yaml", "CLUSTER_TOPOLOGY: \"true\"")
 
+    StatusLine.push "Initializing Cluster API management components (several minutes on first run)..."
     cluster_init_cmd = "#{Setup::CLUSTERCTL_BINARY} init --infrastructure docker --wait-providers"
     stdout = IO::Memory.new
     Process.run(cluster_init_cmd, shell: true, output: stdout, error: stdout)
     Log.for("clusterctl init").info { stdout }
+    StatusLine.pop
 
     create_cluster_file = File.join(Setup::CLUSTER_API_DIR, "capi.yaml")
 

--- a/src/tasks/setup/cluster_setup.cr
+++ b/src/tasks/setup/cluster_setup.cr
@@ -7,6 +7,7 @@ namespace "setup" do
   task "install_cluster_tools" do |_, args|
     logger = SLOG.for("install_cluster_tools")
     logger.info { "Installing cluster_tools on the cluster" }
+    StatusLine.push "Installing cluster-tools on every node (first run pulls the image)..."
 
     begin
       ClusterTools.install
@@ -21,6 +22,7 @@ namespace "setup" do
       exit(1)
     end
     logger.info { "cluster_tools has been installed on the cluster" }
+    StatusLine.pop
   end
 
   desc "Uninstall CNF Test Suite Cluster Tools"

--- a/src/tasks/setup/cnf_setup.cr
+++ b/src/tasks/setup/cnf_setup.cr
@@ -16,16 +16,18 @@ task "cnf_install", ["setup:install_local_helm", "setup:create_namespace"] do |_
     exit 1
   end
 
+  StatusLine.push "CNF installation in progress..."
+  StatusLine.push "Installing cluster-tools on every node (first run pulls the image)..."
   if ClusterTools.install
-    stdout_success "ClusterTools installed"
+    StatusLine.pop
   else
     stdout_failure "The ClusterTools installation timed out. Please check the status of the cluster-tools pods."
     exit 1
   end
 
-  stdout_success "CNF installation start."
   CNFInstall.install_cnf(args)
   logger.info { "CNF installed successfuly" }
+  StatusLine.pop
   stdout_success "CNF installation complete."
 end
 
@@ -34,7 +36,9 @@ task "cnf_uninstall" do |_, args|
   logger = SLOG.for("cnf_uninstall")
   logger.info { "Uninstalling CNF from cluster" }
 
+  StatusLine.push "CNF uninstallation in progress..."
   result = CNFInstall.uninstall_cnf(args)
+  StatusLine.pop
 
   if result
     stdout_success "CNF uninstallation succeeded."

--- a/src/tasks/setup/litmus_setup.cr
+++ b/src/tasks/setup/litmus_setup.cr
@@ -24,6 +24,7 @@ namespace "setup" do
       next
     end
 
+    StatusLine.push "Installing the LitmusChaos operator into the cluster..."
     begin
       KubectlClient::Utils.label("namespace", LitmusManager::LITMUS_NAMESPACE,
         ["pod-security.kubernetes.io/enforce=privileged"])
@@ -35,6 +36,7 @@ namespace "setup" do
     end
 
     logger.info { "Litmus tool has been installed" }
+    StatusLine.pop
   end
 
   desc "Uninstall LitmusChaos"

--- a/src/tasks/setup/opa_setup.cr
+++ b/src/tasks/setup/opa_setup.cr
@@ -19,6 +19,7 @@ task "install_opa", ["setup:install_local_helm", "setup:create_namespace"] do |_
 
   helm_install_args = helm_install_args_list.join(" ")
 
+  StatusLine.push "Installing OPA Gatekeeper into the cluster..."
   Helm.helm_repo_add("gatekeeper", "https://open-policy-agent.github.io/gatekeeper/charts")
   begin
     Helm.install("opa-gatekeeper", "gatekeeper/gatekeeper", values: "--version #{Setup::GATEKEEPER_VERSION} #{helm_install_args}")
@@ -39,6 +40,7 @@ task "install_opa", ["setup:install_local_helm", "setup:create_namespace"] do |_
     raise "Gatekeeper did not create the requiretags constraint CRD within 300 seconds"
   end
   KubectlClient::Apply.file(enforce_manifest)
+  StatusLine.pop
 end
 
 desc "Uninstall OPA"

--- a/src/tasks/utils/cnf_installation/install_common.cr
+++ b/src/tasks/utils/cnf_installation/install_common.cr
@@ -120,7 +120,7 @@ module CNFInstall
     deployment_managers.each do |deployment_manager|
       deployment_name = deployment_manager.deployment_name
 
-      stdout_success "Installing deployment \"#{deployment_name}\"."
+      StatusLine.update "Installing deployment \"#{deployment_name}\"."
       result = deployment_manager.install
       if !result
         stdout_failure "Deployment of \"#{deployment_name}\" failed during CNF installation."
@@ -210,7 +210,7 @@ module CNFInstall
       msg = parsed_args[:skip_wait_for_uninstall] ?
         "All CNF deployments were uninstalled; resources will continue deleting in background." :
         "All CNF deployments were uninstalled."
-      stdout_success msg
+      StatusLine.update msg
     else
       stdout_failure "CNF uninstallation wasn't successful; check logs for details."
     end
@@ -294,9 +294,8 @@ module CNFInstall
     total_resource_count = workload_resources_info.size
     current_resource_number = 1
     workload_resources_info.each do |resource_info|
-      stdout_success "Waiting for resource for \"#{deployment_name}\" deployment (#{current_resource_number}/" +
-                     "#{total_resource_count}): [#{resource_info[:kind]}] #{resource_info[:name]}",
-        same_line: true
+      StatusLine.update "Waiting for resource for \"#{deployment_name}\" deployment (#{current_resource_number}/" +
+                        "#{total_resource_count}): [#{resource_info[:kind]}] #{resource_info[:name]}"
 
       ready = KubectlClient::Wait.resource_wait_for_install(resource_info[:kind],
         resource_info[:name], wait_count: timeout, namespace: resource_info[:namespace])
@@ -334,7 +333,7 @@ module CNFInstall
     end
     
     if workload_resources_info.size > 0
-      stdout_success "All \"#{deployment_name}\" deployment resources are up.", same_line: true
+      StatusLine.update "All \"#{deployment_name}\" deployment resources are up."
     end
     
     # Wait for custom resources (e.g., CRDs) with Ready condition
@@ -342,9 +341,8 @@ module CNFInstall
       total_custom_count = custom_resources_info.size
       current_custom_number = 1
       custom_resources_info.each do |resource_info|
-        stdout_success "Waiting for custom resource for \"#{deployment_name}\" deployment (#{current_custom_number}/" +
-                       "#{total_custom_count}): [#{resource_info[:kind]}] #{resource_info[:name]}",
-          same_line: true
+        StatusLine.update "Waiting for custom resource for \"#{deployment_name}\" deployment (#{current_custom_number}/" +
+                          "#{total_custom_count}): [#{resource_info[:kind]}] #{resource_info[:name]}"
 
         ready = KubectlClient::Wait.resource_wait_for_install(resource_info[:kind],
           resource_info[:name], wait_count: timeout, namespace: resource_info[:namespace])
@@ -357,7 +355,7 @@ module CNFInstall
         end
         current_custom_number += 1
       end
-      stdout_success "All \"#{deployment_name}\" deployment custom resources are ready.", same_line: true
+      StatusLine.update "All \"#{deployment_name}\" deployment custom resources are ready."
     end
   end
 
@@ -368,7 +366,7 @@ module CNFInstall
 
     # Make the sleep before label resource identification configurable
     label_resource_sleep = ENV.has_key?("CNF_TESTSUITE_LABEL_RESOURCE_SLEEP") ? ENV["CNF_TESTSUITE_LABEL_RESOURCE_SLEEP"].to_i : 5
-    stdout_success "Identifying and adding label-selected resources to composite manifest."
+    StatusLine.update "Identifying and adding label-selected resources to composite manifest."
     sleep label_resource_sleep.seconds
     start = Time.utc
 
@@ -445,7 +443,7 @@ module CNFInstall
       label_manifest = Manifest.combine_ymls_with_label_source(label_resource_ymls, label_selector)
       Manifest.add_manifest_to_file("label-identified-resources", label_manifest, COMMON_MANIFEST_FILE_PATH)
       logger.info { "Added #{label_resource_ymls.size} label-identified resources to composite manifest" }
-      stdout_success "Added #{label_resource_ymls.size} label-identified resources to composite manifest."
+      StatusLine.update "Added #{label_resource_ymls.size} label-identified resources to composite manifest."
     end
     
     # Fetch resources owned by CUSTOM resources only (not standard k8s resources)
@@ -478,7 +476,7 @@ module CNFInstall
       owned_manifest = Manifest.combine_ymls_with_owner_source(new_owned_resources, owner_map)
       Manifest.add_manifest_to_file("owner-reference-resources", owned_manifest, COMMON_MANIFEST_FILE_PATH)
       logger.info { "Added #{new_owned_resources.size} owner-reference resources to composite manifest" }
-      stdout_success "Added #{new_owned_resources.size} resources via ownerReferences to composite manifest."
+      StatusLine.update "Added #{new_owned_resources.size} resources via ownerReferences to composite manifest."
     end
 
   end
@@ -527,7 +525,7 @@ module CNFInstall
     crd_manifest = Manifest.combine_ymls_with_crd_source(discovered_crds)
     Manifest.add_manifest_to_file("custom-resource-definitions", crd_manifest, COMMON_MANIFEST_FILE_PATH)
     logger.info { "Added #{discovered_crds.size} CRD(s) backing the CNF's custom resources to composite manifest" }
-    stdout_success "Added #{discovered_crds.size} CRD(s) backing the CNF's custom resources to composite manifest."
+    StatusLine.update "Added #{discovered_crds.size} CRD(s) backing the CNF's custom resources to composite manifest."
   end
 
   private def self.fetch_workload_resources_by_labels(config, default_namespace : String = CLUSTER_DEFAULT_NAMESPACE) : Array(YAML::Any)
@@ -755,10 +753,7 @@ module CNFInstall
       name      = res[:name]
       namespace = res[:namespace]
 
-      stdout_success(
-        "Waiting deletion for \"#{deployment_name}\" (#{idx+1}/#{total}): [#{kind}] #{name}",
-        same_line: idx > 0
-      )
+      StatusLine.update "Waiting deletion for \"#{deployment_name}\" (#{idx+1}/#{total}): [#{kind}] #{name}"
 
       ok = KubectlClient::Wait.resource_wait_for_uninstall(
         kind, name, namespace, timeout, descendants
@@ -774,7 +769,7 @@ module CNFInstall
     end
 
     if all_deleted
-      stdout_success("All \"#{deployment_name}\" resources are gone.", same_line: true)
+      StatusLine.update "All \"#{deployment_name}\" resources are gone."
     else
       stdout_failure("Some resources of \"#{deployment_name}\" did not finish deleting within the timeout.")
     end

--- a/src/tasks/utils/fluent_manager.cr
+++ b/src/tasks/utils/fluent_manager.cr
@@ -27,6 +27,7 @@ module FluentManager
 
     def install
       Log.info { "Installing #{flavor_name} daemonset using #{values_file}" }
+      StatusLine.push "Installing #{flavor_name} DaemonSet into the cluster..."
       Helm.helm_repo_add(flavor_name, repo_url)
       FileUtils.mkdir_p(Setup::RENDERED_MANIFESTS_DIR)
       values_path = File.join(Setup::RENDERED_MANIFESTS_DIR, values_file)
@@ -34,8 +35,10 @@ module FluentManager
       begin
         Helm.install(flavor_name, chart, namespace: TESTSUITE_NAMESPACE, values: "--values #{values_path}")
         KubectlClient::Wait.resource_wait_for_install("Daemonset", flavor_name, namespace: TESTSUITE_NAMESPACE)
+        StatusLine.pop
       rescue Helm::ShellCMD::CannotReuseReleaseNameError
         Log.info { "Release #{flavor_name} already installed" }
+        StatusLine.pop
       end
     end
 

--- a/src/tasks/utils/jaeger.cr
+++ b/src/tasks/utils/jaeger.cr
@@ -19,6 +19,7 @@ module JaegerManager
 
   def self.install
     Log.info { "Installing Jaeger daemonset" }
+    StatusLine.push "Installing Jaeger into the cluster (cassandra warm-up; this can take a few minutes)..."
     Helm.helm_repo_add("jaegertracing", "https://jaegertracing.github.io/helm-charts")
     CNFManager.ensure_namespace_exists!(JAEGER_NAMESPACE)
     Helm.install("jaeger", "jaegertracing/jaeger", namespace: JAEGER_NAMESPACE,
@@ -33,6 +34,7 @@ module JaegerManager
       ready = KubectlClient::Wait.resource_wait_for_install(kind, name, wait_count, namespace: JAEGER_NAMESPACE)
       raise "Jaeger install failed: #{kind} #{name} did not become ready" unless ready
     end
+    StatusLine.pop
   end
 
   # GET against the jaeger-query HTTP API through the API-server proxy: works

--- a/src/tasks/utils/kubescape.cr
+++ b/src/tasks/utils/kubescape.cr
@@ -8,6 +8,7 @@ module Kubescape
 
   #kubescape scan framework nsa --exclude-namespaces kube-system,kube-public
   def self.scan(cli : String? = nil, control_id : String? = nil, namespace : String? = nil)
+    StatusLine.push "Running the Kubescape cluster scan..."
     default_options = "--format json --format-version=v1"
     output_file = RESULTS_FILE
     exclude_namespaces = EXCLUDE_NAMESPACES.join(",")
@@ -30,6 +31,7 @@ module Kubescape
     )
     Log.info { "output: #{output.to_s}" }
     Log.info { "stderr: #{stderr.to_s}" }
+    StatusLine.pop
     {status: status, output: output.to_s, error: stderr.to_s}
   end
 

--- a/src/tasks/utils/litmus_manager.cr
+++ b/src/tasks/utils/litmus_manager.cr
@@ -73,8 +73,19 @@ module LitmusManager
     {status_code, status_response}
   end
 
-  private def self.get_status_info_until(chaos_resource, test_name, output_format, timeout, namespace, &block)
+  private def self.get_status_info_until(chaos_resource, test_name, output_format, timeout, namespace, status : String? = nil, &block)
+    started = Time.utc
+    last_tick = started
     repeat_with_timeout(timeout: timeout, errormsg: "Litmus response timed-out") do
+      if status
+        elapsed = (Time.utc - started).to_i
+        # Every poll on a TTY (the line rewrites itself); every 30 s when piped,
+        # so CI logs get a heartbeat without a line per poll.
+        if STDOUT.tty? || (Time.utc - last_tick) >= 30.seconds
+          StatusLine.update "#{status} (#{elapsed}s of #{timeout}s)..."
+          last_tick = Time.utc
+        end
+      end
       status_code, status_response = get_status_info(chaos_resource, test_name, output_format, namespace)
       status_code == 0 && yield status_response
     end
@@ -84,14 +95,17 @@ module LitmusManager
   def self.wait_for_test(test_name, chaos_experiment_name, args, namespace : String = "default")
     chaos_result_name = "#{test_name}-#{chaos_experiment_name}"
     Log.info { "wait_for_test: #{chaos_result_name}" }
+    status = "Waiting for the #{chaos_experiment_name} chaos experiment to finish"
+    StatusLine.push "#{status}..."
 
-    get_status_info_until("chaosengine", test_name, "jsonpath={.status.engineStatus}", LITMUS_CHAOS_TEST_TIMEOUT, namespace) do |engineStatus|
+    get_status_info_until("chaosengine", test_name, "jsonpath={.status.engineStatus}", LITMUS_CHAOS_TEST_TIMEOUT, namespace, status) do |engineStatus|
       ["completed", "stopped"].includes?(engineStatus)
     end
 
-    get_status_info_until("chaosresults", chaos_result_name, "jsonpath={.status.experimentStatus.verdict}", GENERIC_OPERATION_TIMEOUT, namespace) do |verdict|
+    get_status_info_until("chaosresults", chaos_result_name, "jsonpath={.status.experimentStatus.verdict}", GENERIC_OPERATION_TIMEOUT, namespace, "Waiting for the #{chaos_experiment_name} verdict") do |verdict|
       verdict != "Awaited"
     end
+    StatusLine.pop
   end
 
   ## check_chaos_verdict will check the verdict of chaosexperiment

--- a/src/tasks/utils/tool_install.cr
+++ b/src/tasks/utils/tool_install.cr
@@ -30,8 +30,13 @@ module ToolInstall
     File.delete?(marker(artifact))
     FileUtils.mkdir_p(File.dirname(artifact))
     logger.info { "Installing #{name} #{version}: #{artifact}" }
-    return false unless yield
-    File.write(marker(artifact), version)
+    StatusLine.push "Installing #{name} #{version} (one-time setup)..."
+    begin
+      return false unless yield
+      File.write(marker(artifact), version)
+    ensure
+      StatusLine.pop
+    end
     true
   end
 

--- a/src/tasks/utils/utils.cr
+++ b/src/tasks/utils/utils.cr
@@ -298,11 +298,64 @@ def tools_path
   value
 end
 
+# One line of work-in-progress information, ever. Operations push a message
+# when they start, update it while they run, and pop when they finish; a
+# nested operation rewrites the same line and popping restores the outer
+# message, so the screen never holds more than one status line and holds
+# none once everything is done. On a TTY the line rewrites itself in place;
+# in piped/CI output each message is a plain line and nothing is erased, so
+# logs keep the full trail.
+module StatusLine
+  @@messages = [] of String
+  @@on_screen = false
+
+  def self.push(msg : String)
+    @@messages << msg
+    render(msg)
+  end
+
+  def self.update(msg : String)
+    return push(msg) if @@messages.empty?
+    @@messages[-1] = msg
+    render(msg)
+  end
+
+  def self.pop
+    @@messages.pop?
+    if (outer = @@messages.last?)
+      render(outer)
+    else
+      erase
+    end
+  end
+
+  # Called by the persistent stdout helpers: whatever was on the status line
+  # is no longer the last line on screen.
+  def self.interrupted
+    @@on_screen = false
+  end
+
+  private def self.render(msg : String)
+    print "\e[1A\e[K" if STDOUT.tty? && @@on_screen
+    puts msg
+    @@on_screen = STDOUT.tty?
+  end
+
+  private def self.erase
+    if STDOUT.tty? && @@on_screen
+      print "\e[1A\e[K"
+      STDOUT.flush
+    end
+    @@on_screen = false
+  end
+end
+
 def stdout_info(msg, same_line = false)
   if same_line && STDOUT.tty?
     msg = "#{"\e[1A\e[K"}#{msg}"
   end
   puts msg
+  StatusLine.interrupted
 end
 
 # \e[1A\e[K is a sequence that allows to clear current line and place cursor at
@@ -313,6 +366,7 @@ def stdout_colored(msg, color, same_line = false)
     msg = "#{"\e[1A\e[K"}#{msg}"
   end
   puts msg.colorize(color)
+  StatusLine.interrupted
 end
 
 def stdout_success(msg, same_line = false)
@@ -471,26 +525,92 @@ end
 
 def download_file(url : String, output_path : String,
                   redirect_limit : Int = 5, headers : HTTP::Headers? = nil)
+  # The display label comes from the caller's URL: redirect targets (GitHub
+  # serves release assets under opaque UUID names) and temp output files both
+  # make meaningless labels.
+  label = File.basename(URI.parse(url).path)
+  label = File.basename(output_path) if label.empty?
   NetRetry.with_retries("download #{url}") do
-    follow_and_download(url, output_path, redirect_limit, headers)
+    follow_and_download(url, output_path, redirect_limit, headers, label)
   end
 end
 
+# Streams the response straight to `<output_path>.part` (so a long download
+# leaves visible, growing evidence on disk) and renames on completion; a
+# size-announcing line on stdout tells the user what a first run is fetching.
+# Connect/read timeouts turn a stalled connection into a retryable failure
+# instead of an indefinite silent hang.
 private def follow_and_download(url : String, output_path : String,
-                                redirect_limit : Int, headers : HTTP::Headers?)
+                                redirect_limit : Int, headers : HTTP::Headers?, label : String)
   raise "Too many redirects" if redirect_limit == 0
 
-  response = HTTP::Client.get(url, headers: headers)
-  if response.status_code >= 300 && response.status_code < 400
-    new_location = response.headers["Location"]
-    raise "Status code 3xx, but redirect location missing" unless new_location
-    return follow_and_download(new_location, output_path, redirect_limit - 1, headers)
+  uri = URI.parse(url)
+  client = HTTP::Client.new(uri)
+  client.connect_timeout = 10.seconds
+  client.read_timeout = 60.seconds
+
+  redirect_location = nil
+  partial_path = nil
+  announced = false
+  begin
+    client.get(uri.request_target, headers: headers) do |response|
+      if response.status_code >= 300 && response.status_code < 400
+        redirect_location = response.headers["Location"]?
+        raise "Status code 3xx, but redirect location missing" unless redirect_location
+      else
+        unless response.success?
+          message = "Unsuccessful request, status code: [#{response.status_code}], msg: #{response.status_message}"
+          raise NetRetry::TransientError.new(message) if response.status_code >= 500
+          raise message
+        end
+
+        content_length = response.headers["Content-Length"]?.try(&.to_i64?)
+        size_note = content_length ? " (#{(content_length / 1048576.0).round(1)} MB)" : ""
+        file_label = label
+        # Only downloads worth watching get a status line; a tiny file would
+        # just flash a message that vanishes a moment later.
+        announced = content_length.nil? || content_length >= 1_048_576
+        StatusLine.push "Downloading #{file_label}#{size_note} from #{uri.host}..." if announced
+
+        # Suffixed with the pid so concurrent runs sharing the tools dir never
+        # fight over one partial file.
+        partial_path = "#{output_path}.part.#{Process.pid}"
+        File.open(partial_path, "w") do |file|
+          buffer = Bytes.new(65536)
+          received = 0_i64
+          last_update = Time.utc
+          loop do
+            read_bytes = response.body_io.read(buffer)
+            break if read_bytes == 0
+            file.write(buffer[0, read_bytes])
+            received += read_bytes
+            # Rewrites itself on a TTY; throttled so piped/CI logs stay sane.
+            if announced && (Time.utc - last_update) >= 5.seconds
+              total_note = content_length ? "/#{(content_length / 1048576.0).round(1)}" : ""
+              StatusLine.update "Downloading #{file_label}: #{(received / 1048576.0).round(1)}#{total_note} MB..."
+              last_update = Time.utc
+            end
+          end
+        end
+        if content_length && File.size(partial_path) != content_length
+          raise NetRetry::TransientError.new("Truncated download: got #{File.size(partial_path)} of #{content_length} bytes")
+        end
+        FileUtils.mv(partial_path, output_path)
+        StatusLine.pop if announced
+        announced = false
+      end
+    end
+  ensure
+    # A failed or interrupted attempt must not leave its partial file behind.
+    if (partial = partial_path) && File.exists?(partial)
+      File.delete?(partial)
+      StatusLine.pop if announced # the download failed mid-way: drop its status line
+    end
+    client.close
   end
 
-  unless response.success?
-    message = "Unsuccessful request, status code: [#{response.status_code}], msg: #{response.status_message}"
-    raise NetRetry::TransientError.new(message) if response.status_code >= 500
-    raise message
+  if location = redirect_location
+    # Location may be relative; resolve it against the URI that redirected.
+    return follow_and_download(uri.resolve(location).to_s, output_path, redirect_limit - 1, headers, label)
   end
-  File.write(output_path, response.body.to_s)
 end

--- a/src/tasks/workload/state.cr
+++ b/src/tasks/workload/state.cr
@@ -285,11 +285,13 @@ scored_task "node_drain",
                 # operator down with the workload, so there is no test to run.
                 skip_reason = "node_drain chaos test requires a schedulable node that does not run Litmus, but #{app_node_name} is the only one left"
               else
+                StatusLine.push "Moving the LitmusChaos operator to #{litmus_target_node} so #{app_node_name} can be drained..."
                 download_file(LitmusManager::LITMUS_OPERATOR, LitmusManager.downloaded_operator_file)
                 Log.info { "Re-Schedule Litmus" }
                 LitmusManager.add_node_selector(litmus_target_node)
                 KubectlClient::Apply.file(LitmusManager.modified_operator_file)
                 KubectlClient::Wait.resource_wait_for_install(kind: "Deployment", resource_name: "chaos-operator-ce", wait_count: 180, namespace: "litmus")
+                StatusLine.pop
               end
             end
           end


### PR DESCRIPTION
Twice in one day a first-run tool download looked like a hang: `setup` fetching 25 MB of sonobuoy, then `selinux_options` fetching the 53 MB kyverno CLI — both through a `download_file` that buffered the whole body in memory with no output, no partial file, and no timeouts. This PR fixes the downloader and, more broadly, gives every long silent operation one honest line on the console.

**`download_file`** now streams to `<target>.part` and renames on completion (a stalled-looking run leaves visible, growing evidence on disk), announces what it fetches with the size (`Downloading kyverno-cli.tar.gz (50.9 MB) from github.com...`), enforces connect/read timeouts (10 s / 60 s) so a truly stalled connection becomes a retryable `NetRetry` failure instead of an indefinite hang, and verifies Content-Length so truncated bodies retry instead of untarring garbage.

**One-time installs announce themselves** centrally in `ToolInstall.ensure` (`Installing kyverno CLI 1.19.0 (one-time setup)...`) — covering kubescape, sonobuoy, kind, the kyverno CLI and policies, clusterctl, and helm at once.

**Long cluster-side operations say what they are and roughly how long**: Jaeger (cassandra warm-up), OPA Gatekeeper, the fluentd/fluentbit DaemonSets, the LitmusChaos operator, Cluster API init, the Sonobuoy conformance scan, the Kubescape cluster scan, and the Litmus chaos-experiment wait (with its timeout).

**One status line, ever.** All of it goes through a small `StatusLine` stack (`push` / `update` / `pop`): an operation pushes a message when it starts, updates it while it runs, and pops when it finishes; a nested operation (a download inside a tool install, cluster-tools inside `cnf_install`) rewrites the same line and popping restores the outer message, so the screen never holds more than one work-in-progress line and holds none once everything is done. Persistent prints tell the stack they scrolled it away, so a pop can never erase an unrelated line. `cnf_install` / `cnf_uninstall` follow the same shape — cluster-tools, each deployment's resource waits and the discovery passes are updates of one line, and the only persistent output is `CNF installation complete.` / `CNF uninstallation succeeded.` Chaos waits tick elapsed time (`Waiting for the node-drain chaos experiment to finish (42s of 1800s)...`), node_drain's operator move announces itself, and downloads under 1 MB stay silent instead of flashing.

**On a TTY all of this is transient**: progress lines rewrite themselves in place and are removed once the operation succeeds, so a finished run shows only test headers and verdicts — failures deliberately keep their in-progress lines for context. In piped/CI output the rewrite/clear escapes are not emitted at all (they are TTY-gated), so GitHub Actions logs keep the plain, complete trail with no cursor-motion codes. Downloads also stream to per-process partial files (`.part.<pid>`, removed on failure), so concurrent runs sharing `~/.cnf-testsuite` cannot corrupt each other's fetches, and the progress label names the URL's artifact even when the caller downloads into a temp file.

No test verdicts or messages change, so existing spec assertions are untouched.

### Verification

Built with the CI compiler. Proven under a real PTY with a replayer that applies the escape sequences and tracks the peak number of simultaneously visible lines: `install_kind`, `setup:kubescape_framework_download` (nested install + download), `setup:install_kubescape` (104 MB), `setup:install_kyverno` (50.9 MB + policies clone), `cnf_install` and `cnf_uninstall` all peak at **one** visible line and end with only their result line (or nothing). Manually exercised on a kind cluster through `cert`, including node_drain. Piped output of the same runs carries no escape codes and keeps every line. The full matrix exercises every announce site in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
