### PR TITLE
Drop Debian bullseye from the portability build matrix

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         release:
-          - bullseye
           - bookworm
           - trixie
           - forky
@@ -59,11 +58,6 @@ jobs:
             apt -o Acquire::Retries=3 update && DEBIAN_FRONTEND=noninteractive apt -o Acquire::Retries=3 install git curl \
               gcc pkg-config libpcre2-dev libxml2-dev libyaml-dev zlib1g-dev libssl-dev -y && \
             case ${{ matrix.release }} in \
-            bullseye) \
-              curl -fsSLO --retry 3 --retry-delay 2 https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-1-linux-x86_64.tar.gz && \
-              tar zxf crystal-1.19.1-1-linux-x86_64.tar.gz && \
-              export PATH=/crystal-1.19.1-1/bin:$PATH && \
-              rm -rf crystal-1.19.1-1-linux-x86_64.tar.gz ;; \
             bookworm | forky) \
               DEBIAN_FRONTEND=noninteractive apt -o Acquire::Retries=3 install crystal -y && \
               curl -fsSLO --retry 3 --retry-delay 2 https://github.com/crystal-lang/crystal/releases/download/1.19.1/crystal-1.19.1-1-linux-x86_64.tar.gz && \


### PR DESCRIPTION
Bullseye LTS ended 2026-08-31 and its security pool is being pruned from `deb.debian.org` — `apt install` 404s on superseded `bullseye-security` packages even immediately after `apt update` (seen in [this run](https://github.com/lfn-cnti/testsuite/actions/runs/33985505156/job/101358151643)), so the `debian (bullseye)` job now fails on every branch. Building from source on an EOL release isn't a supported scenario; remove the leg rather than pin `archive.debian.org`. The matrix keeps bookworm, trixie, forky, and sid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)